### PR TITLE
Wave 4: perf + copy (UI audit remediation)

### DIFF
--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -84,7 +84,20 @@ export function CommandPalette() {
     <CommandDialog open={open} onOpenChange={setOpen}>
       <CommandInput placeholder="Search prompts, versions, actions..." />
       <CommandList>
-        <CommandEmpty>No results found.</CommandEmpty>
+        <CommandEmpty>
+          <div className="py-6 text-center text-sm">
+            <p className="text-muted-foreground">
+              No matches in this {projectPath ? "prompt" : "workspace"}.
+            </p>
+            <p className="mt-1 text-xs text-muted-foreground/80">
+              Try a shorter query, or press{" "}
+              <kbd className="rounded border bg-muted px-1 py-0.5 font-mono text-[10px]">
+                Esc
+              </kbd>{" "}
+              to close.
+            </p>
+          </div>
+        </CommandEmpty>
 
         {/* Actions */}
         <CommandGroup heading="Actions">

--- a/src/components/OptimizeConfirmationDialog.tsx
+++ b/src/components/OptimizeConfirmationDialog.tsx
@@ -73,12 +73,13 @@ export function OptimizeConfirmationDialog({
 
         <div className="space-y-3 py-2">
           {/* Input preview */}
-          <div className="rounded-md bg-muted/50 px-3 py-2 text-xs text-muted-foreground space-y-1">
+          <div className="rounded-md bg-muted/50 px-3 py-2 text-xs text-muted-foreground">
             <p>
-              Sending: {feedbackCount.outputFeedbackCount} output feedback{" "}
-              {feedbackCount.outputFeedbackCount === 1 ? "item" : "items"},{" "}
-              {feedbackCount.promptFeedbackCount} prompt feedback{" "}
-              {feedbackCount.promptFeedbackCount === 1 ? "item" : "items"}
+              The optimizer will read{" "}
+              <span className="font-medium text-foreground">
+                {formatFeedbackSummary(feedbackCount)}
+              </span>{" "}
+              from v{versionNumber}.
             </p>
           </div>
 
@@ -113,4 +114,24 @@ export function OptimizeConfirmationDialog({
       </DialogContent>
     </Dialog>
   );
+}
+
+function formatFeedbackSummary(counts: {
+  outputFeedbackCount: number;
+  promptFeedbackCount: number;
+}): string {
+  const parts: string[] = [];
+  if (counts.outputFeedbackCount > 0) {
+    parts.push(
+      `${counts.outputFeedbackCount} note${counts.outputFeedbackCount === 1 ? "" : "s"} on outputs`,
+    );
+  }
+  if (counts.promptFeedbackCount > 0) {
+    parts.push(
+      `${counts.promptFeedbackCount} note${counts.promptFeedbackCount === 1 ? "" : "s"} on the prompt`,
+    );
+  }
+  if (parts.length === 0) return "no feedback yet";
+  if (parts.length === 1) return parts[0]!;
+  return `${parts[0]} and ${parts[1]}`;
 }

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -22,9 +22,12 @@ export function TopBar({ variant = "default" }: TopBarProps) {
             <OrgSwitcher />
           </>
         ) : (
-          <span className="text-sm font-semibold">
+          <Link
+            to="/eval"
+            className="text-sm font-semibold hover:text-primary transition-colors"
+          >
             Blind Bench &mdash; Evaluation
-          </span>
+          </Link>
         )}
       </div>
       <div className="flex items-center gap-2">

--- a/src/components/TrendInsight.tsx
+++ b/src/components/TrendInsight.tsx
@@ -17,11 +17,19 @@ export function TrendInsight({ data }: TrendInsightProps) {
   if (!insight) return null;
 
   return (
-    <p className="text-xs text-muted-foreground italic">{insight}</p>
+    <p className="text-xs text-muted-foreground italic">
+      <span>{insight.fact}</span>{" "}
+      <span className="not-italic">{insight.suggestion}</span>
+    </p>
   );
 }
 
-function computeInsight(data: TrendDataPoint[]): string | null {
+interface Insight {
+  fact: string;
+  suggestion: string;
+}
+
+function computeInsight(data: TrendDataPoint[]): Insight | null {
   // Preference score trend
   const withScores = data.filter((d) => d.preferenceScore !== null);
   if (withScores.length >= 2) {
@@ -29,8 +37,13 @@ function computeInsight(data: TrendDataPoint[]): string | null {
     const last = withScores[withScores.length - 1]!;
     const diff = last.preferenceScore! - first.preferenceScore!;
     if (Math.abs(diff) >= 0.1) {
-      const direction = diff > 0 ? "improved" : "declined";
-      return `Quality ${direction} from v${first.versionNumber} to v${last.versionNumber} (${first.preferenceScore!.toFixed(2)} → ${last.preferenceScore!.toFixed(2)})`;
+      const improved = diff > 0;
+      return {
+        fact: `Quality ${improved ? "improved" : "declined"} from v${first.versionNumber} to v${last.versionNumber} (${first.preferenceScore!.toFixed(2)} → ${last.preferenceScore!.toFixed(2)}).`,
+        suggestion: improved
+          ? `Consider promoting v${last.versionNumber} and running a fresh review cycle.`
+          : `Review what changed between v${first.versionNumber} and v${last.versionNumber}.`,
+      };
     }
   }
 
@@ -40,7 +53,10 @@ function computeInsight(data: TrendDataPoint[]): string | null {
     const last = data[data.length - 1]!;
     if (first.feedbackCount > 0 && last.feedbackCount > first.feedbackCount * 2) {
       const ratio = Math.round(last.feedbackCount / first.feedbackCount);
-      return `Feedback volume increased ${ratio}x from v${first.versionNumber} to v${last.versionNumber}`;
+      return {
+        fact: `Feedback volume increased ${ratio}× from v${first.versionNumber} to v${last.versionNumber}.`,
+        suggestion: `Open v${last.versionNumber}'s dashboard to triage the new comments.`,
+      };
     }
   }
 
@@ -55,13 +71,19 @@ function computeInsight(data: TrendDataPoint[]): string | null {
   }
   const topTag = Object.entries(allTags).sort(([, a], [, b]) => b - a)[0];
   if (topTag && topTag[1] >= 3) {
-    return `Most flagged issue across versions: ${topTag[0]} (${topTag[1]} mentions)`;
+    return {
+      fact: `"${topTag[0]}" is the most flagged issue across versions (${topTag[1]} mentions).`,
+      suggestion: `Target this in the next revision.`,
+    };
   }
 
   // Total feedback summary
   const totalFeedback = data.reduce((sum, d) => sum + d.feedbackCount, 0);
   if (totalFeedback > 0) {
-    return `${totalFeedback} total feedback items across ${data.length} version${data.length !== 1 ? "s" : ""}`;
+    return {
+      fact: `${totalFeedback} total feedback items across ${data.length} version${data.length !== 1 ? "s" : ""}.`,
+      suggestion: `Open a version's dashboard to dig in.`,
+    };
   }
 
   return null;

--- a/src/components/tiptap/AnnotatedEditor.tsx
+++ b/src/components/tiptap/AnnotatedEditor.tsx
@@ -114,7 +114,10 @@ export function AnnotatedEditor({
     }
   }, [content]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Push annotation ranges into the decoration plugin
+  // Push annotation ranges into the decoration plugin.
+  // Ranges change less often than the annotations array reference, so we
+  // dedup via a serialized key to avoid re-dispatching on every parent render.
+  const lastRangesKeyRef = useRef<string>("");
   useEffect(() => {
     if (!editor) return;
     const ranges: AnnotationRange[] = annotations.map((a) => ({
@@ -122,6 +125,11 @@ export function AnnotatedEditor({
       from: a.from,
       to: a.to,
     }));
+    const key = ranges
+      .map((r) => `${r.id ?? ""}:${r.from}-${r.to}`)
+      .join("|");
+    if (key === lastRangesKeyRef.current) return;
+    lastRangesKeyRef.current = key;
     const tr = editor.state.tr.setMeta(annotationPluginKey, ranges);
     editor.view.dispatch(tr);
   }, [editor, annotations]);

--- a/src/routes/eval/CycleEvalView.tsx
+++ b/src/routes/eval/CycleEvalView.tsx
@@ -170,9 +170,12 @@ export function CycleEvalView() {
           >
             <ArrowLeft className="h-4 w-4" />
           </Link>
-          <span className="text-sm font-medium">
-            Evaluation — {data.projectName}
-          </span>
+          <div className="flex flex-col leading-tight">
+            <span className="text-sm font-medium">{data.cycleName}</span>
+            <span className="text-xs text-muted-foreground">
+              {data.projectName}
+            </span>
+          </div>
         </div>
         <div className="flex items-center gap-3">
           <span className="text-xs text-muted-foreground">

--- a/src/routes/eval/EvalInbox.tsx
+++ b/src/routes/eval/EvalInbox.tsx
@@ -36,8 +36,12 @@ export function EvalInbox() {
       <div className="flex flex-1 items-center justify-center p-6">
         <EmptyState
           icon={Inbox}
-          heading="You're all caught up"
-          description="Waiting for new evaluations."
+          heading="No pending evaluations"
+          description="You're caught up — nothing waiting for your review. New evaluations will show up here as teams send them."
+          action={{
+            label: "Back to dashboard",
+            onClick: () => navigate("/"),
+          }}
         />
       </div>
     );

--- a/src/routes/orgs/OrgHome.tsx
+++ b/src/routes/orgs/OrgHome.tsx
@@ -41,6 +41,10 @@ export function OrgHome() {
             icon={FolderOpen}
             heading="No prompts yet"
             description="A prompt holds all its versions, test cases, and run history. Create one to get started."
+            action={{
+              label: "Create prompt",
+              onClick: openNewProjectDialog,
+            }}
           />
         ) : (
           <div className="divide-y rounded-lg border">


### PR DESCRIPTION
## Summary

Fourth of five waves from the UI audit remediation plan. Focus: cut Tiptap perf overhead and clean up copy on empty / no-results / summary surfaces so the app tells the user what to do next.

### Copy clarifications

- **OrgHome empty state** — adds a "Create prompt" action button; aligns with CLAUDE.md "empty states always actionable"
- **EvalInbox empty state** — rewrites "You're all caught up" into actionable "No pending evaluations" with a "Back to dashboard" CTA
- **EvalLayout TopBar title** — `Blind Bench — Evaluation` is now a link back to `/eval`, giving evaluators a breadcrumb-style return path
- **CycleEvalView header** — leads with the cycle name (the context the evaluator actually cares about) and demotes project name to subtitle
- **CommandPalette no-results** — scopes the message to prompt vs workspace context and adds an `Esc` hint
- **TrendInsight** — every insight now has a fact + actionable next step (promote this version, triage new comments, target next revision, etc.) instead of a bare data point
- **OptimizeConfirmationDialog** — the feedback-count preview reads as English: "N notes on outputs and M notes on the prompt" instead of "N output feedback items, M prompt feedback items"

### Perf

- **AnnotatedEditor** — the annotations prop is typically passed inline as `.map(...)` in the parent, which re-references every render. We now dedup via a serialized ranges key stored in a ref so ProseMirror only receives a new transaction when the actual ranges change. Meaningful on cycle-eval pages rendering 3–8 annotated outputs at once.

## Test plan

- [ ] /eval with no cycles → new "Back to dashboard" CTA works
- [ ] /eval/cycle/:token header shows cycle name above project name
- [ ] Click "Blind Bench — Evaluation" from cycle view → returns to /eval
- [ ] Command palette with no match → new contextual copy + Esc hint
- [ ] Open optimize dialog → plain-English feedback-count line
- [ ] VersionDashboard with trend data → two-part insight (fact + suggestion)
- [ ] Annotate an output → highlight still renders, no regressions
- [ ] OrgHome with zero prompts → "Create prompt" CTA opens new-project dialog
- [ ] `npm run build` clean (verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)