### PR TITLE
fix(landing): stabilize hero rotator + mobile journey progress bar

### DIFF
--- a/landing/src/components/Hero.astro
+++ b/landing/src/components/Hero.astro
@@ -55,6 +55,10 @@ const APP_URL = 'https://app.blindbench.dev';
       >
         Get feedback from{' '}
         <span class="hero-rotator" data-hero-rotator>
+          <!-- Invisible sizer reserves width of the longest persona so the
+               H1's line 1 never re-wraps as words rotate. Keep in sync with
+               the ROLES array below. -->
+          <span class="hero-rotator-sizer" aria-hidden="true">customers</span>
           <span
             class="hero-rotator-clip"
             data-hero-rotator-active
@@ -130,6 +134,7 @@ const APP_URL = 'https://app.blindbench.dev';
      end of line 1, so the rotator's width changes don't push any sibling
      text around. */
   .hero-rotator {
+    position: relative;
     display: inline-block;
     vertical-align: baseline;
     color: #ddd6fe;
@@ -141,7 +146,20 @@ const APP_URL = 'https://app.blindbench.dev';
     text-decoration-color: rgba(221, 214, 254, 0.55);
   }
 
+  /* Reserves layout width = longest persona word. Invisible but in-flow so
+     the parent (and its underline) stays sized to the widest case. */
+  .hero-rotator-sizer {
+    display: inline-block;
+    visibility: hidden;
+    white-space: nowrap;
+    pointer-events: none;
+  }
+
+  /* Animated chars overlay the sizer; absolute positioning keeps them out
+     of normal flow so they don't double the rotator's width. */
   .hero-rotator-clip {
+    position: absolute;
+    inset: 0;
     display: inline-flex;
     overflow: hidden;
     white-space: nowrap;

--- a/landing/src/components/journey/Journey.astro
+++ b/landing/src/components/journey/Journey.astro
@@ -48,12 +48,50 @@ const steps = [
     </div>
   </div>
 
+  <!-- Mobile-only sticky progress pill. The full diagram is hidden on
+       mobile (it would consume ~360px above the fold without ever being
+       visible while the steps scroll past). This compact bar reuses the
+       same data-active-step tracking so the active step still updates
+       visually as the user scrolls. -->
+  <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:hidden">
+    <div
+      class="journey-mobile-progress sticky top-14 z-40 mt-10 -mx-4 border-y border-border/70 bg-background/85 px-4 py-2.5 backdrop-blur-md sm:-mx-6 sm:px-6"
+      data-journey-progress
+      data-active-step="0"
+      aria-hidden="true"
+    >
+      <ol class="flex items-center gap-2">
+        {
+          steps.map((s, i) => (
+            <>
+              <li
+                class="journey-progress-item flex flex-1 items-center justify-center gap-2 rounded-md px-2 py-1.5"
+                data-progress-item={i}
+              >
+                <span class="journey-progress-dot inline-flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-full border border-border bg-card font-mono text-[10px] font-semibold text-muted-foreground transition-[color,border-color,background-color,box-shadow] duration-300">
+                  {i + 1}
+                </span>
+                <span class="journey-progress-label truncate text-[11px] font-medium uppercase tracking-[0.14em] text-muted-foreground transition-colors duration-300">
+                  {s.eyebrow}
+                </span>
+              </li>
+              {i < steps.length - 1 && (
+                <li class="h-px w-2 flex-shrink-0 bg-border/60" aria-hidden="true" />
+              )}
+            </>
+          ))
+        }
+      </ol>
+    </div>
+  </div>
+
   <!-- Sticky split: diagram (left) + step blocks (right) — wider container -->
   <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-    <div class="journey-scroller mt-14 lg:mt-20">
+    <div class="journey-scroller mt-8 lg:mt-20">
       <div class="grid grid-cols-1 gap-12 lg:grid-cols-[420px_minmax(0,1fr)] lg:gap-10 xl:gap-16">
-        <!-- Left: sticky diagram (desktop) / inline (mobile) -->
-        <div class="journey-sticky-col">
+        <!-- Left: sticky diagram (desktop only — mobile uses the compact
+             progress pill above) -->
+        <div class="journey-sticky-col hidden lg:block">
           <div class="journey-sticky-inner lg:sticky lg:top-24 lg:flex lg:h-[calc(100vh-7rem)] lg:items-center">
             <JourneyDiagram default={0} />
           </div>
@@ -98,13 +136,6 @@ const steps = [
 </section>
 
 <style>
-  /* Mobile (no sticky): center the diagram naturally above the first step. */
-  @media (max-width: 1023.98px) {
-    .journey-sticky-inner {
-      padding-bottom: 1.5rem;
-    }
-  }
-
   /* On desktop, give each step block enough vertical room so the sticky
      diagram has scroll distance to dwell on each. The min-height of the
      last block is reduced so the section ends near the bottom of its panel
@@ -120,6 +151,30 @@ const steps = [
       min-height: 0;
     }
   }
+
+  /* Mobile progress pill — active item picks up the primary color when the
+     parent's data-active-step matches. Mirrors the diagram highlight. */
+  .journey-mobile-progress[data-active-step='0'] .journey-progress-item[data-progress-item='0'] .journey-progress-dot,
+  .journey-mobile-progress[data-active-step='1'] .journey-progress-item[data-progress-item='1'] .journey-progress-dot,
+  .journey-mobile-progress[data-active-step='2'] .journey-progress-item[data-progress-item='2'] .journey-progress-dot {
+    color: var(--primary);
+    border-color: color-mix(in oklch, var(--primary) 60%, transparent);
+    background-color: color-mix(in oklch, var(--primary) 14%, transparent);
+    box-shadow: 0 0 0 3px color-mix(in oklch, var(--primary) 10%, transparent);
+  }
+
+  .journey-mobile-progress[data-active-step='0'] .journey-progress-item[data-progress-item='0'] .journey-progress-label,
+  .journey-mobile-progress[data-active-step='1'] .journey-progress-item[data-progress-item='1'] .journey-progress-label,
+  .journey-mobile-progress[data-active-step='2'] .journey-progress-item[data-progress-item='2'] .journey-progress-label {
+    color: var(--primary);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .journey-progress-dot,
+    .journey-progress-label {
+      transition: none;
+    }
+  }
 </style>
 
 <script>
@@ -128,17 +183,23 @@ const steps = [
   const section = document.getElementById('how-it-works');
   if (section) {
     const diagram = section.querySelector<DiagramEl>('[data-journey-diagram]');
+    const progress = section.querySelector<HTMLElement>('[data-journey-progress]');
     const stepEls = Array.from(
       section.querySelectorAll<HTMLElement>('[data-journey-step]'),
     );
 
-    if (diagram && stepEls.length) {
-      let active = Number(diagram.dataset.activeStep || '0');
+    // Either the desktop diagram OR the mobile progress bar is enough to
+    // run the tracker — both share the same data-active-step contract.
+    if ((diagram || progress) && stepEls.length) {
+      let active = Number(
+        diagram?.dataset.activeStep || progress?.dataset.activeStep || '0',
+      );
 
       const setActive = (i: number) => {
         if (i === active) return;
         active = i;
-        diagram.dataset.activeStep = String(i);
+        if (diagram) diagram.dataset.activeStep = String(i);
+        if (progress) progress.dataset.activeStep = String(i);
       };
 
       // Pick the step whose center is closest to the viewport's vertical center.


### PR DESCRIPTION
## Summary
- **Hero rotator no longer shifts page height on mobile.** Reserved the rotator's slot width with an invisible sizer span (`customers`, the longest persona). The animated clip is absolutely positioned over it, so line 1 of the H1 never re-wraps as `PMs` → `marketing` → `customers` → … cycle through.
- **Journey scroll animation now works on mobile.** The desktop sticky diagram was rendering full-square above the steps on mobile and then scrolling off — the active-step updates were happening but never visible. Hid the diagram on mobile and added a sticky compact 3-node progress pill below the nav. It shares the same `data-active-step` contract, so the existing scroll tracker drives both desktop diagram and mobile pill.

## Test plan
- [ ] On mobile width (~375px), scroll the landing hero — the H1's first line stays a constant length as the persona rotates (no second-line bounce).
- [ ] On mobile width, scroll through the "How it works" section — the sticky pill below the nav highlights node 1 → 2 → 3 in sync with the step blocks.
- [ ] On desktop (≥1024px), the existing sticky diagram still animates as before; the mobile pill is hidden.
- [ ] `prefers-reduced-motion`: no transitions on the pill, hero rotator still pinned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)