### PR TITLE
Wave 1: token foundation + red/green migration (color-blind safe)

### DIFF
--- a/docs/app-ui-audit-2026-04-16.md
+++ b/docs/app-ui-audit-2026-04-16.md
@@ -1,0 +1,286 @@
+# Blind Bench App — UI Audit
+
+**Date:** 2026-04-16
+**Scope:** React app under `src/` across 6 anchor surfaces. Landing (`landing/`), Convex backend, and the 13 blind-eval security rules (tracked via UX Spec §10) are out of scope.
+**Method:** `/impeccable:audit` across anchors 1–6. Read-only; no code changed.
+
+---
+
+## Audit Health Score
+
+| # | Dimension | Score | Key finding |
+|---|-----------|-------|-------------|
+| 1 | Accessibility | **2/4** | Zero `aria-current` in codebase; icon-only buttons unlabeled; Tiptap lacks `role="textbox"` |
+| 2 | Performance | **3/4** | Mostly clean; AnnotatedEditor re-mounts on every annotation; no virtualization on long lists |
+| 3 | Responsive design | **1/4** | `SideNav` fixed `w-56` with no mobile drawer; touch targets <44px across evaluator flow |
+| 4 | Theming | **1/4** | Dark-mode `--primary` is achromatic; red/green semantic colors in **23 files** |
+| 5 | Anti-patterns | **2/4** | No gradient text / hero metrics / glassmorphism (clean), but systemic CLAUDE.md violations |
+| **Total** | | **9/20** | **Poor — major overhaul needed before the evaluator mobile flow ships confidently** |
+
+**Rating:** Poor (6–9 band). Technically functional but fails its own CLAUDE.md rules at scale.
+
+---
+
+## Anti-Patterns Verdict
+
+**Would someone believe "AI made this"?** **No.** The app does not read as AI slop. It uses Geist Variable (not Inter), OKLch tokens (not hex), no gradient text, no glassmorphism, no hero metric layouts, no glowing dark accents, no identical card grids. Empty states are mostly actionable; errors are mostly specific; loading uses skeletons (per CLAUDE.md). The scientific-elegance direction is coming through.
+
+**Where the shine cracks:** the distinctiveness is undermined by self-inflicted rule violations — the same CLAUDE.md forbids red/green, but red and green appear in 23 files. The `.impeccable.md` demands tinted dark-mode primary, but `--primary` goes achromatic the moment you toggle the theme. These aren't AI tells — they're drift from the project's own spec.
+
+---
+
+## Executive Summary
+
+- **Score:** 9/20 (Poor)
+- **Findings:** 6 × P0, 14 × P1, 13 × P2, 6 × P3 (39 total)
+- **Security surface:** clean — no `data-version-id` / `data-run-id` leaked anywhere in evaluator or share routes ✓
+- **Top 5 issues:**
+  1. Dark-mode `--primary` is achromatic (`oklch(0.922 0 0)`) — brand regression on every dark-mode screen
+  2. Red/green semantic colors in **23 files** — CLAUDE.md forbids this explicitly for color-blind safety
+  3. `SideNav` hard-coded `w-56` with no mobile drawer — app is effectively broken below 768px
+  4. Touch targets <44px on `RatingButtons` and `NotificationBell` — evaluators primarily use mobile
+  5. Zero `aria-current` in the entire codebase — nav state invisible to screen readers
+- **Next steps:** see Recommended Actions below. Start with `/impeccable:polish` for the theming P0s and `/impeccable:adapt` for mobile; those two pass clear ~60% of the P0/P1 count.
+
+---
+
+## Detailed Findings by Severity
+
+### P0 — Blocking (fix immediately)
+
+#### [P0-1] Dark-mode primary color is achromatic — brand regression
+- **File:** `src/index.css:93`
+- **Category:** Theming
+- **Impact:** Every dark-mode surface loses the blue-purple brand tint. `--primary: oklch(0.922 0 0)` has chroma **0** — pure white-gray. `.impeccable.md` line 26 calls this out explicitly as "needs fixing." On light mode, `--primary: oklch(0.546 0.245 262.881)` — correct.
+- **Recommendation:** Change line 93 to something like `oklch(0.72 0.18 262.881)` — same hue as light, boosted lightness for dark-mode contrast, chroma preserved. Verify WCAG AA against `oklch(0.205 0 0)` background afterward.
+- **Follow-up:** `/impeccable:polish`
+
+#### [P0-2] Light-mode sidebar goes achromatic near-black
+- **File:** `src/index.css:78`
+- **Category:** Theming
+- **Impact:** `--sidebar-primary: oklch(0.205 0 0)` in light mode is functionally black, while dark mode correctly keeps `oklch(0.488 0.243 264.376)` (tinted). Light-mode sidebar highlight state loses the brand identity. Asymmetric theming with dark mode.
+- **Recommendation:** `oklch(0.488 0.243 264.376)` works cross-theme; use it in `:root` too, or pick a lighter blue-purple like `oklch(0.60 0.22 264)`.
+- **Follow-up:** `/impeccable:polish`
+
+#### [P0-3] Red/green semantic colors across 23 files — CLAUDE.md violation
+- **Files (primary offenders):**
+  - `src/components/RunStatusPill.tsx:17-24` (failed=red, completed=green)
+  - `src/components/VersionStatusPill.tsx:6` (current=green)
+  - `src/components/CycleStatusPill.tsx:4-9` (closed=green)
+  - `src/components/FeedbackDigest.tsx:17` (severity high=red)
+  - `src/components/FeedbackTagPicker.tsx:4` (Accuracy tag=red)
+  - `src/components/RatingButtons.tsx:17,31` (best=green)
+  - `src/components/PreferenceAggregate.tsx:23,29,35` (green for winner)
+  - `src/components/PromptDiff.tsx:150-152` (dark-mode diff red/green)
+  - `src/routes/orgs/projects/cycles/VersionDashboard.tsx:126,185,258` (green progress + counts)
+  - `src/routes/orgs/settings/{OrgSettings,OrgMembers,OpenRouterKey}.tsx` (success `text-green-600`)
+  - 12 more files surfaced by `rg bg-(red\|green)- src/` — 23 total
+- **Category:** Theming + Accessibility
+- **Impact:** ~7% of male evaluators are red/green colorblind. CLAUDE.md states: "no red/green for diffs — use blue/purple (color-blind safe)." The rule is violated in every status pill, every severity tag, the diff viewer, and every success toast.
+- **WCAG:** 1.4.1 Use of Color
+- **Recommendation:** Canonical replacement palette:
+  - Success/best/positive → `bg-sky-100 text-sky-700 dark:bg-sky-950/40 dark:text-sky-300` (blue)
+  - Warn/medium/watch → `bg-amber-100 text-amber-800 dark:bg-amber-950/40 dark:text-amber-200`
+  - Fail/negative → `bg-purple-100 text-purple-800 dark:bg-purple-950/40 dark:text-purple-200` (or amber if semantic weight matters)
+  - Neutral/draft → `bg-muted text-muted-foreground`
+  - Always pair color with an icon (CheckCircle, AlertTriangle, XCircle) so meaning survives monochrome printing and colorblind viewing.
+- **Follow-up:** `/impeccable:normalize` (extract a `STATUS_STYLES` token map), then `/impeccable:polish`
+
+#### [P0-4] `SideNav` forces horizontal scroll on mobile
+- **Files:** `src/components/SideNav.tsx:25`, `src/components/layouts/OrgLayout.tsx:40`
+- **Category:** Responsive
+- **Impact:** `w-56` = 224px, fixed. On 375px iPhone viewport that's 60% of the width with zero mobile affordance — no drawer, no collapse, no hidden-until-menu-tap. The authenticated app is unusable on phones. Evaluators authenticated into an org see a broken shell.
+- **Recommendation:** `hidden md:block` on `<SideNav>`; add a mobile drawer triggered from `TopBar` with a hamburger-icon button. Preserve current desktop behavior.
+- **Follow-up:** `/impeccable:adapt`
+
+#### [P0-5] `TopBar` hides Cmd+K and shortcut triggers on mobile with no fallback
+- **File:** `src/components/TopBar.tsx:31,41`
+- **Category:** Responsive + discoverability
+- **Impact:** `hidden sm:flex` means mobile users can't open the command palette or shortcut cheat sheet. On mobile the app has no discoverable search.
+- **Recommendation:** Keep an icon-only `Search` button visible at all widths (44×44 touch target). Route the tap to the same command palette open handler. Same for `?` → drop on mobile is fine (shortcuts don't apply to touch), but the search is not negotiable.
+- **Follow-up:** `/impeccable:adapt`
+
+#### [P0-6] `BlindLabelBadge` fails WCAG AA contrast in dark mode
+- **File:** `src/components/BlindLabelBadge.tsx:7`
+- **Category:** Accessibility
+- **Impact:** `text-slate-300` on `dark:bg-slate-800/30` ≈ 3.2:1 — below WCAG AA's 4.5:1. This is the **product's core blind-eval label** — if an evaluator can't read A/B/C on a phone in sunlight, the feature is broken.
+- **WCAG:** 1.4.3 Contrast (Minimum)
+- **Recommendation:** `text-slate-900 dark:text-slate-50` with `bg-slate-100 dark:bg-slate-800` (no alpha) — yields >10:1.
+- **Follow-up:** `/impeccable:polish`
+
+---
+
+### P1 — Major (fix before next release)
+
+#### [P1-1] Zero `aria-current` in codebase — nav state invisible to SR
+- **Files:** `src/components/SideNav.tsx:51-87`, `src/components/ProjectTabs.tsx:39-50`, all `NavLink` usages project-wide (verified via `rg aria-current src/` = 0 matches)
+- **Category:** Accessibility
+- **WCAG:** 1.3.1 Info and Relationships
+- **Recommendation:** On every `NavLink`, add `aria-current={isActive ? "page" : undefined}`. Wrap `SideNav` children in `<nav aria-label="Prompts">` and `ProjectTabs` in `<nav aria-label="Project sections">`.
+- **Follow-up:** `/impeccable:harden`
+
+#### [P1-2] Icon-only buttons missing `aria-label`
+- **Files:** `src/components/HelpMenu.tsx:40-42`, `src/components/SideNav.tsx:30-35` (Plus/new), `src/components/NotificationBell.tsx:44-50`
+- **Category:** Accessibility
+- **WCAG:** 4.1.2 Name, Role, Value
+- **Recommendation:** Labels as noted: `"Help and support"`, `"Create new prompt"`, `"Notifications"` (plus live-region count). `WelcomeCard`'s dismiss already has the label — replicate that pattern.
+- **Follow-up:** `/impeccable:harden`
+
+#### [P1-3] `RatingButtons` touch targets below 44×44
+- **File:** `src/components/RatingButtons.tsx:59-60`
+- **Category:** Responsive + a11y
+- **Impact:** `px-2 py-1` + `h-3 w-3` icons ≈ 32×24px. Blind evaluators use these on phones. Mis-taps skew data.
+- **WCAG:** 2.5.5 Target Size (AAA — recommended baseline for this product)
+- **Recommendation:** `px-4 py-2.5 min-h-[44px]` with `h-4 w-4` icons. Verify the radio group still reads correctly.
+- **Follow-up:** `/impeccable:adapt`
+
+#### [P1-4] `NotificationBell` icon-sm is 28×28px
+- **File:** `src/components/NotificationBell.tsx:44-50`
+- **Category:** Responsive + a11y
+- **WCAG:** 2.5.5
+- **Recommendation:** Use `size="icon"` (32px) and wrap to 44×44 hit area, or `size="lg"` outright on `md:hidden`.
+- **Follow-up:** `/impeccable:adapt`
+
+#### [P1-5] Tiptap editors lack `role="textbox"` and `aria-label`
+- **Files:** `src/components/tiptap/PromptEditor.tsx:24-55`, `src/components/tiptap/AnnotatedEditor.tsx`
+- **Category:** Accessibility
+- **WCAG:** 1.3.1, 4.1.2
+- **Recommendation:** On `EditorContent` wrapper: `role="textbox" aria-multiline="true" aria-label="Prompt template"` (and `"Output annotations"` for `AnnotatedEditor`). Add `aria-describedby` to a visible or SR-only hint mentioning `Cmd+S`.
+- **Follow-up:** `/impeccable:harden`
+
+#### [P1-6] `StreamingOutputPanel` aria-live may miss token bursts
+- **File:** `src/components/StreamingOutputPanel.tsx:116`
+- **Category:** Accessibility
+- **WCAG:** 4.1.3 Status Messages
+- **Recommendation:** Add `role="status" aria-busy={isStreaming}`. Keep `aria-live="polite"`. Announce status transitions (`pending → running → completed`) via a separate `sr-only` live region with text like `"Output A finished streaming"`.
+- **Follow-up:** `/impeccable:harden`
+
+#### [P1-7] `AnnotatedEditor` re-creates Tiptap instance on every annotation/content change
+- **File:** `src/components/tiptap/AnnotatedEditor.tsx:68-96, 99-115`
+- **Category:** Performance
+- **Impact:** Evaluators adding 5–10 annotations to large LLM outputs (code blocks, JSON responses) see visible lag as ProseMirror re-init and re-decorates ranges. This is the feedback-capture hot path.
+- **Recommendation:** Memoize the editor with `useMemo`. Push annotations via `editor.view.dispatch(tr)` in a separate effect instead of depending on them in the useEditor hook. Previously fixed in `concepts/tiptap-bubblemenu-state-trap` — same class of bug.
+- **Follow-up:** `/impeccable:optimize`
+
+#### [P1-8] Empty state on `OrgHome` has no action
+- **File:** `src/routes/orgs/OrgHome.tsx:34-38`
+- **Category:** Anti-pattern (CLAUDE.md)
+- **Recommendation:** Pass `action={{ label: "Create prompt", onClick: openNewProjectDialog }}` to `<EmptyState>`. The same pattern is done correctly in `Versions.tsx` and `TestCases.tsx` — just propagate it.
+- **Follow-up:** `/impeccable:clarify`
+
+#### [P1-9] `EvalInbox` empty copy is celebratory, not actionable
+- **File:** `src/routes/eval/EvalInbox.tsx:37-41`
+- **Category:** Anti-pattern (CLAUDE.md)
+- **Recommendation:** Heading → `"No pending evaluations"`. Add action: link to `/eval/history` if implemented, else a link back to user's project dashboard. CLAUDE.md: "always actionable."
+- **Follow-up:** `/impeccable:clarify`
+
+#### [P1-10] `VersionEditor` sidebar collapses editor on narrow viewports
+- **File:** `src/routes/orgs/projects/VersionEditor.tsx:366`
+- **Category:** Responsive
+- **Impact:** `w-[22%] min-w-[220px]` on sidebar + no breakpoint collapse → at 375px the editor pane is ~70px wide. Authoring becomes impossible.
+- **Recommendation:** `hidden lg:flex` on sidebar; add a `Sheet` trigger on mobile to open sidebar as an overlay.
+- **Follow-up:** `/impeccable:adapt`
+
+#### [P1-11] `PromptDiff` forces two-column grid on mobile
+- **File:** `src/components/PromptDiff.tsx:91`
+- **Category:** Responsive
+- **Recommendation:** `grid-cols-1 md:grid-cols-2`. Stacked diff is more readable on phone than 160px columns.
+- **Follow-up:** `/impeccable:adapt`
+
+#### [P1-12] `CycleEvalView` output cards hard-capped at `max-h-[400px]` on mobile
+- **File:** `src/routes/eval/CycleEvalView.tsx:265`
+- **Category:** Responsive
+- **Impact:** On 640×800 phones, 400px fixed height after headers/rating strip leaves nothing. Evaluators scroll within the card and between cards — dual-scroll UX.
+- **Recommendation:** `max-h-none sm:max-h-[400px]` (remove cap on mobile) or `max-h-[60vh]` throughout.
+- **Follow-up:** `/impeccable:adapt`
+
+#### [P1-13] Public share `/s/cycle/:token` ignores `prefers-color-scheme`
+- **File:** `src/routes/share/CycleShareableEvalView.tsx:195`
+- **Category:** Theming
+- **Impact:** Anonymous evaluators arriving via email link see a hard-coded theme. `.impeccable.md` requires respecting user preference.
+- **Recommendation:** Add a mount-time `matchMedia('(prefers-color-scheme: dark)')` check that toggles `.dark` on `<html>` for this route (or use the app's existing theme provider if one exists).
+- **Follow-up:** `/impeccable:polish`
+
+#### [P1-14] Collapsible sections missing `aria-expanded` / `aria-controls`
+- **Files:** `src/routes/orgs/projects/VersionEditor.tsx:524-536` (System message, Meta Context), `src/components/tiptap/AnnotatedEditor.tsx` (comment toggle), `src/components/RunComment.tsx:87-89`
+- **Category:** Accessibility
+- **WCAG:** 4.1.2
+- **Recommendation:** `aria-expanded={open} aria-controls="<section-id>"` on every disclosure button. Give target sections stable IDs.
+- **Follow-up:** `/impeccable:harden`
+
+---
+
+### P2 — Minor (next pass)
+
+- **[P2-1] Multiple `<h1>` across settings** — `OrgSettings.tsx:67`, `OrgMembers.tsx:40`, `OpenRouterKey.tsx:74`. Demote to `<h2>` since layout should own `<h1>`. `/impeccable:harden`
+- **[P2-2] `Progress` bar in `CycleEvalView:197-205` lacks `aria-live`** — Add `role="status" aria-live="polite" aria-label="${n} of ${total} outputs rated"`. `/impeccable:harden`
+- **[P2-3] `Summary` table in `RunConfigurator.tsx:1138-1198` not mobile-responsive** — Wrap in `overflow-x-auto`; consider card layout below `md`. `/impeccable:adapt`
+- **[P2-4] `RunView.tsx:170-176` grid goes to `xl:grid-cols-5`** — cards become 380px wide at 1920px. Cap at 4 columns; allow horizontal scroll for 5+ outputs. `/impeccable:arrange`
+- **[P2-5] `FeedbackSheet` feedback groups lack `role="region"` + labelledby** — `src/components/FeedbackSheet.tsx:84-98`. `/impeccable:harden`
+- **[P2-6] `SendEvaluationDialog` email label not `htmlFor`-linked** — `src/components/SendEvaluationDialog.tsx:193-194`. `/impeccable:harden`
+- **[P2-7] `OptimizeConfirmationDialog` + `RollbackConfirmationDialog` both modals for binary confirms** — Rollback is destructive, keep modal. Optimize is not; consider inline confirm banner. `/impeccable:distill`
+- **[P2-8] Skeletons not announced** — missing `role="status" aria-label="Loading"` on skeleton containers (`OrgLayout.tsx:37-48`, `OrgHome.tsx:29-31`). `/impeccable:harden`
+- **[P2-9] `NotificationBell` count badge uses `bg-destructive`** — `src/components/NotificationBell.tsx:52-54`. Non-error semantics; switch to `bg-primary`. `/impeccable:polish`
+- **[P2-10] `EvalLayout` header lacks cycle/project context** — `src/components/layouts/EvalLayout.tsx:1-13`. Evaluators have no orientation between email → eval page. Add breadcrumb or cycle-name subtitle. `/impeccable:clarify`
+- **[P2-11] `VersionEditor` has no unsaved-changes indicator** — `src/routes/orgs/projects/VersionEditor.tsx:147-165`. Add dot-marker or "Unsaved" pill on section headers when dirty. `/impeccable:harden`
+- **[P2-12] `QualityTrend` SVG data points not keyboard-accessible** — `src/components/QualityTrend.tsx:122-134`. Circles have `role="button"` but no visible `:focus-visible` ring; mobile users get no focus affordance. `/impeccable:harden`
+- **[P2-13] `CommandPalette` "No results" generic** — `src/components/CommandPalette.tsx:87`. Contextualize with suggested actions. `/impeccable:clarify`
+
+---
+
+### P3 — Polish
+
+- **[P3-1] `WelcomeCard` nests bordered divs inside a `Card`** — `src/components/WelcomeCard.tsx:44-62`. Flatten to flex without inner borders. `/impeccable:distill`
+- **[P3-2] Dialog animations may ignore `prefers-reduced-motion`** — `src/components/ui/dialog.tsx:32,54`. Verify Base UI respects it; if not, add media-query override. `/impeccable:harden`
+- **[P3-3] `AnnotatedEditor` annotation highlight colors not contrast-checked in dark mode** — `src/components/tiptap/AnnotatedEditor.tsx:362-373`. 60% lightness blue at 15% bg + 50% border may fail AA on dark surface. `/impeccable:polish`
+- **[P3-4] `VersionDashboard` stat percentages underemphasized** — `src/routes/orgs/projects/cycles/VersionDashboard.tsx:366-372`. `text-sm text-muted-foreground` buries the key insight. Promote to `text-base font-medium text-foreground`. `/impeccable:typeset`
+- **[P3-5] `TrendInsight` copy is passive/flat** — `src/components/TrendInsight.tsx:24-68`. Add actionable second sentence. `/impeccable:clarify`
+- **[P3-6] `OptimizeConfirmationDialog` feedback-count copy is grammatically awkward** — `src/components/OptimizeConfirmationDialog.tsx:76-83`. Rewrite in plain English. `/impeccable:clarify`
+
+---
+
+## Systemic Patterns
+
+1. **Red/green semantic color** — **23 files** hit by `rg 'bg-(red|green)-|text-(red|green)-' src/`. Includes every status pill, severity tag, diff view, success toast. Single largest theming defect. **Fix via** centralized `STATUS_STYLES` token map → replace red/green with sky/amber/purple + icons.
+2. **Zero `aria-current`** — `rg aria-current src/` returns 0 matches. Every `NavLink` in `SideNav`, `ProjectTabs`, and elsewhere is silent to screen readers about which page is active.
+3. **Touch targets <44×44** — `RatingButtons` (32×24), `NotificationBell` (28×28), `ProjectTabs` settings icon, `HelpMenu` icon. Mobile-first evaluator UX at risk.
+4. **Icon-only buttons without labels** — `HelpMenu`, `SideNav` Plus, `NotificationBell`. Inconsistent with the good `WelcomeCard` dismiss pattern already in the code.
+5. **Hard-coded Tailwind color classes, no token indirection** — `RatingButtons`, `CycleStatusPill`, `VersionStatusPill`, `FeedbackTagPicker`, `FeedbackDigest`, `PreferenceAggregate`, `VersionDashboard`. No central `STATUS_STYLES` constant — updates require touching each file.
+6. **Mobile layouts not handled** — `SideNav` fixed width, `TopBar` hidden search, `VersionEditor` sidebar collapse, `PromptDiff` two-column, `CycleEvalView` max-h, `RunConfigurator` summary table, `RunView` 5-column grid. Mobile is not a first-class target anywhere.
+
+---
+
+## Positive Findings
+
+- **Security surface is clean** — `rg 'data-(version|run)-id' src/` returns **zero** matches. The 13 blind-eval rules from UX Spec §10 are holding up on the DOM side. Token-based routing on `/eval/cycle/:token` and `/s/cycle/:token` is correctly enforced.
+- **Skeletons, not spinners** — Loading states across `OrgLayout`, `OrgHome`, `Versions`, `RunConfigurator`, `RunView`, `EvalInbox`, `CycleEvalView`, `CycleShareableEvalView` use shimmer skeletons. CLAUDE.md adherence is strong here.
+- **Form labels solid** — `Onboarding.tsx:52-59`, `OrgMembers.tsx:98-107`, `OrgSettings.tsx:74-87`. Labels are `htmlFor`-bound, inputs sized adequately (`h-8` = 32px).
+- **Errors name the resource** — `friendlyError()` is used consistently. No "Something went wrong" sightings.
+- **Dialog focus management** — Base UI `Dialog` handles focus trap + Escape correctly in all dialog-using components.
+- **No AI slop** — Geist Variable (not Inter), no gradient text on metrics, no glassmorphism, no hero metric layouts, no glowing dark accents, no identical card grids, no pure `#000`/`#fff`. The scientific-elegance direction shows.
+- **`EmptyState` component** — well-designed primitive. The gap is propagation: it's present on `OrgHome` but without an `action` prop, and `EvalInbox` doesn't use it for its empty state.
+- **Keyboard shortcuts visible where they exist** — `Cmd+S` in `VersionEditor.tsx:311`, `Cmd+Enter` in `RunConfigurator.tsx:1219-1236` render as `<kbd>` elements.
+- **`SendEvaluationDialog` email input UX** — handles paste, comma/Enter, backspace removal. Polished beyond spec.
+
+---
+
+## Recommended Actions
+
+Run in priority order. Each command addresses a cluster — don't run them all at once.
+
+1. **[P0] `/impeccable:polish`** — Fix theming P0s (dark `--primary`, light sidebar, `BlindLabelBadge` contrast, public share `prefers-color-scheme`, notification badge color, annotation highlight contrast).
+2. **[P0] `/impeccable:normalize`** — Extract a central `STATUS_STYLES` / `SEVERITY_STYLES` token map; migrate all 23 red/green files to sky/amber/purple with icons.
+3. **[P0] `/impeccable:adapt`** — Mobile pass: `SideNav` drawer, `TopBar` mobile search, `VersionEditor` sidebar sheet, `PromptDiff` stacked grid, `CycleEvalView` max-h, `RunConfigurator` table, `RatingButtons` / `NotificationBell` touch targets.
+4. **[P1] `/impeccable:harden`** — A11y pass: `aria-current` on every `NavLink`, `aria-label` on icon buttons, `role="textbox"` on Tiptap, `aria-expanded` on collapsibles, `role="region"` on `FeedbackSheet` groups, announce skeletons, fix heading hierarchy.
+5. **[P1] `/impeccable:optimize`** — Memoize `AnnotatedEditor` so Tiptap doesn't re-mount per annotation.
+6. **[P1] `/impeccable:clarify`** — Empty state + copy pass: `OrgHome` action, `EvalInbox` action, `EvalLayout` breadcrumb, `CommandPalette` no-results, `TrendInsight` next-step, `OptimizeConfirmationDialog` feedback-count copy.
+7. **[P2] `/impeccable:distill`** — Flatten `WelcomeCard` nested borders, replace `OptimizeConfirmationDialog` modal with inline confirm.
+8. **[P2] `/impeccable:arrange`** — Cap `RunView` columns, add `overflow-x-auto` on summary tables.
+9. **[P3] `/impeccable:typeset`** — `VersionDashboard` stat percentage hierarchy.
+10. **[Final] `/impeccable:polish`** — One more pass after the above lands to catch micro-regressions.
+
+---
+
+You can ask me to run these one at a time, all at once, or in any order you prefer.
+
+Re-run `/impeccable:audit` after fixes to see your score improve.

--- a/src/components/CycleStatusPill.tsx
+++ b/src/components/CycleStatusPill.tsx
@@ -1,12 +1,6 @@
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
-
-const STATUS_STYLES = {
-  draft: "bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300",
-  open: "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300",
-  closed:
-    "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300",
-};
+import { CYCLE_STATUS_STYLES } from "@/lib/status-styles";
 
 export function CycleStatusPill({
   status,
@@ -15,15 +9,18 @@ export function CycleStatusPill({
   status: "draft" | "open" | "closed";
   className?: string;
 }) {
+  const config = CYCLE_STATUS_STYLES[status];
+  const Icon = config.icon;
   return (
     <Badge
       variant="secondary"
       className={cn(
-        "text-[10px] font-medium",
-        STATUS_STYLES[status],
+        "text-[10px] font-medium gap-1",
+        config.className,
         className,
       )}
     >
+      <Icon className={cn("h-3 w-3", config.animate && "animate-spin")} />
       {status}
     </Badge>
   );

--- a/src/components/FeedbackDigest.tsx
+++ b/src/components/FeedbackDigest.tsx
@@ -7,17 +7,12 @@ import { cn } from "@/lib/utils";
 import { Sparkles, AlertCircle, ChevronDown, ChevronRight } from "lucide-react";
 import { useState } from "react";
 import { friendlyError, sanitizeStoredError } from "@/lib/errors";
+import { SEVERITY_STYLES, RATING_TEXT_COLORS } from "@/lib/status-styles";
 
 interface FeedbackDigestProps {
   versionId: Id<"promptVersions">;
   compact?: boolean;
 }
-
-const SEVERITY_STYLES = {
-  high: "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300",
-  medium: "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300",
-  low: "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300",
-};
 
 export function FeedbackDigest({ versionId, compact = false }: FeedbackDigestProps) {
   const digest = useQuery(api.feedbackDigest.getDigest, { versionId });
@@ -121,7 +116,7 @@ export function FeedbackDigest({ versionId, compact = false }: FeedbackDigestPro
                 key={i}
                 className={cn(
                   "rounded-full px-2 py-0.5 text-[10px] font-medium",
-                  SEVERITY_STYLES[theme.severity],
+                  SEVERITY_STYLES[theme.severity].className,
                 )}
               >
                 {theme.title}
@@ -151,13 +146,13 @@ export function FeedbackDigest({ versionId, compact = false }: FeedbackDigestPro
       {/* Preference breakdown */}
       {digest.preferenceBreakdown && (
         <div className="flex items-center gap-3 text-xs">
-          <span className="text-green-600 dark:text-green-400">
+          <span className={RATING_TEXT_COLORS.best}>
             Best: {digest.preferenceBreakdown.bestCount}
           </span>
-          <span className="text-muted-foreground">
+          <span className={RATING_TEXT_COLORS.acceptable}>
             Acceptable: {digest.preferenceBreakdown.acceptableCount}
           </span>
-          <span className="text-amber-600 dark:text-amber-400">
+          <span className={RATING_TEXT_COLORS.weak}>
             Weak: {digest.preferenceBreakdown.weakCount}
           </span>
         </div>
@@ -221,7 +216,7 @@ function ThemeItem({
         <span
           className={cn(
             "rounded-full px-1.5 py-0.5 text-[10px] font-medium",
-            SEVERITY_STYLES[theme.severity],
+            SEVERITY_STYLES[theme.severity].className,
           )}
         >
           {theme.severity}

--- a/src/components/FeedbackTagPicker.tsx
+++ b/src/components/FeedbackTagPicker.tsx
@@ -1,14 +1,17 @@
 import { cn } from "@/lib/utils";
 
+// Categorical (not semantic) hues — must be color-blind safe (no red/green).
+// Each tag gets a distinct swatch so users with normal and deficient vision
+// can still tell them apart by lightness/hue.
 const TAGS = [
-  { value: "accuracy", label: "Accuracy", color: "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300" },
+  { value: "accuracy", label: "Accuracy", color: "bg-fuchsia-100 text-fuchsia-700 dark:bg-fuchsia-900/30 dark:text-fuchsia-300" },
   { value: "tone", label: "Tone", color: "bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-300" },
   { value: "length", label: "Length", color: "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300" },
-  { value: "relevance", label: "Relevance", color: "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300" },
+  { value: "relevance", label: "Relevance", color: "bg-indigo-100 text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-300" },
   { value: "safety", label: "Safety", color: "bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-300" },
   { value: "format", label: "Format", color: "bg-cyan-100 text-cyan-700 dark:bg-cyan-900/30 dark:text-cyan-300" },
   { value: "clarity", label: "Clarity", color: "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300" },
-  { value: "other", label: "Other", color: "bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300" },
+  { value: "other", label: "Other", color: "bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300" },
 ] as const;
 
 interface FeedbackTagPickerProps {

--- a/src/components/PreferenceAggregate.tsx
+++ b/src/components/PreferenceAggregate.tsx
@@ -2,6 +2,7 @@ import { useQuery } from "convex/react";
 import { api } from "../../convex/_generated/api";
 import { Id } from "../../convex/_generated/dataModel";
 import { ThumbsUp, Check, ThumbsDown } from "lucide-react";
+import { RATING_TEXT_COLORS } from "@/lib/status-styles";
 
 interface PreferenceAggregateProps {
   runId: Id<"promptRuns">;
@@ -20,19 +21,19 @@ export function PreferenceAggregate({ runId, outputId }: PreferenceAggregateProp
   return (
     <div className="flex items-center gap-2 text-xs text-muted-foreground">
       {data.bestCount > 0 && (
-        <span className="inline-flex items-center gap-0.5 text-green-600 dark:text-green-400">
+        <span className={`inline-flex items-center gap-0.5 ${RATING_TEXT_COLORS.best}`}>
           <ThumbsUp className="h-3 w-3" />
           {data.bestCount}
         </span>
       )}
       {data.acceptableCount > 0 && (
-        <span className="inline-flex items-center gap-0.5 text-gray-500 dark:text-gray-400">
+        <span className={`inline-flex items-center gap-0.5 ${RATING_TEXT_COLORS.acceptable}`}>
           <Check className="h-3 w-3" />
           {data.acceptableCount}
         </span>
       )}
       {data.weakCount > 0 && (
-        <span className="inline-flex items-center gap-0.5 text-amber-600 dark:text-amber-400">
+        <span className={`inline-flex items-center gap-0.5 ${RATING_TEXT_COLORS.weak}`}>
           <ThumbsDown className="h-3 w-3" />
           {data.weakCount}
         </span>

--- a/src/components/RatingButtons.tsx
+++ b/src/components/RatingButtons.tsx
@@ -1,35 +1,12 @@
 import { cn } from "@/lib/utils";
-import { ThumbsUp, Check, ThumbsDown } from "lucide-react";
+import { RATING_STYLES, type Rating } from "@/lib/status-styles";
 
-export type Rating = "best" | "acceptable" | "weak";
+export type { Rating };
 
-export const RATINGS: {
-  value: Rating;
-  label: string;
-  icon: typeof ThumbsUp;
-  activeClass: string;
-}[] = [
-  {
-    value: "best",
-    label: "Best",
-    icon: ThumbsUp,
-    activeClass:
-      "bg-green-100 text-green-700 border-green-300 dark:bg-green-900/30 dark:text-green-300 dark:border-green-700",
-  },
-  {
-    value: "acceptable",
-    label: "Acceptable",
-    icon: Check,
-    activeClass:
-      "bg-gray-100 text-gray-700 border-gray-300 dark:bg-gray-800 dark:text-gray-300 dark:border-gray-600",
-  },
-  {
-    value: "weak",
-    label: "Weak",
-    icon: ThumbsDown,
-    activeClass:
-      "bg-amber-100 text-amber-700 border-amber-300 dark:bg-amber-900/30 dark:text-amber-300 dark:border-amber-700",
-  },
+export const RATINGS: { value: Rating; label: string }[] = [
+  { value: "best", label: "Best" },
+  { value: "acceptable", label: "Acceptable" },
+  { value: "weak", label: "Weak" },
 ];
 
 export function RatingButtons({
@@ -45,7 +22,9 @@ export function RatingButtons({
       role="radiogroup"
       aria-label="Rate this output"
     >
-      {RATINGS.map(({ value, label, icon: Icon, activeClass }) => {
+      {RATINGS.map(({ value, label }) => {
+        const config = RATING_STYLES[value];
+        const Icon = config.icon;
         const isSelected = currentRating === value;
         return (
           <button
@@ -60,7 +39,7 @@ export function RatingButtons({
               "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1",
               "motion-safe:transition-all motion-safe:duration-150",
               isSelected
-                ? activeClass
+                ? config.className
                 : "border-border text-muted-foreground hover:bg-muted/50",
             )}
           >

--- a/src/components/RunComment.tsx
+++ b/src/components/RunComment.tsx
@@ -95,7 +95,7 @@ function RunCommentEditor({
         )}
         General notes about this run
         {saved && (
-          <span className="ml-auto flex items-center gap-1 text-xs text-green-600 dark:text-green-400">
+          <span className="ml-auto flex items-center gap-1 text-xs text-sky-700 dark:text-sky-300">
             <Check className="h-3 w-3" />
             Saved
           </span>

--- a/src/components/RunStatusPill.tsx
+++ b/src/components/RunStatusPill.tsx
@@ -1,44 +1,25 @@
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
-import { Loader2, CheckCircle2, XCircle, Clock } from "lucide-react";
+import {
+  RUN_STATUS_STYLES,
+  type RunStatus,
+} from "@/lib/status-styles";
 
-const statusConfig: Record<
-  string,
-  { style: string; icon: React.ComponentType<{ className?: string }> }
-> = {
-  pending: {
-    style: "bg-slate-100 text-slate-600 border-slate-300 dark:bg-slate-800/30 dark:text-slate-400 dark:border-slate-600",
-    icon: Clock,
-  },
-  running: {
-    style: "bg-blue-100 text-blue-700 border-blue-300 dark:bg-blue-900/30 dark:text-blue-400 dark:border-blue-700",
-    icon: Loader2,
-  },
-  completed: {
-    style: "bg-green-100 text-green-800 border-green-300 dark:bg-green-900/30 dark:text-green-400 dark:border-green-700",
-    icon: CheckCircle2,
-  },
-  failed: {
-    style: "bg-red-100 text-red-700 border-red-300 dark:bg-red-900/30 dark:text-red-400 dark:border-red-700",
-    icon: XCircle,
-  },
-};
+function isRunStatus(value: string): value is RunStatus {
+  return value in RUN_STATUS_STYLES;
+}
 
 export function RunStatusPill({ status }: { status: string }) {
-  const config = statusConfig[status] ?? statusConfig.pending!;
+  const key: RunStatus = isRunStatus(status) ? status : "pending";
+  const config = RUN_STATUS_STYLES[key];
   const Icon = config.icon;
 
   return (
     <Badge
       variant="outline"
-      className={cn("text-xs font-medium capitalize gap-1", config.style)}
+      className={cn("text-xs font-medium capitalize gap-1", config.className)}
     >
-      <Icon
-        className={cn(
-          "h-3 w-3",
-          status === "running" && "animate-spin",
-        )}
-      />
+      <Icon className={cn("h-3 w-3", config.animate && "animate-spin")} />
       {status}
     </Badge>
   );

--- a/src/components/VersionStatusPill.tsx
+++ b/src/components/VersionStatusPill.tsx
@@ -1,18 +1,33 @@
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
+import {
+  VERSION_STATUS_STYLES,
+  type VersionStatus,
+} from "@/lib/status-styles";
 
-const statusStyles: Record<string, string> = {
-  draft: "bg-yellow-100 text-yellow-800 border-yellow-300 dark:bg-yellow-900/30 dark:text-yellow-400 dark:border-yellow-700",
-  current: "bg-green-100 text-green-800 border-green-300 dark:bg-green-900/30 dark:text-green-400 dark:border-green-700",
-  archived: "bg-slate-100 text-slate-600 border-slate-300 dark:bg-slate-800/30 dark:text-slate-400 dark:border-slate-600",
-};
+function isVersionStatus(value: string): value is VersionStatus {
+  return value in VERSION_STATUS_STYLES;
+}
 
 export function VersionStatusPill({ status }: { status: string }) {
+  if (!isVersionStatus(status)) {
+    return (
+      <Badge variant="outline" className="text-xs font-medium capitalize">
+        {status}
+      </Badge>
+    );
+  }
+  const config = VERSION_STATUS_STYLES[status];
+  const Icon = config.icon;
   return (
     <Badge
       variant="outline"
-      className={cn("text-xs font-medium capitalize", statusStyles[status])}
+      className={cn(
+        "text-xs font-medium capitalize gap-1",
+        config.className,
+      )}
     >
+      <Icon className={cn("h-3 w-3", config.animate && "animate-spin")} />
       {status}
     </Badge>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -75,7 +75,7 @@
   --radius: 0.625rem;
   --sidebar: oklch(0.985 0 0);
   --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.205 0 0);
+  --sidebar-primary: oklch(0.488 0.243 264.376);
   --sidebar-primary-foreground: oklch(0.985 0 0);
   --sidebar-accent: oklch(0.97 0 0);
   --sidebar-accent-foreground: oklch(0.205 0 0);
@@ -90,8 +90,8 @@
   --card-foreground: oklch(0.985 0 0);
   --popover: oklch(0.205 0 0);
   --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.922 0 0);
-  --primary-foreground: oklch(0.205 0 0);
+  --primary: oklch(0.72 0.18 262.881);
+  --primary-foreground: oklch(0.145 0 0);
   --secondary: oklch(0.269 0 0);
   --secondary-foreground: oklch(0.985 0 0);
   --muted: oklch(0.269 0 0);

--- a/src/lib/status-styles.ts
+++ b/src/lib/status-styles.ts
@@ -1,0 +1,169 @@
+import {
+  Clock,
+  Loader2,
+  CheckCircle2,
+  XCircle,
+  AlertTriangle,
+  Info,
+  Circle,
+  ThumbsUp,
+  ThumbsDown,
+  Check,
+  type LucideIcon,
+} from "lucide-react";
+
+/**
+ * Central status / severity token map.
+ *
+ * Palette (color-blind safe — no semantic red/green, per CLAUDE.md):
+ *   sky    → positive / running / in-progress
+ *   amber  → attention / warning / warm urgency
+ *   purple → negative / failure / destructive outcome
+ *   slate  → neutral / pending / archived / low-signal
+ *
+ * Every status pairs a color className with a Lucide icon so meaning
+ * survives colorblind viewing and monochrome printing. Icons are the
+ * primary carrier of intent; color reinforces.
+ */
+
+export type StatusStyle = {
+  className: string;
+  icon: LucideIcon;
+  /** Whether the icon should animate (e.g. `animate-spin` on Loader2). */
+  animate?: boolean;
+};
+
+// ---------- Run status ----------
+
+export type RunStatus = "pending" | "running" | "completed" | "failed";
+
+export const RUN_STATUS_STYLES: Record<RunStatus, StatusStyle> = {
+  pending: {
+    className:
+      "bg-slate-100 text-slate-600 border-slate-300 dark:bg-slate-800/30 dark:text-slate-400 dark:border-slate-600",
+    icon: Clock,
+  },
+  running: {
+    className:
+      "bg-sky-100 text-sky-700 border-sky-300 dark:bg-sky-900/30 dark:text-sky-300 dark:border-sky-700",
+    icon: Loader2,
+    animate: true,
+  },
+  completed: {
+    className:
+      "bg-sky-100 text-sky-800 border-sky-300 dark:bg-sky-900/30 dark:text-sky-300 dark:border-sky-700",
+    icon: CheckCircle2,
+  },
+  failed: {
+    className:
+      "bg-purple-100 text-purple-700 border-purple-300 dark:bg-purple-900/30 dark:text-purple-300 dark:border-purple-700",
+    icon: XCircle,
+  },
+};
+
+// ---------- Version status ----------
+
+export type VersionStatus = "draft" | "current" | "archived";
+
+export const VERSION_STATUS_STYLES: Record<VersionStatus, StatusStyle> = {
+  draft: {
+    className:
+      "bg-amber-100 text-amber-800 border-amber-300 dark:bg-amber-900/30 dark:text-amber-300 dark:border-amber-700",
+    icon: Clock,
+  },
+  current: {
+    className:
+      "bg-sky-100 text-sky-800 border-sky-300 dark:bg-sky-900/30 dark:text-sky-300 dark:border-sky-700",
+    icon: CheckCircle2,
+  },
+  archived: {
+    className:
+      "bg-slate-100 text-slate-600 border-slate-300 dark:bg-slate-800/30 dark:text-slate-400 dark:border-slate-600",
+    icon: Circle,
+  },
+};
+
+// ---------- Cycle status ----------
+
+export type CycleStatus = "draft" | "open" | "closed";
+
+export const CYCLE_STATUS_STYLES: Record<CycleStatus, StatusStyle> = {
+  draft: {
+    className:
+      "bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300",
+    icon: Clock,
+  },
+  open: {
+    className:
+      "bg-sky-100 text-sky-700 dark:bg-sky-900/30 dark:text-sky-300",
+    icon: Loader2,
+    animate: true,
+  },
+  closed: {
+    className:
+      "bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300",
+    icon: CheckCircle2,
+  },
+};
+
+// ---------- Feedback severity ----------
+
+export type FeedbackSeverity = "high" | "medium" | "low";
+
+export const SEVERITY_STYLES: Record<FeedbackSeverity, StatusStyle> = {
+  high: {
+    className:
+      "bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300",
+    icon: AlertTriangle,
+  },
+  medium: {
+    className: "bg-sky-100 text-sky-700 dark:bg-sky-900/30 dark:text-sky-300",
+    icon: Info,
+  },
+  low: {
+    className:
+      "bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300",
+    icon: Circle,
+  },
+};
+
+// ---------- Rating (preference) ----------
+
+export type Rating = "best" | "acceptable" | "weak";
+
+export const RATING_STYLES: Record<Rating, StatusStyle> = {
+  best: {
+    className:
+      "bg-sky-100 text-sky-700 border-sky-300 dark:bg-sky-900/30 dark:text-sky-300 dark:border-sky-700",
+    icon: ThumbsUp,
+  },
+  acceptable: {
+    className:
+      "bg-slate-100 text-slate-700 border-slate-300 dark:bg-slate-800 dark:text-slate-300 dark:border-slate-600",
+    icon: Check,
+  },
+  weak: {
+    className:
+      "bg-amber-100 text-amber-700 border-amber-300 dark:bg-amber-900/30 dark:text-amber-300 dark:border-amber-700",
+    icon: ThumbsDown,
+  },
+};
+
+/** Inline color classes for rating aggregates (count spans, chart text). */
+export const RATING_TEXT_COLORS: Record<Rating, string> = {
+  best: "text-sky-700 dark:text-sky-300",
+  acceptable: "text-slate-600 dark:text-slate-400",
+  weak: "text-amber-700 dark:text-amber-300",
+};
+
+// ---------- Semantic success/info text (toasts, inline confirmations) ----------
+
+/** Inline success-message text color — e.g. "Settings saved." */
+export const SUCCESS_TEXT = "text-sky-700 dark:text-sky-300";
+
+/** Inline success background for larger surfaces (banners, badges). */
+export const SUCCESS_SURFACE =
+  "bg-sky-50 text-sky-800 dark:bg-sky-950/30 dark:text-sky-300";
+
+/** Inline destructive text — e.g. form validation errors. Uses the theme token. */
+export const DESTRUCTIVE_TEXT = "text-destructive";

--- a/src/routes/orgs/projects/HistoryPage.tsx
+++ b/src/routes/orgs/projects/HistoryPage.tsx
@@ -111,7 +111,7 @@ const EVENT_ICONS: Record<string, typeof Play> = {
 };
 
 const EVENT_COLORS: Record<string, string> = {
-  run_completed: "text-green-600 dark:text-green-400",
+  run_completed: "text-sky-700 dark:text-sky-300",
   run_failed: "text-destructive",
   version_created: "text-blue-600 dark:text-blue-400",
   cycle_opened: "text-primary",

--- a/src/routes/orgs/projects/OptimizationReview.tsx
+++ b/src/routes/orgs/projects/OptimizationReview.tsx
@@ -527,12 +527,12 @@ function ResolvedView({
     accepted: {
       label: "Accepted",
       icon: CheckCircle2,
-      style: "text-green-700 dark:text-green-400",
+      style: "text-sky-700 dark:text-sky-300",
     },
     rejected: {
       label: "Rejected",
       icon: XCircle,
-      style: "text-red-600 dark:text-red-400",
+      style: "text-purple-700 dark:text-purple-300",
     },
     edited: {
       label: "Edited and accepted",

--- a/src/routes/orgs/projects/TestCaseEditor.tsx
+++ b/src/routes/orgs/projects/TestCaseEditor.tsx
@@ -175,7 +175,7 @@ export function TestCaseEditor() {
       {/* Actions */}
       {error && <p className="text-sm text-destructive">{error}</p>}
       {success && (
-        <p className="text-sm text-green-600">Saved successfully.</p>
+        <p className="text-sm text-sky-700 dark:text-sky-300">Saved successfully.</p>
       )}
       <div className="flex justify-end">
         <Button onClick={handleSave} disabled={saving || !name.trim()}>

--- a/src/routes/orgs/projects/VersionEditor.tsx
+++ b/src/routes/orgs/projects/VersionEditor.tsx
@@ -348,8 +348,8 @@ export function VersionEditor() {
         </div>
       )}
       {success && (
-        <div className="px-4 py-2 bg-green-50 dark:bg-green-900/10 border-b">
-          <p className="text-sm text-green-600">Saved successfully.</p>
+        <div className="px-4 py-2 bg-sky-50 dark:bg-sky-950/30 border-b">
+          <p className="text-sm text-sky-700 dark:text-sky-300">Saved successfully.</p>
         </div>
       )}
 

--- a/src/routes/orgs/projects/Versions.tsx
+++ b/src/routes/orgs/projects/Versions.tsx
@@ -133,9 +133,9 @@ export function Versions() {
                     className={cn(
                       "flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-xs font-bold",
                       version.status === "current"
-                        ? "bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-400"
+                        ? "bg-sky-100 text-sky-800 dark:bg-sky-900/40 dark:text-sky-300"
                         : version.status === "draft"
-                          ? "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/40 dark:text-yellow-400"
+                          ? "bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300"
                           : "bg-slate-100 text-slate-600 dark:bg-slate-800/40 dark:text-slate-400",
                     )}
                   >
@@ -373,7 +373,7 @@ function SetupStep({
       className={cn(
         "flex items-start gap-3 rounded-lg border px-4 py-3 transition-colors",
         done
-          ? "border-green-200 bg-green-50/50 dark:border-green-900/40 dark:bg-green-950/10"
+          ? "border-sky-200 bg-sky-50/50 dark:border-sky-900/40 dark:bg-sky-950/20"
           : isNext
             ? "border-primary/30 bg-primary/5 hover:bg-primary/10"
             : "border-border hover:bg-muted/50",
@@ -381,7 +381,7 @@ function SetupStep({
     >
       <div className="mt-0.5">
         {done ? (
-          <CheckCircle2 className="h-5 w-5 text-green-600 dark:text-green-400" />
+          <CheckCircle2 className="h-5 w-5 text-sky-700 dark:text-sky-300" />
         ) : (
           <Circle
             className={cn(
@@ -397,14 +397,14 @@ function SetupStep({
             className={cn(
               "h-4 w-4 shrink-0",
               done
-                ? "text-green-600 dark:text-green-400"
+                ? "text-sky-700 dark:text-sky-300"
                 : "text-muted-foreground",
             )}
           />
           <span
             className={cn(
               "text-sm font-medium",
-              done && "text-green-700 dark:text-green-400",
+              done && "text-sky-700 dark:text-sky-300",
             )}
           >
             {done ? doneLabel : label}

--- a/src/routes/orgs/projects/cycles/CycleDetail.tsx
+++ b/src/routes/orgs/projects/cycles/CycleDetail.tsx
@@ -455,7 +455,7 @@ export function CycleDetail() {
                         className={cn(
                           "text-[10px]",
                           evaluator.status === "completed" &&
-                            "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300",
+                            "bg-sky-100 text-sky-700 dark:bg-sky-900/30 dark:text-sky-300",
                           evaluator.status === "in_progress" &&
                             "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300",
                         )}
@@ -515,7 +515,7 @@ export function CycleDetail() {
                       className={cn(
                         "text-[10px]",
                         inv.status === "responded" &&
-                          "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300",
+                          "bg-sky-100 text-sky-700 dark:bg-sky-900/30 dark:text-sky-300",
                       )}
                     >
                       {inv.status}
@@ -675,7 +675,7 @@ export function CycleDetail() {
                   )}
                 </div>
                 <div className="flex items-center gap-2 text-xs">
-                  <span className="text-green-600 dark:text-green-400">
+                  <span className="text-sky-700 dark:text-sky-300">
                     {output.ratings.best} best
                   </span>
                   <span className="text-muted-foreground">

--- a/src/routes/orgs/projects/cycles/VersionDashboard.tsx
+++ b/src/routes/orgs/projects/cycles/VersionDashboard.tsx
@@ -94,7 +94,7 @@ export function VersionDashboard() {
               ? Math.round((overallRatings.best / totalRatings) * 100)
               : 0
           }
-          color="text-green-600 dark:text-green-400"
+          color="text-sky-700 dark:text-sky-300"
         />
         <StatCard
           label="Acceptable"
@@ -123,7 +123,7 @@ export function VersionDashboard() {
       {totalRatings > 0 && (
         <div className="mt-4 h-3 rounded-full overflow-hidden flex bg-muted">
           <div
-            className="bg-green-500 transition-all"
+            className="bg-sky-500 transition-all"
             style={{
               width: `${(overallRatings.best / totalRatings) * 100}%`,
             }}
@@ -182,7 +182,7 @@ export function VersionDashboard() {
                     )}
                   </div>
                   <div className="flex items-center gap-3 text-xs">
-                    <span className="text-green-600 dark:text-green-400">
+                    <span className="text-sky-700 dark:text-sky-300">
                       {cycle.aggregatedRatings.best} best
                     </span>
                     <span className="text-muted-foreground">
@@ -255,7 +255,7 @@ export function VersionDashboard() {
                 <div className="mt-2 flex gap-4 text-xs">
                   {transition.resolved.length > 0 && (
                     <div>
-                      <span className="text-green-600 dark:text-green-400 font-medium">
+                      <span className="text-sky-700 dark:text-sky-300 font-medium">
                         Resolved:
                       </span>{" "}
                       {transition.resolved
@@ -390,14 +390,14 @@ function TrendIndicator({
       );
     case "down":
       return (
-        <span className="flex items-center gap-1 text-xs text-green-600 dark:text-green-400">
+        <span className="flex items-center gap-1 text-xs text-sky-700 dark:text-sky-300">
           <TrendingDown className="h-3 w-3" />
           decreasing
         </span>
       );
     case "resolved":
       return (
-        <span className="flex items-center gap-1 text-xs text-green-600 dark:text-green-400">
+        <span className="flex items-center gap-1 text-xs text-sky-700 dark:text-sky-300">
           <CheckCircle className="h-3 w-3" />
           resolved
         </span>

--- a/src/routes/orgs/projects/settings/ProjectCollaborators.tsx
+++ b/src/routes/orgs/projects/settings/ProjectCollaborators.tsx
@@ -134,7 +134,7 @@ function InviteRow({ projectId }: { projectId: Id<"projects"> }) {
         </Button>
       </form>
       {error && <p className="mt-2 text-sm text-destructive">{error}</p>}
-      {success && <p className="mt-2 text-sm text-green-600">{success}</p>}
+      {success && <p className="mt-2 text-sm text-sky-700 dark:text-sky-300">{success}</p>}
     </div>
   );
 }

--- a/src/routes/orgs/projects/settings/ProjectSettings.tsx
+++ b/src/routes/orgs/projects/settings/ProjectSettings.tsx
@@ -92,7 +92,7 @@ export function ProjectSettings() {
           />
         </div>
         {error && <p className="text-sm text-destructive">{error}</p>}
-        {success && <p className="text-sm text-green-600">Settings saved.</p>}
+        {success && <p className="text-sm text-sky-700 dark:text-sky-300">Settings saved.</p>}
         <Button type="submit" disabled={saving || !name.trim()}>
           {saving ? "Saving..." : "Save"}
         </Button>

--- a/src/routes/orgs/projects/solo-eval/SoloEvalResults.tsx
+++ b/src/routes/orgs/projects/solo-eval/SoloEvalResults.tsx
@@ -124,7 +124,7 @@ export function SoloEvalResults() {
                     <p className="text-xs text-muted-foreground">avg score</p>
                     <div className="mt-2 flex items-center gap-2 text-xs text-muted-foreground">
                       <span className="flex items-center gap-0.5">
-                        <ThumbsUp className="h-3 w-3 text-green-600" />
+                        <ThumbsUp className="h-3 w-3 text-sky-700 dark:text-sky-300" />
                         {vs.bestCount}
                       </span>
                       <span className="flex items-center gap-0.5">
@@ -241,12 +241,12 @@ function RatingBadge({ rating }: { rating: string }) {
     best: {
       label: "Best",
       className:
-        "bg-green-100 text-green-700 border-green-300 dark:bg-green-900/30 dark:text-green-300 dark:border-green-700",
+        "bg-sky-100 text-sky-700 border-sky-300 dark:bg-sky-900/30 dark:text-sky-300 dark:border-sky-700",
     },
     acceptable: {
       label: "OK",
       className:
-        "bg-gray-100 text-gray-700 border-gray-300 dark:bg-gray-800 dark:text-gray-300 dark:border-gray-600",
+        "bg-slate-100 text-slate-700 border-slate-300 dark:bg-slate-800 dark:text-slate-300 dark:border-slate-600",
     },
     weak: {
       label: "Weak",

--- a/src/routes/orgs/projects/solo-eval/SoloEvalSetup.tsx
+++ b/src/routes/orgs/projects/solo-eval/SoloEvalSetup.tsx
@@ -242,7 +242,7 @@ export function SoloEvalSetup() {
             </div>
           )}
           {error && (
-            <div className="mt-2 flex items-start gap-2 text-xs text-red-600 dark:text-red-400">
+            <div className="mt-2 flex items-start gap-2 text-xs text-destructive">
               <AlertCircle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
               <span>{error}</span>
             </div>

--- a/src/routes/orgs/settings/OpenRouterKey.tsx
+++ b/src/routes/orgs/settings/OpenRouterKey.tsx
@@ -87,7 +87,7 @@ function OpenRouterKeyForm() {
           {/* Status line */}
           <div className="text-sm">
             {keyStatus.hasKey ? (
-              <span className="text-green-600 dark:text-green-400">
+              <span className="text-sky-700 dark:text-sky-300">
                 Key set &middot; last rotated{" "}
                 {formatRelativeTime(keyStatus.lastRotatedAt!)}
               </span>
@@ -113,7 +113,7 @@ function OpenRouterKeyForm() {
 
             {error && <p className="text-sm text-destructive">{error}</p>}
             {success && (
-              <p className="text-sm text-green-600">Key saved successfully.</p>
+              <p className="text-sm text-sky-700 dark:text-sky-300">Key saved successfully.</p>
             )}
 
             <Button type="submit" disabled={saving || !key.trim()}>

--- a/src/routes/orgs/settings/OrgMembers.tsx
+++ b/src/routes/orgs/settings/OrgMembers.tsx
@@ -125,7 +125,7 @@ function InviteRow({ orgId }: { orgId: Id<"organizations"> }) {
         </Button>
       </form>
       {error && <p className="mt-2 text-sm text-destructive">{error}</p>}
-      {success && <p className="mt-2 text-sm text-green-600">{success}</p>}
+      {success && <p className="mt-2 text-sm text-sky-700 dark:text-sky-300">{success}</p>}
     </div>
   );
 }

--- a/src/routes/orgs/settings/OrgSettings.tsx
+++ b/src/routes/orgs/settings/OrgSettings.tsx
@@ -93,7 +93,7 @@ function OrgSettingsForm({
         </div>
         {error && <p className="text-sm text-destructive">{error}</p>}
         {success && (
-          <p className="text-sm text-green-600">Settings saved.</p>
+          <p className="text-sm text-sky-700 dark:text-sky-300">Settings saved.</p>
         )}
         <Button type="submit" disabled={saving || !name.trim() || !slugPreview}>
           {saving ? "Saving..." : "Save"}

--- a/src/routes/share/CycleShareableEvalView.tsx
+++ b/src/routes/share/CycleShareableEvalView.tsx
@@ -69,8 +69,8 @@ export function CycleShareableEvalView() {
     return (
       <PageShell>
         <div className="text-center py-12">
-          <div className="mx-auto w-12 h-12 rounded-full bg-green-100 dark:bg-green-900/30 flex items-center justify-center">
-            <Check className="h-6 w-6 text-green-600 dark:text-green-400" />
+          <div className="mx-auto w-12 h-12 rounded-full bg-sky-100 dark:bg-sky-900/30 flex items-center justify-center">
+            <Check className="h-6 w-6 text-sky-700 dark:text-sky-300" />
           </div>
           <p className="mt-3 text-lg font-medium">Thank you!</p>
           <p className="mt-1 text-sm text-muted-foreground">


### PR DESCRIPTION
## Summary

First wave of the UI audit remediation (`docs/app-ui-audit-2026-04-16.md`). Addresses the most systemic P0 findings so every subsequent wave inherits the corrected visual foundation.

- **Theme tokens** — restore tinted primary in dark mode (`oklch(0.722 0.18 262.881)`) and switch light-mode sidebar primary from achromatic gray to the brand blue-purple so the whole shell reads consistently across themes.
- **Status token module** — new `src/lib/status-styles.ts` centralizes Run / Version / Cycle status, feedback severity, and rating styles behind typed records. Every style pairs a className with a Lucide icon so meaning survives colorblind viewing and monochrome printing.
- **Red/green migration (22 files)** — CLAUDE.md forbids red/green for diffs/status (color-blind rule), but drift had crept into 23 components and routes. Palette is now sky=positive, amber=warning, purple=negative, slate=neutral. Feedback tags stay categorical but swap red→fuchsia and green→indigo.

Tracks umbrella issue #100.

## Test plan

- [x] `npm run build` — clean
- [ ] Visual smoke: `npm run dev`, verify `/orgs/:slug`, `/runs/:id`, `/cycles/:id`, `/s/cycle/<token>` in light + dark
- [ ] Confirm no `bg-(red|green)-` or `text-(red|green)-` classes remain: `rg 'bg-(red\|green)-|text-(red\|green)-' src/` returns empty
- [ ] Contrast spot-check on status pills, rating buttons, digest severity chips in both themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)