### PR TITLE
UI audit wave 2: mobile responsive pass

### DIFF
--- a/src/components/HelpMenu.tsx
+++ b/src/components/HelpMenu.tsx
@@ -37,8 +37,8 @@ export function HelpMenu() {
   return (
     <>
       <DropdownMenu>
-        <DropdownMenuTrigger className="flex items-center justify-center rounded-md h-8 w-8 hover:bg-accent transition-colors">
-          <HelpCircle className="h-4 w-4" />
+        <DropdownMenuTrigger className="flex items-center justify-center rounded-md h-11 w-11 hover:bg-accent transition-colors sm:h-8 sm:w-8">
+          <HelpCircle className="h-5 w-5 sm:h-4 sm:w-4" />
           <span className="sr-only">Help</span>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end" className="w-56">

--- a/src/components/MobileNavDrawer.tsx
+++ b/src/components/MobileNavDrawer.tsx
@@ -1,0 +1,45 @@
+import { useState } from "react";
+import { Drawer as DrawerPrimitive } from "@base-ui/react/drawer";
+import { Menu, XIcon } from "lucide-react";
+import { SideNavContent } from "./SideNavContent";
+import { useOrgLayout } from "@/components/layouts/OrgLayout";
+
+/**
+ * Mobile navigation drawer — hamburger trigger + left-sliding Sheet. Rendered
+ * only on mobile (< md) by TopBar; desktop uses the always-visible `SideNav`.
+ *
+ * Reuses `SideNavContent` to keep a single source of truth for nav structure.
+ * The drawer closes automatically when a NavLink is clicked (`onNavigate`).
+ */
+export function MobileNavDrawer() {
+  const { openNewProjectDialog } = useOrgLayout();
+  const [open, setOpen] = useState(false);
+
+  return (
+    <DrawerPrimitive.Root open={open} onOpenChange={setOpen}>
+      <DrawerPrimitive.Trigger
+        aria-label="Open navigation"
+        className="flex h-11 w-11 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground md:hidden"
+      >
+        <Menu className="h-5 w-5" />
+      </DrawerPrimitive.Trigger>
+      <DrawerPrimitive.Portal>
+        <DrawerPrimitive.Backdrop className="fixed inset-0 isolate z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0" />
+        <DrawerPrimitive.Popup className="fixed left-0 top-0 z-50 flex h-full w-72 flex-col gap-1 bg-popover p-3 text-sm text-popover-foreground shadow-xl ring-1 ring-foreground/10 outline-hidden duration-200 data-open:animate-in data-open:slide-in-from-left data-closed:animate-out data-closed:slide-out-to-left">
+          <div className="flex items-center justify-end pb-1">
+            <DrawerPrimitive.Close
+              aria-label="Close navigation"
+              className="flex h-9 w-9 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+            >
+              <XIcon className="h-4 w-4" />
+            </DrawerPrimitive.Close>
+          </div>
+          <SideNavContent
+            onNewProject={openNewProjectDialog}
+            onNavigate={() => setOpen(false)}
+          />
+        </DrawerPrimitive.Popup>
+      </DrawerPrimitive.Portal>
+    </DrawerPrimitive.Root>
+  );
+}

--- a/src/components/NotificationBell.tsx
+++ b/src/components/NotificationBell.tsx
@@ -43,11 +43,12 @@ export function NotificationBell() {
     <div className="relative" ref={ref}>
       <Button
         variant="ghost"
-        size="icon-sm"
+        size="icon"
         onClick={() => setOpen(!open)}
         aria-label={`Notifications${count > 0 ? ` (${count} unread)` : ""}`}
+        className="h-11 w-11 sm:h-9 sm:w-9"
       >
-        <Bell className="h-4 w-4" />
+        <Bell className="h-5 w-5 sm:h-4 sm:w-4" />
         {count > 0 && (
           <span className="absolute -top-0.5 -right-0.5 flex h-4 min-w-[16px] items-center justify-center rounded-full bg-destructive px-1 text-[10px] font-medium text-destructive-foreground">
             {count > 9 ? "9+" : count}

--- a/src/components/ProjectTabs.tsx
+++ b/src/components/ProjectTabs.tsx
@@ -41,7 +41,7 @@ export function ProjectTabs() {
               to={to}
               className={() =>
                 cn(
-                  "inline-flex items-center px-3 py-2.5 text-sm transition-colors border-b-2",
+                  "inline-flex min-h-11 items-center px-3 py-2.5 text-sm transition-colors border-b-2 sm:min-h-0",
                   isActive
                     ? "border-primary text-foreground font-medium"
                     : "border-transparent text-muted-foreground hover:text-foreground",
@@ -58,15 +58,16 @@ export function ProjectTabs() {
           to={`${basePath}/settings`}
           className={({ isActive }) =>
             cn(
-              "ml-2 rounded-md p-1.5 transition-colors",
+              "ml-2 inline-flex h-11 w-11 items-center justify-center rounded-md transition-colors sm:h-auto sm:w-auto sm:p-1.5",
               isActive
                 ? "text-foreground bg-accent"
                 : "text-muted-foreground hover:text-foreground hover:bg-accent",
             )
           }
           title="Settings"
+          aria-label="Project settings"
         >
-          <Settings className="h-4 w-4" />
+          <Settings className="h-5 w-5 sm:h-4 sm:w-4" />
         </NavLink>
       )}
     </div>

--- a/src/components/PromptDiff.tsx
+++ b/src/components/PromptDiff.tsx
@@ -88,7 +88,7 @@ export function PromptDiff({
 
 function SideBySideView({ parts }: { parts: DiffPart[] }) {
   return (
-    <div className="grid grid-cols-2 gap-2">
+    <div className="grid grid-cols-1 gap-2 md:grid-cols-2">
       {/* Old (removed) */}
       <div className="rounded-md border bg-card p-3 overflow-auto">
         <div className="text-[10px] font-medium text-purple-600 dark:text-purple-400 mb-2 uppercase tracking-wider">

--- a/src/components/RatingButtons.tsx
+++ b/src/components/RatingButtons.tsx
@@ -35,7 +35,7 @@ export function RatingButtons({
             aria-label={label}
             onClick={() => onRate(value)}
             className={cn(
-              "inline-flex items-center gap-1 rounded-md border px-2 py-1 text-xs font-medium transition-colors",
+              "inline-flex min-h-11 items-center gap-1.5 rounded-md border px-3 py-2 text-sm font-medium transition-colors sm:min-h-0 sm:gap-1 sm:px-2 sm:py-1 sm:text-xs",
               "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1",
               "motion-safe:transition-all motion-safe:duration-150",
               isSelected
@@ -43,7 +43,7 @@ export function RatingButtons({
                 : "border-border text-muted-foreground hover:bg-muted/50",
             )}
           >
-            <Icon className="h-3 w-3" />
+            <Icon className="h-4 w-4 sm:h-3 sm:w-3" />
             {label}
           </button>
         );

--- a/src/components/SideNav.tsx
+++ b/src/components/SideNav.tsx
@@ -1,91 +1,18 @@
-import { useQuery } from "convex/react";
-import { NavLink } from "react-router-dom";
-import { api } from "../../convex/_generated/api";
-import { useOrg } from "@/contexts/OrgContext";
-import { cn } from "@/lib/utils";
-import { FolderOpen, Key, Settings, Users, Plus } from "lucide-react";
+import { SideNavContent } from "./SideNavContent";
 
 interface SideNavProps {
   onNewProject: () => void;
 }
 
+/**
+ * Desktop sidebar wrapper — hidden on mobile (< md). Mobile uses
+ * `MobileNavDrawer` instead, which renders the same `SideNavContent`
+ * inside a Sheet.
+ */
 export function SideNav({ onNewProject }: SideNavProps) {
-  const { org, orgId, role } = useOrg();
-  const projects = useQuery(api.projects.list, { orgId });
-
-  const linkClass = ({ isActive }: { isActive: boolean }) =>
-    cn(
-      "flex items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors",
-      isActive
-        ? "bg-accent text-accent-foreground font-medium"
-        : "text-muted-foreground hover:bg-accent hover:text-accent-foreground",
-    );
-
   return (
-    <nav className="flex w-56 shrink-0 flex-col gap-1 border-r p-3">
-      <div className="flex items-center justify-between px-2 pb-1">
-        <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
-          Prompts
-        </span>
-        <button
-          onClick={onNewProject}
-          className="rounded p-0.5 text-muted-foreground hover:bg-accent hover:text-accent-foreground"
-        >
-          <Plus className="h-4 w-4" />
-        </button>
-      </div>
-
-      {projects === undefined ? (
-        <div className="space-y-1 px-2">
-          {[1, 2, 3].map((i) => (
-            <div
-              key={i}
-              className="h-7 animate-pulse rounded bg-muted"
-            />
-          ))}
-        </div>
-      ) : projects.length === 0 ? (
-        <p className="px-2 text-xs text-muted-foreground">No prompts yet</p>
-      ) : (
-        projects.map((p) => (
-          <NavLink
-            key={p._id}
-            to={`/orgs/${org.slug}/projects/${p._id}`}
-            className={linkClass}
-          >
-            <FolderOpen className="h-4 w-4 shrink-0" />
-            <span className="truncate">{p.name}</span>
-          </NavLink>
-        ))
-      )}
-
-      {role === "owner" && (
-        <>
-          <div className="mt-4 px-2 pb-1">
-            <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              Settings
-            </span>
-          </div>
-          <NavLink to={`/orgs/${org.slug}/settings`} end className={linkClass}>
-            <Settings className="h-4 w-4 shrink-0" />
-            General
-          </NavLink>
-          <NavLink
-            to={`/orgs/${org.slug}/settings/members`}
-            className={linkClass}
-          >
-            <Users className="h-4 w-4 shrink-0" />
-            Members
-          </NavLink>
-          <NavLink
-            to={`/orgs/${org.slug}/settings/openrouter-key`}
-            className={linkClass}
-          >
-            <Key className="h-4 w-4 shrink-0" />
-            OpenRouter Key
-          </NavLink>
-        </>
-      )}
+    <nav className="hidden w-56 shrink-0 flex-col gap-1 border-r p-3 md:flex">
+      <SideNavContent onNewProject={onNewProject} />
     </nav>
   );
 }

--- a/src/components/SideNavContent.tsx
+++ b/src/components/SideNavContent.tsx
@@ -1,0 +1,114 @@
+import { useQuery } from "convex/react";
+import { NavLink } from "react-router-dom";
+import { api } from "../../convex/_generated/api";
+import { useOrg } from "@/contexts/OrgContext";
+import { cn } from "@/lib/utils";
+import { FolderOpen, Key, Settings, Users, Plus } from "lucide-react";
+
+interface SideNavContentProps {
+  /** Called when the "+" button is clicked. */
+  onNewProject: () => void;
+  /** Called after any NavLink is clicked — used by mobile drawer to close itself. */
+  onNavigate?: () => void;
+}
+
+/**
+ * The shared inner body of the side nav — used by both the desktop `SideNav`
+ * wrapper and the mobile `MobileNavDrawer`.
+ *
+ * Renders its own content only; the caller supplies the surrounding container
+ * (desktop sidebar frame vs. Sheet popup).
+ */
+export function SideNavContent({
+  onNewProject,
+  onNavigate,
+}: SideNavContentProps) {
+  const { org, orgId, role } = useOrg();
+  const projects = useQuery(api.projects.list, { orgId });
+
+  const linkClass = ({ isActive }: { isActive: boolean }) =>
+    cn(
+      "flex items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors",
+      isActive
+        ? "bg-accent text-accent-foreground font-medium"
+        : "text-muted-foreground hover:bg-accent hover:text-accent-foreground",
+    );
+
+  return (
+    <>
+      <div className="flex items-center justify-between px-2 pb-1">
+        <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+          Prompts
+        </span>
+        <button
+          type="button"
+          onClick={() => {
+            onNewProject();
+            onNavigate?.();
+          }}
+          aria-label="New prompt"
+          className="rounded p-0.5 text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+        >
+          <Plus className="h-4 w-4" />
+        </button>
+      </div>
+
+      {projects === undefined ? (
+        <div className="space-y-1 px-2">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="h-7 animate-pulse rounded bg-muted" />
+          ))}
+        </div>
+      ) : projects.length === 0 ? (
+        <p className="px-2 text-xs text-muted-foreground">No prompts yet</p>
+      ) : (
+        projects.map((p) => (
+          <NavLink
+            key={p._id}
+            to={`/orgs/${org.slug}/projects/${p._id}`}
+            className={linkClass}
+            onClick={onNavigate}
+          >
+            <FolderOpen className="h-4 w-4 shrink-0" />
+            <span className="truncate">{p.name}</span>
+          </NavLink>
+        ))
+      )}
+
+      {role === "owner" && (
+        <>
+          <div className="mt-4 px-2 pb-1">
+            <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+              Settings
+            </span>
+          </div>
+          <NavLink
+            to={`/orgs/${org.slug}/settings`}
+            end
+            className={linkClass}
+            onClick={onNavigate}
+          >
+            <Settings className="h-4 w-4 shrink-0" />
+            General
+          </NavLink>
+          <NavLink
+            to={`/orgs/${org.slug}/settings/members`}
+            className={linkClass}
+            onClick={onNavigate}
+          >
+            <Users className="h-4 w-4 shrink-0" />
+            Members
+          </NavLink>
+          <NavLink
+            to={`/orgs/${org.slug}/settings/openrouter-key`}
+            className={linkClass}
+            onClick={onNavigate}
+          >
+            <Key className="h-4 w-4 shrink-0" />
+            OpenRouter Key
+          </NavLink>
+        </>
+      )}
+    </>
+  );
+}

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -3,9 +3,10 @@ import { OrgSwitcher } from "@/components/OrgSwitcher";
 import { UserMenu } from "@/components/UserMenu";
 import { HelpMenu } from "@/components/HelpMenu";
 import { NotificationBell } from "@/components/NotificationBell";
+import { MobileNavDrawer } from "@/components/MobileNavDrawer";
 import { toggleCommandPalette } from "@/lib/commandPaletteState";
 import { toggleCheatSheet } from "@/lib/shortcutCheatSheetState";
-import { LayoutDashboard } from "lucide-react";
+import { LayoutDashboard, Search } from "lucide-react";
 
 interface TopBarProps {
   variant?: "default" | "evaluator";
@@ -16,7 +17,10 @@ export function TopBar({ variant = "default" }: TopBarProps) {
     <header className="flex h-14 shrink-0 items-center justify-between border-b px-4">
       <div className="flex items-center gap-2">
         {variant === "default" ? (
-          <OrgSwitcher />
+          <>
+            <MobileNavDrawer />
+            <OrgSwitcher />
+          </>
         ) : (
           <span className="text-sm font-semibold">
             Blind Bench &mdash; Evaluation
@@ -26,6 +30,16 @@ export function TopBar({ variant = "default" }: TopBarProps) {
       <div className="flex items-center gap-2">
         {variant === "default" && (
           <>
+            {/* Mobile: 44×44 icon button */}
+            <button
+              onClick={() => toggleCommandPalette()}
+              aria-label="Open command palette"
+              className="flex h-11 w-11 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground sm:hidden"
+              title="Command palette"
+            >
+              <Search className="h-5 w-5" />
+            </button>
+            {/* Desktop: labeled button with ⌘K hint */}
             <button
               onClick={() => toggleCommandPalette()}
               className="hidden sm:flex items-center gap-1.5 rounded-md border px-2 py-1 text-xs text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"

--- a/src/routes/eval/CycleEvalView.tsx
+++ b/src/routes/eval/CycleEvalView.tsx
@@ -102,7 +102,7 @@ export function CycleEvalView() {
     return (
       <div className="p-6 space-y-4">
         <Skeleton className="h-6 w-64" />
-        <div className="grid grid-cols-3 gap-4">
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
           <Skeleton className="h-96" />
           <Skeleton className="h-96" />
           <Skeleton className="h-96" />
@@ -262,7 +262,7 @@ export function CycleEvalView() {
               </div>
 
               {/* Annotatable output */}
-              <div className="flex-1 overflow-y-auto max-h-[400px]">
+              <div className="flex-1 overflow-y-auto sm:max-h-[400px]">
                 <AnnotatedEditor
                   content={output.outputContentSnapshot}
                   annotations={output.annotations.map((a) => ({

--- a/src/routes/orgs/projects/RunConfigurator.tsx
+++ b/src/routes/orgs/projects/RunConfigurator.tsx
@@ -1136,8 +1136,8 @@ export function RunConfigurator() {
           )}
 
           {summaryRows.length > 0 ? (
-            <div className="border rounded-md overflow-hidden">
-              <table className="w-full text-xs">
+            <div className="border rounded-md overflow-x-auto">
+              <table className="w-full min-w-[520px] text-xs">
                 <thead>
                   <tr className="border-b bg-muted/50">
                     {selectedVersionIds.size > 1 && (

--- a/src/routes/orgs/projects/VersionEditor.tsx
+++ b/src/routes/orgs/projects/VersionEditor.tsx
@@ -249,7 +249,7 @@ export function VersionEditor() {
       <div className="p-6 space-y-4">
         <Skeleton className="h-6 w-32" />
         <div className="flex gap-4">
-          <Skeleton className="w-[22%] h-96" />
+          <Skeleton className="hidden lg:block w-[22%] h-96" />
           <Skeleton className="flex-1 h-96" />
         </div>
       </div>
@@ -362,8 +362,8 @@ export function VersionEditor() {
 
       {/* Two-column layout */}
       <div className="flex flex-1 overflow-hidden">
-        {/* Left — Sidebar */}
-        <div className="w-[22%] min-w-[220px] border-r overflow-y-auto p-3 space-y-4">
+        {/* Left — Sidebar (desktop only; hidden below lg to give the editor room on mobile) */}
+        <div className="hidden lg:flex lg:w-[22%] lg:min-w-[220px] flex-col border-r overflow-y-auto p-3 space-y-4">
           {/* Variables */}
           <div className="space-y-2">
             <div className="flex items-center justify-between">

--- a/src/routes/share/CycleShareableEvalView.tsx
+++ b/src/routes/share/CycleShareableEvalView.tsx
@@ -151,7 +151,7 @@ export function CycleShareableEvalView() {
                 <span className="text-xs text-primary">rated</span>
               )}
             </div>
-            <div className="flex-1 p-3 overflow-y-auto max-h-[300px]">
+            <div className="flex-1 p-3 overflow-y-auto sm:max-h-[300px]">
               <p className="text-sm whitespace-pre-wrap">
                 {output.outputContentSnapshot}
               </p>


### PR DESCRIPTION
## Summary

Second wave of the UI audit remediation — the mobile responsive pass. Addresses 44×44 touch targets, off-screen sidebars, and dense tables that broke on phones. No behavior or API changes.

## Changes

- **Mobile navigation** — SideNav is now `hidden md:flex`; new `MobileNavDrawer` renders a hamburger + left-sliding Sheet on mobile, reusing the extracted `SideNavContent` so desktop and drawer share one source of truth.
- **TopBar** — adds a 44×44 search icon on mobile (replaces the `⌘K` pill that was hidden below `sm`). Desktop UI unchanged.
- **Touch targets (WCAG 2.1 AA)** — `RatingButtons`, `NotificationBell`, `HelpMenu`, `ProjectTabs` tabs + settings icon all hit 44×44 on mobile, dense sizes preserved on `sm:` and up.
- **Stacked layouts** — `PromptDiff` goes to 1 column below `md`; `CycleEvalView` loading grid stacks below `sm`.
- **Table overflow** — `RunConfigurator` summary table wraps in `overflow-x-auto` with `min-w-[520px]` so it scrolls horizontally instead of overflowing the viewport.
- **Sidebar on phones** — `VersionEditor` sidebar is `hidden lg:flex`; phone editor gets the full width for Tiptap.
- **Scrollable output cards** — share and internal eval views drop hard `max-h-[300px]` / `max-h-[400px]` on mobile (applied only at `sm:` and up) so tall outputs don't require nested scrolling on phones.

## Test plan

- [ ] Verify OrgLayout renders hamburger + drawer below `md`, full sidebar at `md+`
- [ ] Tap each nav item in the mobile drawer — drawer should auto-close after navigation
- [ ] Check rating buttons (cycle eval, public share link) measure ≥44px tall on mobile
- [ ] Open `/runs/:runId` PromptDiff on mobile — stacks vertically
- [ ] Open `/run` with summary rows — table scrolls horizontally
- [ ] Open VersionEditor on mobile — sidebar hidden, editor takes full width
- [ ] Public blind-eval link on a phone — scroll the whole page freely; output cards don't clip at 300px

🤖 Generated with [Claude Code](https://claude.com/claude-code)