### PR TITLE
UI audit wave 3: accessibility semantics

### DIFF
--- a/src/components/FeedbackSheet.tsx
+++ b/src/components/FeedbackSheet.tsx
@@ -80,9 +80,13 @@ function OutputFeedbackSection({
 
   if (!feedback || feedback.length === 0) return null;
 
+  const headingId = `feedback-output-${blindLabel}`;
   return (
-    <div className="space-y-1.5">
-      <h4 className="text-xs font-medium text-muted-foreground">
+    <section aria-labelledby={headingId} className="space-y-1.5">
+      <h4
+        id={headingId}
+        className="text-xs font-medium text-muted-foreground"
+      >
         Output {blindLabel}
       </h4>
       {feedback.map((fb) => (
@@ -94,7 +98,7 @@ function OutputFeedbackSection({
           createdAt={fb._creationTime}
         />
       ))}
-    </div>
+    </section>
   );
 }
 
@@ -119,8 +123,14 @@ function PromptFeedbackList({
   return (
     <div className="space-y-3 mt-3">
       {systemFeedback.length > 0 && (
-        <div className="space-y-1.5">
-          <h4 className="text-xs font-medium text-muted-foreground">
+        <section
+          aria-labelledby="feedback-system-message"
+          className="space-y-1.5"
+        >
+          <h4
+            id="feedback-system-message"
+            className="text-xs font-medium text-muted-foreground"
+          >
             System message
           </h4>
           {systemFeedback.map((fb) => (
@@ -132,11 +142,17 @@ function PromptFeedbackList({
               createdAt={fb._creationTime}
             />
           ))}
-        </div>
+        </section>
       )}
       {userFeedback.length > 0 && (
-        <div className="space-y-1.5">
-          <h4 className="text-xs font-medium text-muted-foreground">
+        <section
+          aria-labelledby="feedback-user-template"
+          className="space-y-1.5"
+        >
+          <h4
+            id="feedback-user-template"
+            className="text-xs font-medium text-muted-foreground"
+          >
             User template
           </h4>
           {userFeedback.map((fb) => (
@@ -148,7 +164,7 @@ function PromptFeedbackList({
               createdAt={fb._creationTime}
             />
           ))}
-        </div>
+        </section>
       )}
     </div>
   );

--- a/src/components/MobileNavDrawer.tsx
+++ b/src/components/MobileNavDrawer.tsx
@@ -25,7 +25,10 @@ export function MobileNavDrawer() {
       </DrawerPrimitive.Trigger>
       <DrawerPrimitive.Portal>
         <DrawerPrimitive.Backdrop className="fixed inset-0 isolate z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0" />
-        <DrawerPrimitive.Popup className="fixed left-0 top-0 z-50 flex h-full w-72 flex-col gap-1 bg-popover p-3 text-sm text-popover-foreground shadow-xl ring-1 ring-foreground/10 outline-hidden duration-200 data-open:animate-in data-open:slide-in-from-left data-closed:animate-out data-closed:slide-out-to-left">
+        <DrawerPrimitive.Popup
+          aria-label="Primary navigation"
+          className="fixed left-0 top-0 z-50 flex h-full w-72 flex-col gap-1 bg-popover p-3 text-sm text-popover-foreground shadow-xl ring-1 ring-foreground/10 outline-hidden duration-200 data-open:animate-in data-open:slide-in-from-left data-closed:animate-out data-closed:slide-out-to-left"
+        >
           <div className="flex items-center justify-end pb-1">
             <DrawerPrimitive.Close
               aria-label="Close navigation"
@@ -34,10 +37,12 @@ export function MobileNavDrawer() {
               <XIcon className="h-4 w-4" />
             </DrawerPrimitive.Close>
           </div>
-          <SideNavContent
-            onNewProject={openNewProjectDialog}
-            onNavigate={() => setOpen(false)}
-          />
+          <nav aria-label="Primary" className="flex flex-1 flex-col gap-1">
+            <SideNavContent
+              onNewProject={openNewProjectDialog}
+              onNavigate={() => setOpen(false)}
+            />
+          </nav>
         </DrawerPrimitive.Popup>
       </DrawerPrimitive.Portal>
     </DrawerPrimitive.Root>

--- a/src/components/OrgSwitcher.tsx
+++ b/src/components/OrgSwitcher.tsx
@@ -17,9 +17,15 @@ export function OrgSwitcher() {
 
   return (
     <DropdownMenu>
-      <DropdownMenuTrigger className="flex items-center gap-1.5 rounded-md px-2 py-1.5 text-sm font-semibold hover:bg-accent">
+      <DropdownMenuTrigger
+        className="flex items-center gap-1.5 rounded-md px-2 py-1.5 text-sm font-semibold hover:bg-accent"
+        aria-label={`Current organization: ${org.name}. Switch organization`}
+      >
         {org.name}
-        <ChevronsUpDown className="h-3.5 w-3.5 text-muted-foreground" />
+        <ChevronsUpDown
+          className="h-3.5 w-3.5 text-muted-foreground"
+          aria-hidden="true"
+        />
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start" className="w-56">
         {orgs?.map(({ org: o }) => (

--- a/src/components/ProjectTabs.tsx
+++ b/src/components/ProjectTabs.tsx
@@ -17,7 +17,10 @@ export function ProjectTabs() {
   const basePath = `/orgs/${orgSlug}/projects/${projectId}`;
 
   return (
-    <div className="flex items-center border-b px-4">
+    <nav
+      aria-label="Project sections"
+      className="flex items-center border-b px-4"
+    >
       <div className="flex items-center gap-1 flex-1 overflow-x-auto">
         {tabs.map((tab) => {
           // Evaluators: hide Run and Editor tabs
@@ -39,6 +42,7 @@ export function ProjectTabs() {
             <NavLink
               key={tab.label}
               to={to}
+              aria-current={isActive ? "page" : undefined}
               className={() =>
                 cn(
                   "inline-flex min-h-11 items-center px-3 py-2.5 text-sm transition-colors border-b-2 sm:min-h-0",
@@ -70,6 +74,6 @@ export function ProjectTabs() {
           <Settings className="h-5 w-5 sm:h-4 sm:w-4" />
         </NavLink>
       )}
-    </div>
+    </nav>
   );
 }

--- a/src/components/RunComment.tsx
+++ b/src/components/RunComment.tsx
@@ -85,8 +85,11 @@ function RunCommentEditor({
   return (
     <div className="rounded-lg border bg-card">
       <button
+        type="button"
         className="flex items-center gap-1.5 w-full px-3 py-2 text-sm font-medium text-muted-foreground hover:text-foreground"
         onClick={() => setExpanded(!expanded)}
+        aria-expanded={expanded}
+        aria-controls="run-general-notes"
       >
         {expanded ? (
           <ChevronDown className="h-3.5 w-3.5" />
@@ -103,7 +106,7 @@ function RunCommentEditor({
       </button>
 
       {expanded && (
-        <div className="px-3 pb-3 space-y-1.5">
+        <div id="run-general-notes" className="px-3 pb-3 space-y-1.5">
           <Textarea
             value={text}
             onChange={(e) => handleChange(e.target.value)}

--- a/src/components/SendEvaluationDialog.tsx
+++ b/src/components/SendEvaluationDialog.tsx
@@ -159,14 +159,16 @@ export function SendEvaluationDialog({
         <div className="space-y-4 py-2">
           {showTargetPicker && (
             <div className="space-y-1.5">
-              <label className="text-sm font-medium">What to evaluate</label>
+              <label htmlFor="send-eval-target" className="text-sm font-medium">
+                What to evaluate
+              </label>
               <Select
                 value={selectedTarget}
                 onValueChange={(v) => {
                   if (v) setSelectedTarget(v);
                 }}
               >
-                <SelectTrigger className="w-full">
+                <SelectTrigger id="send-eval-target" className="w-full">
                   <SelectValue placeholder="Select a review cycle" />
                 </SelectTrigger>
                 <SelectContent>
@@ -190,7 +192,12 @@ export function SendEvaluationDialog({
           )}
 
           <div className="space-y-1.5">
-            <label className="text-sm font-medium">Email addresses</label>
+            <label
+              htmlFor="send-eval-emails"
+              className="text-sm font-medium"
+            >
+              Email addresses
+            </label>
             <div className="rounded-md border border-input bg-transparent px-3 py-2 min-h-[42px] flex flex-wrap gap-1.5 items-center focus-within:border-ring focus-within:ring-3 focus-within:ring-ring/50">
               {emails.map((email) => (
                 <span
@@ -201,6 +208,7 @@ export function SendEvaluationDialog({
                   <button
                     type="button"
                     onClick={() => removeEmail(email)}
+                    aria-label={`Remove ${email}`}
                     className="text-muted-foreground hover:text-foreground"
                   >
                     <X className="h-3 w-3" />
@@ -208,6 +216,7 @@ export function SendEvaluationDialog({
                 </span>
               ))}
               <Input
+                id="send-eval-emails"
                 type="email"
                 placeholder={
                   emails.length === 0 ? "name@example.com" : "Add another..."
@@ -222,10 +231,14 @@ export function SendEvaluationDialog({
                 onBlur={() => {
                   if (inputValue.trim()) handleAddEmail(inputValue);
                 }}
+                aria-describedby="send-eval-emails-hint"
                 className="flex-1 min-w-[140px] border-0 p-0 h-auto text-sm shadow-none focus-visible:ring-0"
               />
             </div>
-            <p className="text-xs text-muted-foreground">
+            <p
+              id="send-eval-emails-hint"
+              className="text-xs text-muted-foreground"
+            >
               Separate multiple emails with commas or Enter
             </p>
           </div>

--- a/src/components/SideNav.tsx
+++ b/src/components/SideNav.tsx
@@ -11,7 +11,10 @@ interface SideNavProps {
  */
 export function SideNav({ onNewProject }: SideNavProps) {
   return (
-    <nav className="hidden w-56 shrink-0 flex-col gap-1 border-r p-3 md:flex">
+    <nav
+      aria-label="Primary"
+      className="hidden w-56 shrink-0 flex-col gap-1 border-r p-3 md:flex"
+    >
       <SideNavContent onNewProject={onNewProject} />
     </nav>
   );

--- a/src/components/StreamingOutputPanel.tsx
+++ b/src/components/StreamingOutputPanel.tsx
@@ -57,7 +57,12 @@ export function StreamingOutputPanel({
   }));
 
   return (
-    <div className="flex flex-col rounded-lg border bg-card h-full">
+    <div
+      className="flex flex-col rounded-lg border bg-card h-full"
+      role="status"
+      aria-busy={isStreaming}
+      aria-label={`Output ${output.blindLabel} — ${runStatus}`}
+    >
       {/* Header */}
       <div className="flex items-center justify-between px-3 py-2 border-b">
         <div className="flex items-center gap-2">

--- a/src/components/layouts/OrgLayout.tsx
+++ b/src/components/layouts/OrgLayout.tsx
@@ -32,7 +32,12 @@ export function OrgLayout() {
 
   if (result === undefined) {
     return (
-      <div className="flex min-h-screen flex-col">
+      <div
+        className="flex min-h-screen flex-col"
+        role="status"
+        aria-live="polite"
+        aria-label="Loading workspace"
+      >
         <div className="flex h-14 items-center border-b px-4">
           <Skeleton className="h-5 w-32" />
         </div>
@@ -47,6 +52,7 @@ export function OrgLayout() {
             <Skeleton className="h-32 w-full" />
           </div>
         </div>
+        <span className="sr-only">Loading workspace…</span>
       </div>
     );
   }

--- a/src/components/tiptap/AnnotatedEditor.tsx
+++ b/src/components/tiptap/AnnotatedEditor.tsx
@@ -36,6 +36,8 @@ interface AnnotatedEditorProps {
   showAuthor?: boolean;
   canAnnotate?: boolean;
   className?: string;
+  /** Accessible name for the annotatable text. Falls back to a generic label. */
+  ariaLabel?: string;
 }
 
 interface PendingComment {
@@ -53,7 +55,13 @@ export function AnnotatedEditor({
   showAuthor = true,
   canAnnotate = true,
   className,
+  ariaLabel,
 }: AnnotatedEditorProps) {
+  const resolvedAriaLabel =
+    ariaLabel ??
+    (canAnnotate
+      ? "Model output — select text to leave feedback"
+      : "Model output");
   const [commentText, setCommentText] = useState("");
   const [pendingComment, setPendingComment] = useState<PendingComment | null>(
     null,
@@ -89,6 +97,10 @@ export function AnnotatedEditor({
           "prose prose-sm max-w-none focus:outline-none min-h-[200px] px-3 py-2",
           "whitespace-pre-wrap font-mono leading-relaxed text-sm",
         ),
+        role: "textbox",
+        "aria-multiline": "true",
+        "aria-readonly": "true",
+        "aria-label": resolvedAriaLabel,
       },
       handlePaste: () => true,
       handleDrop: () => true,

--- a/src/components/tiptap/PromptEditor.tsx
+++ b/src/components/tiptap/PromptEditor.tsx
@@ -11,6 +11,8 @@ interface PromptEditorProps {
   placeholder?: string;
   validationError?: string;
   className?: string;
+  /** Accessible name for screen readers. Falls back to placeholder, then a generic label. */
+  ariaLabel?: string;
 }
 
 export function PromptEditor({
@@ -20,7 +22,10 @@ export function PromptEditor({
   placeholder,
   validationError,
   className,
+  ariaLabel,
 }: PromptEditorProps) {
+  const resolvedAriaLabel =
+    ariaLabel ?? placeholder ?? "Prompt text editor";
   const editor = useEditor({
     extensions: [
       StarterKit.configure({
@@ -50,6 +55,11 @@ export function PromptEditor({
           readOnly && "opacity-60",
         ),
         "data-placeholder": placeholder ?? "",
+        role: "textbox",
+        "aria-multiline": "true",
+        "aria-label": resolvedAriaLabel,
+        "aria-readonly": readOnly ? "true" : "false",
+        "aria-invalid": validationError ? "true" : "false",
       },
     },
   });

--- a/src/routes/eval/CycleEvalView.tsx
+++ b/src/routes/eval/CycleEvalView.tsx
@@ -195,7 +195,14 @@ export function CycleEvalView() {
       </div>
 
       {/* Progress bar */}
-      <div className="h-1 bg-muted">
+      <div
+        className="h-1 bg-muted"
+        role="progressbar"
+        aria-valuenow={ratedCount}
+        aria-valuemin={0}
+        aria-valuemax={outputCount}
+        aria-label={`${ratedCount} of ${outputCount} outputs rated`}
+      >
         <div
           className="h-full bg-primary transition-all duration-300"
           style={{

--- a/src/routes/orgs/OrgHome.tsx
+++ b/src/routes/orgs/OrgHome.tsx
@@ -25,10 +25,16 @@ export function OrgHome() {
 
       <div className="mt-6">
         {projects === undefined ? (
-          <div className="space-y-2">
+          <div
+            className="space-y-2"
+            role="status"
+            aria-live="polite"
+            aria-label="Loading prompts"
+          >
             {[1, 2, 3, 4, 5].map((i) => (
               <Skeleton key={i} className="h-14 w-full" />
             ))}
+            <span className="sr-only">Loading prompts…</span>
           </div>
         ) : projects.length === 0 ? (
           <EmptyState

--- a/src/routes/orgs/projects/VersionEditor.tsx
+++ b/src/routes/orgs/projects/VersionEditor.tsx
@@ -523,8 +523,11 @@ export function VersionEditor() {
           {/* System message (collapsible) */}
           <div>
             <button
+              type="button"
               className="flex items-center gap-1 text-sm font-medium text-muted-foreground hover:text-foreground"
               onClick={() => setSystemExpanded(!systemExpanded)}
+              aria-expanded={systemExpanded}
+              aria-controls="system-message-panel"
             >
               {systemExpanded ? (
                 <ChevronDown className="h-4 w-4" />
@@ -535,7 +538,10 @@ export function VersionEditor() {
               <span className="text-xs font-normal">(optional)</span>
             </button>
             {systemExpanded && (
-              <div className="mt-2 max-h-[400px] overflow-y-auto">
+              <div
+                id="system-message-panel"
+                className="mt-2 max-h-[400px] overflow-y-auto"
+              >
                 {feedbackMode ? (
                   <AnnotatedEditor
                     content={systemMessage}

--- a/src/routes/share/CycleShareableEvalView.tsx
+++ b/src/routes/share/CycleShareableEvalView.tsx
@@ -125,7 +125,14 @@ export function CycleShareableEvalView() {
 
       {/* Progress */}
       <div className="mt-4 flex items-center gap-3">
-        <div className="flex-1 h-1.5 bg-muted rounded-full overflow-hidden">
+        <div
+          className="flex-1 h-1.5 bg-muted rounded-full overflow-hidden"
+          role="progressbar"
+          aria-valuenow={ratedCount}
+          aria-valuemin={0}
+          aria-valuemax={outputCount}
+          aria-label={`${ratedCount} of ${outputCount} outputs rated`}
+        >
           <div
             className="h-full bg-primary transition-all duration-300"
             style={{


### PR DESCRIPTION
## Summary

Third wave of the UI audit remediation — additive a11y semantics. Zero visual or behavior changes; no logic touched. The prior codebase had **zero** \`aria-current\` sites and only the default ARIA that components shipped with. This pass adds the landmarks, labels, and states screen readers and keyboard users rely on.

## Changes

- **Nav landmarks** — \`SideNav\`, \`MobileNavDrawer\`, and \`ProjectTabs\` wrap their content in \`<nav aria-label="…">\`. \`ProjectTabs\` also sets an explicit \`aria-current="page"\` on active tabs (NavLink's built-in aria-current was being bypassed by the component's custom \`isActive\` logic).
- **Tiptap editors** — \`PromptEditor\` and \`AnnotatedEditor\` now expose \`role="textbox"\`, \`aria-multiline="true"\`, \`aria-readonly\`, \`aria-invalid\`, and a resolved \`aria-label\` (prop → placeholder → generic fallback).
- **Disclosure buttons** — VersionEditor system-message toggle and RunComment general-notes toggle get \`aria-expanded\` + \`aria-controls\` pointing at the revealed panel id.
- **Live regions** — \`StreamingOutputPanel\` is a \`role="status"\` with \`aria-busy={isStreaming}\`; OrgLayout and OrgHome loading skeletons announce as \`role="status" aria-live="polite"\` with an \`sr-only\` "Loading…" line.
- **Progress** — Internal cycle eval and public share-link progress bars both get \`role="progressbar"\` with \`aria-valuenow/min/max\` and a descriptive \`aria-label\`.
- **Forms** — \`SendEvaluationDialog\` labels now properly \`htmlFor\`-linked; per-email remove buttons get individual aria-labels; instruction line is \`aria-describedby\`-linked to the email input.
- **Grouped feedback** — \`FeedbackSheet\` output/system/user groups wrapped in \`<section aria-labelledby>\` with ids on their \`h4\`s.
- **OrgSwitcher** — descriptive \`aria-label\` on the dropdown trigger; decorative chevron marked \`aria-hidden\`.

## Test plan

- [ ] VoiceOver on \`/orgs/:slug\`: "Primary navigation", active prompt announced as current, skeleton states announced as "Loading…"
- [ ] VoiceOver on \`/eval/cycle/<token>\`: progress bar reads "3 of 5 outputs rated", textbox role on output body
- [ ] Keyboard pass: tab through VersionEditor disclosures — expanded state reflected
- [ ] \`rg 'aria-current' src/\` — was 0 matches, now non-zero
- [ ] axe DevTools on \`/orgs/:slug\`, \`/runs/:id\`, \`/eval/cycle/<token>\`: no new critical violations (and several existing ones resolved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)