### PR TITLE
perf(runs): smooth streaming output via chunk batching and typewriter

### DIFF
--- a/convex/runsActions.ts
+++ b/convex/runsActions.ts
@@ -411,6 +411,26 @@ async function runSingleOutput(params: {
   let finalUsage: StreamUsage | undefined;
   let streamError: unknown;
 
+  // Per-slot chunk batching. OpenRouter emits tokens individually (often
+  // 30-60/sec), and a per-token mutation triples that under 3 parallel slots,
+  // which floods the Convex subscription channel and makes the UI feel chunky.
+  // Buffer up to BATCH_CHARS or BATCH_MS and flush as one mutation. Flushes
+  // are chained via lastFlush so concurrent mutations can't reorder chunks
+  // (appendOutputChunk reads-then-patches outputContent).
+  const BATCH_MS = 80;
+  const BATCH_CHARS = 48;
+  let buffer = "";
+  let lastFlushAt = Date.now();
+  let lastFlush: Promise<unknown> = Promise.resolve();
+
+  const flush = () => {
+    if (buffer.length === 0) return;
+    const pending = buffer;
+    buffer = "";
+    lastFlushAt = Date.now();
+    lastFlush = lastFlush.then(() => appendChunk(outputId, pending));
+  };
+
   try {
     await streamChatCompletion({
       apiKey,
@@ -420,7 +440,10 @@ async function runSingleOutput(params: {
       maxTokens,
       onChunk: async ({ chunk, done, usage }) => {
         if (chunk) {
-          await appendChunk(outputId, chunk);
+          buffer += chunk;
+          if (buffer.length >= BATCH_CHARS || Date.now() - lastFlushAt >= BATCH_MS) {
+            flush();
+          }
         }
         if (done && usage) {
           finalUsage = usage;
@@ -430,6 +453,11 @@ async function runSingleOutput(params: {
   } catch (err) {
     streamError = err;
   }
+
+  // Drain any remaining buffered text before finalize so the completed view
+  // never shows truncated output, even on error.
+  flush();
+  await lastFlush;
 
   // Always finalize so this slot's promise settles. Without this, a thrown
   // stream leaves latencyMs unset and (combined with the run-level promise

--- a/src/components/StreamingOutputPanel.tsx
+++ b/src/components/StreamingOutputPanel.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from "react";
 import { useQuery, useMutation } from "convex/react";
 import { api } from "../../convex/_generated/api";
 import { Doc, Id } from "../../convex/_generated/dataModel";
@@ -5,7 +6,12 @@ import { BlindLabelBadge } from "./BlindLabelBadge";
 import { RunStatusPill } from "./RunStatusPill";
 import { AnnotatedEditor } from "./tiptap/AnnotatedEditor";
 import type { EditorFormat } from "./tiptap/PromptEditor";
+import { useTypewriter } from "@/hooks/useTypewriter";
 import { cn } from "@/lib/utils";
+
+// User must scroll within this many px of the bottom for sticky-follow to engage.
+// Generous enough that small layout shifts don't count as "scrolled up".
+const STICKY_THRESHOLD_PX = 40;
 
 interface StreamingOutputPanelProps {
   output: Doc<"runOutputs">;
@@ -40,6 +46,39 @@ export function StreamingOutputPanel({
   const isStreaming = runStatus === "running";
   const isFailed = runStatus === "failed";
   const isCompleted = runStatus === "completed";
+
+  // Smooth out the backend's 80ms-batched chunks into per-frame character
+  // reveal. When the run ends, snap to the full text so the final byte lands
+  // immediately (no animation tail blocking annotations).
+  const displayed = useTypewriter(output.outputContent ?? "", {
+    active: isStreaming,
+  });
+
+  // Sticky auto-scroll: follow new text while the user is parked near the
+  // bottom; if they scroll up to read earlier text, leave them be until they
+  // return to the bottom on their own.
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const stickyRef = useRef(true);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const onScroll = () => {
+      const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
+      stickyRef.current = distanceFromBottom <= STICKY_THRESHOLD_PX;
+    };
+    el.addEventListener("scroll", onScroll, { passive: true });
+    return () => el.removeEventListener("scroll", onScroll);
+  }, []);
+
+  useEffect(() => {
+    if (!isStreaming) return;
+    const el = scrollRef.current;
+    if (!el) return;
+    if (stickyRef.current) {
+      el.scrollTop = el.scrollHeight;
+    }
+  }, [displayed, isStreaming]);
 
   // Feedback queries/mutations — only active when completed
   const feedback = useQuery(
@@ -126,14 +165,15 @@ export function StreamingOutputPanel({
         </div>
       ) : (
         <div
+          ref={scrollRef}
           className={cn(
             "flex-1 overflow-y-auto p-3 text-sm whitespace-pre-wrap font-mono leading-relaxed min-h-[200px]",
-            !output.outputContent && "text-muted-foreground italic",
+            !displayed && !isStreaming && "text-muted-foreground italic",
           )}
           aria-live="polite"
           data-ph-mask
         >
-          {output.outputContent ||
+          {displayed ||
             (isStreaming
               ? ""
               : isCompleted

--- a/src/hooks/useTypewriter.ts
+++ b/src/hooks/useTypewriter.ts
@@ -1,0 +1,93 @@
+import { useEffect, useRef, useState } from "react";
+
+interface UseTypewriterOptions {
+  /** Reveal rate in chars/sec. Default 120 ~= 7200 wpm visual, feels like fast continuous typing. */
+  charsPerSec?: number;
+  /**
+   * When false, displayed snaps to target immediately. Use this to skip animation
+   * once a run completes so the final byte is on-screen without delay.
+   */
+  active?: boolean;
+  /**
+   * If displayed falls more than this many chars behind target, jump forward
+   * to keep the animation from accumulating multi-second lag (e.g. after a tab
+   * switch or a large single chunk).
+   */
+  maxLagChars?: number;
+}
+
+/**
+ * Smooths visually-jumpy text updates by revealing characters at a fixed rate
+ * via requestAnimationFrame. Designed for LLM streaming where the backend
+ * batches chunks every ~80ms — without smoothing, text appears in visible
+ * bursts; with it, every batch flows in as continuous typing.
+ */
+export function useTypewriter(
+  target: string,
+  { charsPerSec = 120, active = true, maxLagChars = 400 }: UseTypewriterOptions = {},
+): string {
+  const [displayed, setDisplayed] = useState(active ? "" : target);
+  const displayedLenRef = useRef(active ? 0 : target.length);
+  const targetRef = useRef(target);
+  const lastTickRef = useRef<number | null>(null);
+  const rafRef = useRef<number | null>(null);
+
+  targetRef.current = target;
+
+  // If target shrinks below current displayed length (e.g. a new run reset
+  // the output to ""), resync immediately so we don't render stale text.
+  if (target.length < displayedLenRef.current) {
+    displayedLenRef.current = target.length;
+    // Defer setState — we may be in render path. useEffect below will catch up.
+  }
+
+  useEffect(() => {
+    if (!active) {
+      // Snap to full when inactive (e.g., run completed).
+      if (rafRef.current !== null) {
+        cancelAnimationFrame(rafRef.current);
+        rafRef.current = null;
+      }
+      displayedLenRef.current = targetRef.current.length;
+      setDisplayed(targetRef.current);
+      lastTickRef.current = null;
+      return;
+    }
+
+    const tick = (now: number) => {
+      const last = lastTickRef.current ?? now;
+      const dt = now - last;
+      lastTickRef.current = now;
+
+      const t = targetRef.current;
+      let len = displayedLenRef.current;
+
+      if (len < t.length) {
+        const advance = Math.max(1, Math.round((dt / 1000) * charsPerSec));
+        len = Math.min(t.length, len + advance);
+
+        // Jump-forward guard: if we're way behind, keep within maxLagChars of
+        // the target so we don't accumulate seconds of visual lag.
+        if (t.length - len > maxLagChars) {
+          len = t.length - Math.floor(maxLagChars / 2);
+        }
+
+        displayedLenRef.current = len;
+        setDisplayed(t.slice(0, len));
+      }
+
+      rafRef.current = requestAnimationFrame(tick);
+    };
+
+    rafRef.current = requestAnimationFrame(tick);
+    return () => {
+      if (rafRef.current !== null) {
+        cancelAnimationFrame(rafRef.current);
+        rafRef.current = null;
+      }
+      lastTickRef.current = null;
+    };
+  }, [active, charsPerSec, maxLagChars]);
+
+  return displayed;
+}


### PR DESCRIPTION
## Summary

Streaming responses felt laggy/chunky because every OpenRouter token triggered a separate `appendOutputChunk` Convex mutation — at ~30–60 tokens/sec × 3 parallel slots, that flooded the subscription channel and pushed re-renders faster than the browser could absorb cleanly.

Three layers of smoothing:

- **Backend chunk batching** (`convex/runsActions.ts`): buffer tokens per slot, flush at 80ms or 48 chars (whichever first). Flushes are chained via `lastFlush` so concurrent patches can't reorder `outputContent` (it's read-then-patch). Final drain on done/error before `finalize` so completed output is never truncated.
- **Typewriter reveal** (`src/hooks/useTypewriter.ts`): new hook reveals buffered text at 120 chars/sec via `requestAnimationFrame`. Snaps to full when `active=false` so the final byte lands immediately on completion. Jump-forward guard caps lag at 400 chars (handles tab-switch and large single chunks without accumulating multi-second visual lag).
- **Sticky auto-scroll** (`src/components/StreamingOutputPanel.tsx`): the streaming container follows new text while the user is within 40px of the bottom; pauses if they scroll up to read; resumes when they return.

Net effect: mutation rate drops roughly 5× on the wire, and the remaining 80ms gaps look like continuous typing instead of visible bursts. No schema changes, no changes to the OpenRouter client, no changes to `AnnotatedEditor` (only mounts post-completion).

## Test plan

- [ ] Run a 3-slot prompt with a long-output model (e.g., a paragraph-length completion). Confirm text reveals smoothly, no visible burst-then-pause cadence.
- [ ] During streaming, scroll up in one of the output panels — verify auto-scroll pauses and you can read earlier text uninterrupted.
- [ ] Scroll back to bottom — verify auto-scroll resumes.
- [ ] Let the run complete — verify the cursor disappears, full text is on screen with no missing trailing chars, annotations work normally.
- [ ] Run completes after an error mid-stream — verify partial output is preserved (not truncated by an unflushed buffer) and the run transitions to failed.
- [ ] Switch browser tabs during a long stream, return — confirm the typewriter catches up rather than spending seconds replaying buffered text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)