### PR TITLE
feat(review): no-account guest review via anonymous auth (M30)

### DIFF
--- a/convex/admin.ts
+++ b/convex/admin.ts
@@ -74,7 +74,6 @@ const APP_TABLES: TableNames[] = [
   "cycleFeedback",
   "reviewSessions",
   "reviewMatchups",
-  "guestIdentities",
   "invitations",
   "traceImports",
 ];

--- a/convex/anonCleanup.ts
+++ b/convex/anonCleanup.ts
@@ -1,0 +1,79 @@
+import { internalMutation } from "./_generated/server";
+import type { MutationCtx } from "./_generated/server";
+import type { Id } from "./_generated/dataModel";
+
+const ORPHAN_TTL_MS = 24 * 60 * 60 * 1000;
+const BATCH_SIZE = 200;
+
+/**
+ * M30: reap orphan guest accounts. `signIn("anonymous")` is reachable from the
+ * public invite page, so a bot — or a user who bails before accepting — can
+ * mint empty anonymous users. An anon user that never accepted a reviewer
+ * invite has no projectCollaborators row: it is inert (can see and do nothing)
+ * and safe to delete. We keep any anon user that became an evaluator so their
+ * in-flight review session and ratings survive.
+ *
+ * Deleting a Convex Auth user means cascading its auth rows by hand
+ * (authSessions → authRefreshTokens, authAccounts → authVerificationCodes);
+ * the library exposes no destroy helper.
+ */
+export const cleanupAnonUsers = internalMutation({
+  args: {},
+  handler: async (ctx) => {
+    const cutoff = Date.now() - ORPHAN_TTL_MS;
+    // Oldest-first: once we reach a user newer than the cutoff, the rest are
+    // newer too, so we can stop.
+    const candidates = await ctx.db
+      .query("users")
+      .withIndex("by_anonymous", (q) => q.eq("isAnonymous", true))
+      .order("asc")
+      .take(BATCH_SIZE);
+
+    let deleted = 0;
+    for (const user of candidates) {
+      if (user._creationTime >= cutoff) break;
+      const collaborator = await ctx.db
+        .query("projectCollaborators")
+        .withIndex("by_user", (q) => q.eq("userId", user._id))
+        .first();
+      if (collaborator) continue; // active reviewer — keep
+
+      await deleteAuthUser(ctx, user._id);
+      deleted++;
+    }
+    return { scanned: candidates.length, deleted };
+  },
+});
+
+async function deleteAuthUser(
+  ctx: MutationCtx,
+  userId: Id<"users">,
+): Promise<void> {
+  const sessions = await ctx.db
+    .query("authSessions")
+    .withIndex("userId", (q) => q.eq("userId", userId))
+    .collect();
+  for (const session of sessions) {
+    const tokens = await ctx.db
+      .query("authRefreshTokens")
+      .withIndex("sessionId", (q) => q.eq("sessionId", session._id))
+      .collect();
+    for (const token of tokens) await ctx.db.delete(token._id);
+    await ctx.db.delete(session._id);
+  }
+
+  const accounts = await ctx.db
+    .query("authAccounts")
+    .withIndex("userIdAndProvider", (q) => q.eq("userId", userId))
+    .collect();
+  for (const account of accounts) {
+    const codes = await ctx.db
+      .query("authVerificationCodes")
+      .withIndex("accountId", (q) => q.eq("accountId", account._id))
+      .collect();
+    for (const code of codes) await ctx.db.delete(code._id);
+    await ctx.db.delete(account._id);
+  }
+
+  await ctx.db.delete(userId);
+}

--- a/convex/auth.ts
+++ b/convex/auth.ts
@@ -2,10 +2,19 @@ import Google from "@auth/core/providers/google";
 import { Resend } from "resend";
 import { convexAuth } from "@convex-dev/auth/server";
 import { Email } from "@convex-dev/auth/providers/Email";
+import { Anonymous } from "@convex-dev/auth/providers/Anonymous";
 
 export const { auth, signIn, signOut, store } = convexAuth({
   providers: [
     Google,
+    // M30: no-account guest reviewers. `signIn("anonymous")` mints a powerless
+    // user (isAnonymous: true) with NO memberships — it can see and do nothing
+    // on its own. Authorization comes solely from the invite-validated
+    // evaluator row written by `invitations.acceptInviteAsGuest`, which is the
+    // real gate. So enabling this provider does not widen access; a bare anon
+    // account is inert until it accepts a reviewer invite. Orphan anon accounts
+    // (signed in, never accepted) are reaped by the cleanupAnonUsers cron.
+    Anonymous,
     Email({
       id: "resend",
       authorize: undefined,

--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -1,0 +1,14 @@
+import { cronJobs } from "convex/server";
+import { internal } from "./_generated/api";
+
+const crons = cronJobs();
+
+// M30: sweep orphan guest accounts (signed in anonymously, never accepted a
+// reviewer invite). See convex/anonCleanup.ts for the cascade + retention rule.
+crons.daily(
+  "cleanup orphan guest accounts",
+  { hourUTC: 8, minuteUTC: 0 },
+  internal.anonCleanup.cleanupAnonUsers,
+);
+
+export default crons;

--- a/convex/invitations.ts
+++ b/convex/invitations.ts
@@ -13,8 +13,12 @@
  *      a single project as `owner` / `editor` / `evaluator`. Independent
  *      of org membership: a project collaborator does *not* implicitly
  *      gain org-level read access.
- *   3. **Guest** (`guestIdentities`) — unauthenticated cycle reviewer
- *      identified by verified email. Separate principal type entirely.
+ *
+ * M30: there is no separate guest principal. A "guest" reviewer is an
+ * anonymous Convex Auth user (`isAnonymous: true`) that accepts a reviewer
+ * invite and is written into ring 2 as an `evaluator`. See
+ * `acceptInviteAsGuest` — the entire review pipeline then treats it like any
+ * other evaluator collaborator.
  *
  * # One-row-per-scope rule
  *
@@ -39,8 +43,9 @@
  * the seed-signal decoupling and commit `6e01dd7` for the cycle-invite
  * fix that motivated the rule.
  *
- * Guest principals may ONLY accept scope=cycle with role=cycle_reviewer.
- * Org/project invites require real auth.
+ * Anonymous guests may ONLY accept reviewer-role invites (`cycle_reviewer`,
+ * `project_evaluator`) — both resolve to an `evaluator` row. Owner/editor and
+ * all org invites require a real account.
  */
 
 import { v } from "convex/values";
@@ -556,33 +561,58 @@ export const acceptWithAuth = mutation({
 });
 
 /**
- * Guest accept (unauthenticated). Only allowed for scope=cycle,
- * role=cycle_reviewer. Creates/reuses a guestIdentities row keyed on the
- * invite email.
+ * M30: No-account guest accept. The caller is an *anonymous* Convex Auth user
+ * (minted client-side via `signIn("anonymous")` right before this call), so
+ * `getAuthUserId` resolves to a real `users` row and the entire review
+ * pipeline — `requireProjectRole`, `isBlindReviewer`, session/rating tables —
+ * works unchanged. The guest simply becomes an `evaluator` collaborator.
  *
- * For shareable invites the caller must provide `email` (public link,
- * self-attested). For targeted invites the email is pre-bound.
+ * Privilege gate: anonymous users may ONLY accept reviewer-role invites
+ * (`cycle_reviewer`, `project_evaluator`). Both resolve to an `evaluator`
+ * projectCollaborators row — never owner/editor/org access — so a guest can
+ * never escalate by presenting an org/project-owner token. Real signed-in
+ * users must use `acceptWithAuth` (which handles every scope).
+ *
+ * `displayName`/`email` are self-reported attribution stored on the anon user
+ * row so the cycle owner can tell guests apart. They are NOT auth credentials
+ * and are never verified.
  */
-export const acceptAsGuest = mutation({
+export const acceptInviteAsGuest = mutation({
   args: {
     token: v.string(),
-    // Required only for shareable invites; ignored otherwise.
-    email: v.optional(v.string()),
     displayName: v.optional(v.string()),
+    email: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx);
+    const user = await ctx.db.get(userId);
+    if (!user) throw new Error("Not authenticated");
+    // Real accounts carry richer identity and route through acceptWithAuth.
+    // Keeping guests on the anonymous path stops a signed-in user from
+    // accidentally laundering an owner invite down to evaluator access.
+    if (!user.isAnonymous) {
+      throw new Error("Signed-in users should accept with their account");
+    }
+
     const invite = await ctx.db
       .query("invitations")
       .withIndex("by_token", (q) => q.eq("token", args.token))
       .unique();
     if (!invite) throw new Error("Invitation not found");
-    if (invite.scope !== "cycle" || invite.role !== "cycle_reviewer") {
-      throw new Error("Guest acceptance is only allowed for cycle reviewers");
+
+    // The privilege gate — see the function-level comment.
+    if (
+      invite.role !== "cycle_reviewer" &&
+      invite.role !== "project_evaluator"
+    ) {
+      throw new Error("This invitation requires an account");
     }
+
     if (invite.status === "revoked") throw new Error("Invitation was revoked");
     if (invite.expiresAt < Date.now())
       throw new Error("This invitation has expired");
-
+    if (!invite.shareable && invite.status === "accepted")
+      throw new Error("Invitation was already accepted");
     if (
       invite.shareable &&
       invite.maxAccepts !== undefined &&
@@ -591,35 +621,25 @@ export const acceptAsGuest = mutation({
       throw new Error("This invitation has reached its response limit");
     }
 
-    const email = normalizeEmail(
-      invite.shareable ? args.email ?? "" : invite.email,
-    );
-    if (!email) throw new Error("Email is required");
+    // Self-reported attribution. Only fill blanks — never overwrite values the
+    // user already has (an anon user could accept a second invite).
+    const patch: { name?: string; email?: string } = {};
+    const trimmedName = args.displayName?.trim();
+    if (trimmedName && !user.name) patch.name = trimmedName.slice(0, 80);
+    const normalizedEmail = args.email ? normalizeEmail(args.email) : "";
+    if (normalizedEmail && !user.email) patch.email = normalizedEmail;
+    if (Object.keys(patch).length > 0) await ctx.db.patch(userId, patch);
 
-    // Find-or-create the guest identity.
-    const existingGuest = await ctx.db
-      .query("guestIdentities")
-      .withIndex("by_email", (q) => q.eq("email", email))
-      .unique();
-
-    let guestId: Id<"guestIdentities">;
-    const now = Date.now();
-    if (existingGuest) {
-      guestId = existingGuest._id;
-      if (args.displayName && !existingGuest.displayName) {
-        await ctx.db.patch(guestId, { displayName: args.displayName });
-      }
+    // Both reviewer roles land as an `evaluator` collaborator via the same
+    // per-scope acceptors used by acceptWithAuth — one membership row, blind
+    // semantics carried from the invite.
+    if (invite.scope === "cycle") {
+      await acceptCycleInvite(ctx, invite, userId);
     } else {
-      guestId = await ctx.db.insert("guestIdentities", {
-        email,
-        verifiedAt: now,
-        displayName: args.displayName,
-      });
+      await acceptProjectInvite(ctx, invite, userId);
     }
 
-    // Write the cycleEvaluator row as a guest marker? No — cycleEvaluators is
-    // userId-keyed. M25.5 will repoint evaluator tracking through invitations.
-    // For now we just mark the invite accepted.
+    const now = Date.now();
     if (invite.shareable) {
       await ctx.db.patch(invite._id, {
         acceptCount: invite.acceptCount + 1,
@@ -628,7 +648,7 @@ export const acceptAsGuest = mutation({
       await ctx.db.patch(invite._id, {
         status: "accepted",
         acceptedAt: now,
-        acceptedByGuestId: guestId,
+        acceptedByUserId: userId,
         acceptCount: invite.acceptCount + 1,
       });
     }
@@ -637,7 +657,7 @@ export const acceptAsGuest = mutation({
       scope: invite.scope,
       scopeId: invite.scopeId,
       role: invite.role,
-      guestIdentityId: guestId,
+      blindMode: invite.blindMode ?? true,
     };
   },
 });

--- a/convex/lib/auth.ts
+++ b/convex/lib/auth.ts
@@ -16,41 +16,6 @@ export async function requireAuth(
   return userId;
 }
 
-/**
- * M25: Unified principal type. A principal is either a signed-in user or a
- * verified guest (email-only identity) that accepted a cycle invite. Review
- * session endpoints that can serve guests use `resolvePrincipal` — everything
- * else stays on `requireAuth`.
- */
-export type Principal =
-  | { kind: "user"; userId: Id<"users">; email: string | null }
-  | { kind: "guest"; guestId: Id<"guestIdentities">; email: string };
-
-/**
- * Resolve the current caller to a Principal. Passing a `guestToken` falls
- * back to guest resolution when there is no signed-in user — guest tokens
- * are minted at guest-invite acceptance time and stored client-side.
- *
- * Throws if neither auth nor a valid guest token is present.
- */
-export async function resolvePrincipal(
-  ctx: QueryCtx,
-  guestIdentityId?: Id<"guestIdentities">,
-): Promise<Principal> {
-  const userId = await getAuthUserId(ctx);
-  if (userId !== null) {
-    const user = await ctx.db.get(userId);
-    return { kind: "user", userId, email: user?.email ?? null };
-  }
-  if (guestIdentityId) {
-    const guest = await ctx.db.get(guestIdentityId);
-    if (guest) {
-      return { kind: "guest", guestId: guestIdentityId, email: guest.email };
-    }
-  }
-  throw new Error("Not authenticated");
-}
-
 type OrgRole = Doc<"organizationMembers">["role"];
 
 /**

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -20,7 +20,9 @@ const schema = defineSchema({
     firstActivationAt: v.optional(v.number()),
   })
     .index("email", ["email"])
-    .index("phone", ["phone"]),
+    .index("phone", ["phone"])
+    // M30: lets the cleanupAnonUsers cron sweep guest accounts cheaply.
+    .index("by_anonymous", ["isAnonymous"]),
 
   // M1: Organizations & Projects
   organizations: defineTable({
@@ -266,9 +268,6 @@ const schema = defineSchema({
     targetKind: v.optional(
       v.union(v.literal("inline"), v.literal("overall")),
     ),
-    // M25: when set, the author is a verified guest (no user account).
-    // Mutually exclusive with userId in practice; enforced in code.
-    guestIdentityId: v.optional(v.id("guestIdentities")),
     // M27.4: conventional-comments-style label. Optional for legacy rows;
     // new annotations always set it (default "thought") at write time.
     label: v.optional(
@@ -374,8 +373,6 @@ const schema = defineSchema({
     // so session resume can find prior ratings by this user. Absent on legacy
     // rows from before M19.
     reviewSessionId: v.optional(v.id("reviewSessions")),
-    // M25: guest principal attribution (see outputFeedback.guestIdentityId).
-    guestIdentityId: v.optional(v.id("guestIdentities")),
   })
     .index("by_run_user", ["runId", "userId"])
     .index("by_output", ["outputId"])
@@ -759,8 +756,6 @@ const schema = defineSchema({
     sessionId: v.optional(v.string()),
     // M19: links back to the review session that produced this rating.
     reviewSessionId: v.optional(v.id("reviewSessions")),
-    // M25: guest principal attribution (see outputFeedback.guestIdentityId).
-    guestIdentityId: v.optional(v.id("guestIdentities")),
   })
     .index("by_cycle", ["cycleId"])
     .index("by_cycle_user", ["cycleId", "userId"])
@@ -808,8 +803,6 @@ const schema = defineSchema({
     targetKind: v.optional(
       v.union(v.literal("inline"), v.literal("overall")),
     ),
-    // M25: guest principal attribution (see outputFeedback.guestIdentityId).
-    guestIdentityId: v.optional(v.id("guestIdentities")),
     // M27.4: conventional-comments-style label (see outputFeedback.label).
     label: v.optional(
       v.union(
@@ -839,11 +832,10 @@ const schema = defineSchema({
     // Exactly one of runId / cycleId is set (enforced in code).
     runId: v.optional(v.id("promptRuns")),
     cycleId: v.optional(v.id("reviewCycles")),
-    // M25: exactly one of {userId, guestIdentityId} is set. userId was
-    // required pre-M25 and remains the common case; guestIdentityId is set
-    // only when an unauthenticated guest accepts a cycle invite.
-    userId: v.optional(v.id("users")),
-    guestIdentityId: v.optional(v.id("guestIdentities")),
+    // The reviewer who owns this session. M30: guests are anonymous Convex
+    // Auth users (isAnonymous: true), so this is always a real users row —
+    // there is no separate guest principal.
+    userId: v.id("users"),
     // Reviewer's capacity for this session. "author" is the run/cycle creator;
     // "collaborator" is another project member; "evaluator" is an invited
     // blind reviewer routed via cycleEvaluators.
@@ -879,7 +871,6 @@ const schema = defineSchema({
   })
     .index("by_project_user", ["projectId", "userId"])
     .index("by_user_status", ["userId", "phase"])
-    .index("by_guest_status", ["guestIdentityId", "phase"])
     .index("by_run", ["runId"])
     .index("by_cycle", ["cycleId"]),
 
@@ -925,30 +916,12 @@ const schema = defineSchema({
     .index("by_session_round", ["sessionId", "round"]),
 
   // =========================================================================
-  // M25: Unified Invites & Guest Identities
+  // M25: Unified Invites (M30: guests are anonymous users, not a separate
+  // principal — see invitations.acceptInviteAsGuest)
   // =========================================================================
 
-  // A verified email identity for users who haven't created an account yet.
-  // Created lazily on first click of an invite link. If the guest later signs
-  // up with the same email, `promotedToUserId` is set and queries that fan
-  // out across both principals can follow the pointer.
-  //
-  // Attribution guarantees: every cyclePreferences / cycleFeedback /
-  // outputPreferences / outputFeedback row authored by a guest carries
-  // guestIdentityId, so cycle owners can see "3 reviewers (2 users + 1 guest:
-  // jane@example.com)" without exposing version identity.
-  guestIdentities: defineTable({
-    email: v.string(),
-    verifiedAt: v.number(),
-    displayName: v.optional(v.string()),
-    promotedToUserId: v.optional(v.id("users")),
-    promotedAt: v.optional(v.number()),
-  })
-    .index("by_email", ["email"])
-    .index("by_promoted_user", ["promotedToUserId"]),
-
   // Unified invitation table. `shareable: true` means a single token many
-  // guests can redeem. Targeted email invites have shareable=false and a
+  // people can redeem. Targeted email invites have shareable=false and a
   // single recipient email.
   invitations: defineTable({
     scope: v.union(
@@ -972,8 +945,10 @@ const schema = defineSchema({
       // project roles
       v.literal("project_owner"),
       v.literal("project_editor"),
+      // M30: project_evaluator + cycle_reviewer are the reviewer roles an
+      // anonymous guest may accept (both resolve to an evaluator row).
       v.literal("project_evaluator"),
-      // cycle roles (guests can only accept this)
+      // cycle roles
       v.literal("cycle_reviewer"),
     ),
 
@@ -998,12 +973,12 @@ const schema = defineSchema({
     invitedAt: v.number(),
     expiresAt: v.number(),
 
-    // Set when accepted. Exactly one of acceptedByUserId / acceptedByGuestId
-    // for shareable=false. For shareable=true, these are left empty on the
-    // root invite and acceptance is tracked via acceptCount + child
-    // guestIdentities / user membership rows.
+    // Set when a targeted (shareable=false) invite is accepted. M30: guests
+    // are anonymous users, so acceptance is always recorded against a real
+    // users row. For shareable=true this is left empty on the root invite and
+    // acceptance is tracked via acceptCount + the membership rows written on
+    // accept.
     acceptedByUserId: v.optional(v.id("users")),
-    acceptedByGuestId: v.optional(v.id("guestIdentities")),
     acceptedAt: v.optional(v.number()),
 
     acceptCount: v.number(),

--- a/convex/tests/guestReview.test.ts
+++ b/convex/tests/guestReview.test.ts
@@ -1,0 +1,320 @@
+/**
+ * M30: No-account guest review.
+ *
+ * Verifies the anonymous-guest accept gate and that an anonymous guest, once
+ * accepted, is a normal blind evaluator the review pipeline accepts unchanged.
+ * Blind-filter guarantees themselves are covered by evalSecurity.test.ts —
+ * a guest is just an evaluator collaborator, so those guarantees transfer.
+ */
+
+import { convexTest } from "convex-test";
+import { expect, test, describe } from "vitest";
+import { api } from "../_generated/api";
+import schema from "../schema";
+import type { Id } from "../_generated/dataModel";
+
+async function seedGuestEnv() {
+  const t = convexTest(schema);
+
+  const ids = await t.run(async (ctx) => {
+    const ownerUserId = await ctx.db.insert("users", {
+      name: "Owner",
+      email: "owner@test.com",
+    });
+    const orgId = await ctx.db.insert("organizations", {
+      name: "Org",
+      slug: "org",
+      createdById: ownerUserId,
+    });
+    const projectId = await ctx.db.insert("projects", {
+      organizationId: orgId,
+      name: "Project",
+      createdById: ownerUserId,
+    });
+    await ctx.db.insert("projectCollaborators", {
+      projectId,
+      userId: ownerUserId,
+      role: "owner",
+      invitedById: ownerUserId,
+      invitedAt: Date.now(),
+    });
+    const versionId = await ctx.db.insert("promptVersions", {
+      projectId,
+      versionNumber: 1,
+      userMessageTemplate: "Hi {{name}}",
+      status: "current",
+      createdById: ownerUserId,
+    });
+    const testCaseId = await ctx.db.insert("testCases", {
+      projectId,
+      name: "TC1",
+      variableValues: { name: "World" },
+      attachmentIds: [],
+      order: 0,
+      createdById: ownerUserId,
+    });
+    const runId = await ctx.db.insert("promptRuns", {
+      projectId,
+      promptVersionId: versionId,
+      testCaseId,
+      model: "openai/gpt-4",
+      temperature: 0.7,
+      status: "completed",
+      completedAt: Date.now(),
+      triggeredById: ownerUserId,
+    });
+    const runOutputId = await ctx.db.insert("runOutputs", {
+      runId,
+      blindLabel: "A",
+      outputContent: "content A",
+      promptTokens: 10,
+      completionTokens: 5,
+      totalTokens: 15,
+      latencyMs: 100,
+    });
+    const cycleId = await ctx.db.insert("reviewCycles", {
+      projectId,
+      primaryVersionId: versionId,
+      name: "Cycle",
+      status: "open",
+      includeSoloEval: false,
+      createdById: ownerUserId,
+      openedAt: Date.now(),
+    });
+    await ctx.db.insert("cycleOutputs", {
+      cycleId,
+      sourceOutputId: runOutputId,
+      sourceRunId: runId,
+      sourceVersionId: versionId,
+      cycleBlindLabel: "A",
+      outputContentSnapshot: "content A",
+    });
+
+    return { ownerUserId, orgId, projectId, cycleId, runId };
+  });
+
+  // Mint an anonymous guest user, as the Anonymous provider would.
+  const guestUserId = await t.run((ctx) =>
+    ctx.db.insert("users", { isAnonymous: true }),
+  );
+  const asGuest = t.withIdentity({
+    subject: `${guestUserId}|test-session-guest`,
+    tokenIdentifier: `test|${guestUserId}`,
+  });
+
+  return { t, ids, guestUserId, asGuest };
+}
+
+type InviteOverrides = {
+  scope?: "org" | "project" | "cycle";
+  scopeId?: string;
+  role?:
+    | "org_owner"
+    | "org_admin"
+    | "org_member"
+    | "project_owner"
+    | "project_editor"
+    | "project_evaluator"
+    | "cycle_reviewer";
+  shareable?: boolean;
+  status?: "pending" | "accepted" | "revoked" | "expired";
+  expiresAt?: number;
+  acceptCount?: number;
+  maxAccepts?: number;
+  blindMode?: boolean;
+  email?: string;
+};
+
+async function makeInvite(
+  t: Awaited<ReturnType<typeof seedGuestEnv>>["t"],
+  ids: Awaited<ReturnType<typeof seedGuestEnv>>["ids"],
+  o: InviteOverrides = {},
+): Promise<{ id: Id<"invitations">; token: string }> {
+  const token = `tok-${Math.round(o.acceptCount ?? 0)}-${o.role ?? "cycle_reviewer"}-${o.scope ?? "cycle"}-${o.status ?? "pending"}`;
+  const id = await t.run((ctx) =>
+    ctx.db.insert("invitations", {
+      scope: o.scope ?? "cycle",
+      scopeId: o.scopeId ?? (ids.cycleId as string),
+      orgId: ids.orgId,
+      role: o.role ?? "cycle_reviewer",
+      email: o.email ?? "",
+      token,
+      shareable: o.shareable ?? true,
+      blindMode: o.blindMode ?? true,
+      status: o.status ?? "pending",
+      invitedById: ids.ownerUserId,
+      invitedAt: Date.now(),
+      expiresAt: o.expiresAt ?? Date.now() + 1_000_000,
+      acceptCount: o.acceptCount ?? 0,
+      maxAccepts: o.maxAccepts,
+    }),
+  );
+  return { id, token };
+}
+
+describe("acceptInviteAsGuest — provisioning", () => {
+  test("cycle_reviewer accept makes exactly one evaluator collaborator + cycle evaluator", async () => {
+    const { t, ids, guestUserId, asGuest } = await seedGuestEnv();
+    const { token } = await makeInvite(t, ids, {
+      scope: "cycle",
+      role: "cycle_reviewer",
+      shareable: false,
+    });
+
+    const res = await asGuest.mutation(api.invitations.acceptInviteAsGuest, {
+      token,
+      displayName: "Jane",
+    });
+    expect(res).toMatchObject({
+      scope: "cycle",
+      scopeId: ids.cycleId,
+      role: "cycle_reviewer",
+      blindMode: true,
+    });
+
+    const { collaborators, cycleEvals, user } = await t.run(async (ctx) => ({
+      collaborators: await ctx.db
+        .query("projectCollaborators")
+        .withIndex("by_project_and_user", (q) =>
+          q.eq("projectId", ids.projectId).eq("userId", guestUserId),
+        )
+        .collect(),
+      cycleEvals: await ctx.db
+        .query("cycleEvaluators")
+        .withIndex("by_cycle_and_user", (q) =>
+          q.eq("cycleId", ids.cycleId).eq("userId", guestUserId),
+        )
+        .collect(),
+      user: await ctx.db.get(guestUserId),
+    }));
+
+    expect(collaborators).toHaveLength(1);
+    expect(collaborators[0]).toMatchObject({ role: "evaluator", blindMode: true });
+    expect(cycleEvals).toHaveLength(1);
+    expect(cycleEvals[0]?.status).toBe("pending");
+    expect(user?.name).toBe("Jane");
+  });
+
+  test("project_evaluator accept makes an evaluator collaborator on the project", async () => {
+    const { t, ids, guestUserId, asGuest } = await seedGuestEnv();
+    const { token } = await makeInvite(t, ids, {
+      scope: "project",
+      scopeId: ids.projectId as string,
+      role: "project_evaluator",
+      shareable: true,
+    });
+
+    await asGuest.mutation(api.invitations.acceptInviteAsGuest, { token });
+
+    const collaborators = await t.run((ctx) =>
+      ctx.db
+        .query("projectCollaborators")
+        .withIndex("by_project_and_user", (q) =>
+          q.eq("projectId", ids.projectId).eq("userId", guestUserId),
+        )
+        .collect(),
+    );
+    expect(collaborators).toHaveLength(1);
+    expect(collaborators[0]?.role).toBe("evaluator");
+  });
+
+  test("shareable accept bumps acceptCount without marking the invite accepted", async () => {
+    const { t, ids, asGuest } = await seedGuestEnv();
+    const { id, token } = await makeInvite(t, ids, { shareable: true });
+
+    await asGuest.mutation(api.invitations.acceptInviteAsGuest, { token });
+
+    const invite = await t.run((ctx) => ctx.db.get(id));
+    expect(invite?.acceptCount).toBe(1);
+    expect(invite?.status).toBe("pending");
+  });
+});
+
+describe("acceptInviteAsGuest — privilege gate", () => {
+  test("rejects non-reviewer roles (no escalation to owner/org access)", async () => {
+    const { t, ids, asGuest } = await seedGuestEnv();
+    for (const role of [
+      "org_member",
+      "project_owner",
+      "project_editor",
+    ] as const) {
+      const scope = role.startsWith("org") ? "org" : "project";
+      const scopeId =
+        scope === "org" ? (ids.orgId as string) : (ids.projectId as string);
+      const { token } = await makeInvite(t, ids, { role, scope, scopeId });
+      await expect(
+        asGuest.mutation(api.invitations.acceptInviteAsGuest, { token }),
+      ).rejects.toThrow(/requires an account/);
+    }
+  });
+
+  test("rejects a real (non-anonymous) signed-in user", async () => {
+    const { t, ids } = await seedGuestEnv();
+    const realUserId = await t.run((ctx) =>
+      ctx.db.insert("users", { name: "Real", email: "real@test.com" }),
+    );
+    const asReal = t.withIdentity({
+      subject: `${realUserId}|test-session-real`,
+      tokenIdentifier: `test|${realUserId}`,
+    });
+    const { token } = await makeInvite(t, ids);
+    await expect(
+      asReal.mutation(api.invitations.acceptInviteAsGuest, { token }),
+    ).rejects.toThrow(/account/);
+  });
+
+  test("enforces maxAccepts on shareable links", async () => {
+    const { t, ids, asGuest } = await seedGuestEnv();
+    const { token } = await makeInvite(t, ids, {
+      shareable: true,
+      maxAccepts: 1,
+      acceptCount: 1,
+    });
+    await expect(
+      asGuest.mutation(api.invitations.acceptInviteAsGuest, { token }),
+    ).rejects.toThrow(/limit/);
+  });
+
+  test("rejects expired invites", async () => {
+    const { t, ids, asGuest } = await seedGuestEnv();
+    const { token } = await makeInvite(t, ids, { expiresAt: Date.now() - 1 });
+    await expect(
+      asGuest.mutation(api.invitations.acceptInviteAsGuest, { token }),
+    ).rejects.toThrow(/expired/);
+  });
+
+  test("rejects revoked invites", async () => {
+    const { t, ids, asGuest } = await seedGuestEnv();
+    const { token } = await makeInvite(t, ids, { status: "revoked" });
+    await expect(
+      asGuest.mutation(api.invitations.acceptInviteAsGuest, { token }),
+    ).rejects.toThrow(/revoked/);
+  });
+});
+
+describe("guest review pipeline", () => {
+  test("a bare anonymous user (no invite accepted) cannot start a review", async () => {
+    const { t, ids, asGuest } = await seedGuestEnv();
+    await expect(
+      asGuest.mutation(api.reviewSessions.start, { cycleId: ids.cycleId }),
+    ).rejects.toThrow(/Permission denied/);
+  });
+
+  test("an accepted guest can start a blind review session as an evaluator", async () => {
+    const { t, ids, asGuest } = await seedGuestEnv();
+    const { token } = await makeInvite(t, ids, { scope: "cycle" });
+    await asGuest.mutation(api.invitations.acceptInviteAsGuest, { token });
+
+    const sessionId = await asGuest.mutation(api.reviewSessions.start, {
+      cycleId: ids.cycleId,
+    });
+    const data = await asGuest.query(api.reviewSessions.get, { sessionId });
+    expect(data.session.role).toBe("evaluator");
+    // Blind: outputs carry a session-scoped label and content, never the
+    // source version/run identity.
+    for (const output of data.outputs as Array<Record<string, unknown>>) {
+      expect(output).not.toHaveProperty("sourceVersionId");
+      expect(output).not.toHaveProperty("promptVersionId");
+    }
+  });
+});

--- a/src/components/InviteDialog.tsx
+++ b/src/components/InviteDialog.tsx
@@ -133,7 +133,7 @@ export function InviteDialog({
         : "Invite reviewers";
   const description =
     scope === "cycle"
-      ? "Invitees will blind-evaluate this cycle. They can accept with an account or continue as a guest."
+      ? "Reviewers rate responses blind — no account needed. Anyone with the link can start in one click."
       : "Invitees will get an email with a link to accept.";
 
   return (

--- a/src/routes/invite/InviteLanding.tsx
+++ b/src/routes/invite/InviteLanding.tsx
@@ -1,14 +1,25 @@
 import { useEffect, useRef, useState } from "react";
 import { useMutation, useQuery } from "convex/react";
 import { Authenticated, Unauthenticated, AuthLoading } from "convex/react";
+import { useAuthActions } from "@convex-dev/auth/react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import { toast } from "sonner";
 
 import { api } from "../../../convex/_generated/api";
 import type { Doc } from "../../../convex/_generated/dataModel";
 import { Button, buttonVariants } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
 import { friendlyError } from "@/lib/errors";
+
+// M30: reviewer-role invites can be accepted without an account — the guest
+// becomes an anonymous user that is registered as a blind evaluator.
+function roleAllowsGuest(role: string): boolean {
+  return role === "project_evaluator" || role === "cycle_reviewer";
+}
+
+type GuestInfo = { displayName?: string; email?: string };
 
 type InviteMeta = {
   scope: "org" | "project" | "cycle";
@@ -68,14 +79,46 @@ function InviteContent({ token }: { token: string }) {
   if (!meta.shareable && meta.status === "accepted")
     return <AlreadyAcceptedState />;
 
+  return <InviteAccept token={token} meta={meta} />;
+}
+
+function InviteAccept({ token, meta }: { token: string; meta: InviteMeta }) {
+  const { signIn } = useAuthActions();
+  // Self-reported attribution typed on the guest card. Held in this parent so
+  // it survives the Unauthenticated → Authenticated flip after anonymous
+  // sign-in; AuthenticatedAccept reads it to attribute the guest.
+  const [guestInfo, setGuestInfo] = useState<GuestInfo>({});
+  const [guestStarting, setGuestStarting] = useState(false);
+
+  const startGuest = async (info: GuestInfo) => {
+    setGuestInfo({
+      displayName: info.displayName || undefined,
+      email: info.email || meta.email || undefined,
+    });
+    setGuestStarting(true);
+    try {
+      // Mints a powerless anonymous user. The tree flips to Authenticated and
+      // AuthenticatedAccept finishes the accept as a guest.
+      await signIn("anonymous");
+    } catch (err) {
+      setGuestStarting(false);
+      toast.error(friendlyError(err, "Couldn't start your review."));
+    }
+  };
+
   return (
     <>
       <InviteHeader meta={meta} />
       <Authenticated>
-        <AuthenticatedAccept token={token} meta={meta} />
+        <AuthenticatedAccept token={token} meta={meta} guestInfo={guestInfo} />
       </Authenticated>
       <Unauthenticated>
-        <UnauthenticatedPath token={token} meta={meta} />
+        <UnauthenticatedPath
+          token={token}
+          meta={meta}
+          guestStarting={guestStarting}
+          onGuestStart={startGuest}
+        />
       </Unauthenticated>
       <AuthLoading>
         <Skeleton className="mt-6 h-10 w-full" />
@@ -85,13 +128,13 @@ function InviteContent({ token }: { token: string }) {
 }
 
 function InviteHeader({ meta }: { meta: InviteMeta }) {
-  const isReviewerRole =
-    meta.role === "project_evaluator" || meta.role === "cycle_reviewer";
+  const reviewerRole = roleAllowsGuest(meta.role);
+  const showBlindBadge = reviewerRole && meta.blindMode !== undefined;
   const verb =
     meta.scope === "cycle"
       ? "Evaluate"
       : meta.scope === "project"
-        ? isReviewerRole
+        ? reviewerRole
           ? meta.blindMode === false
             ? "Review"
             : "Blind-review"
@@ -105,15 +148,22 @@ function InviteHeader({ meta }: { meta: InviteMeta }) {
       <h1 className="text-xl font-semibold">
         {verb} {meta.scopeName}
       </h1>
-      <p className="text-xs text-muted-foreground">
-        Role: {readableRole(meta.role)}
-        {meta.email ? ` · For ${meta.email}` : ""}
-      </p>
-      {isReviewerRole && meta.blindMode !== undefined && (
+      <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+        <span>
+          Role: {readableRole(meta.role)}
+          {meta.email ? ` · For ${meta.email}` : ""}
+        </span>
+        {showBlindBadge && (
+          <span className="inline-flex items-center rounded-full border px-2 py-0.5 font-medium">
+            {meta.blindMode ? "Blind review" : "Open review"}
+          </span>
+        )}
+      </div>
+      {showBlindBadge && (
         <p className="rounded-md border bg-muted/50 p-3 text-xs text-muted-foreground">
           {meta.blindMode
-            ? "You'll rate example outputs without seeing the prompt or other reviewers' comments. Designed to keep feedback unbiased."
-            : "You'll see the full prompt and leave feedback on example outputs. The author will act on what you write."}
+            ? "You'll rate example responses without seeing the prompt or who wrote them — it keeps feedback honest."
+            : "You'll see the full prompt and comment on example responses. The author acts on what you write."}
         </p>
       )}
     </div>
@@ -123,21 +173,27 @@ function InviteHeader({ meta }: { meta: InviteMeta }) {
 function AuthenticatedAccept({
   token,
   meta,
+  guestInfo,
 }: {
   token: string;
   meta: InviteMeta;
+  guestInfo: GuestInfo;
 }) {
   const currentUser = useQuery(api.users.viewer) as
     | Doc<"users">
     | null
     | undefined;
   const acceptWithAuth = useMutation(api.invitations.acceptWithAuth);
+  const acceptInviteAsGuest = useMutation(api.invitations.acceptInviteAsGuest);
   const navigate = useNavigate();
   const [accepting, setAccepting] = useState(false);
+  const [guestError, setGuestError] = useState<string | null>(null);
   const ran = useRef(false);
 
+  const isAnonymous = currentUser?.isAnonymous === true;
   const currentEmail = currentUser?.email?.toLowerCase() ?? null;
   const emailMismatch =
+    !isAnonymous &&
     !meta.shareable &&
     meta.email &&
     currentEmail &&
@@ -149,16 +205,41 @@ function AuthenticatedAccept({
     if (emailMismatch) return;
     ran.current = true;
     setAccepting(true);
-    void acceptWithAuth({ token })
-      .then((res) => {
-        navigate(routeForAccepted(res, meta.blindMode), { replace: true });
-      })
-      .catch((err) => {
-        ran.current = false;
-        setAccepting(false);
+
+    const run = isAnonymous
+      ? acceptInviteAsGuest({
+          token,
+          displayName: guestInfo.displayName,
+          email: guestInfo.email,
+        }).then((res) =>
+          navigate(routeForGuestAccepted(res), { replace: true }),
+        )
+      : acceptWithAuth({ token }).then((res) =>
+          navigate(routeForAccepted(res, meta.blindMode), { replace: true }),
+        );
+
+    void run.catch((err) => {
+      ran.current = false;
+      setAccepting(false);
+      if (isAnonymous) {
+        // Most likely an account-only invite or a full shareable link.
+        setGuestError(friendlyError(err, "Couldn't start your review."));
+      } else {
         toast.error(friendlyError(err, "Failed to accept invitation."));
-      });
-  }, [acceptWithAuth, currentUser, emailMismatch, meta.blindMode, navigate, token]);
+      }
+    });
+  }, [
+    acceptInviteAsGuest,
+    acceptWithAuth,
+    currentUser,
+    emailMismatch,
+    guestInfo.displayName,
+    guestInfo.email,
+    isAnonymous,
+    meta.blindMode,
+    navigate,
+    token,
+  ]);
 
   if (emailMismatch) {
     return (
@@ -181,10 +262,26 @@ function AuthenticatedAccept({
     );
   }
 
+  if (guestError) {
+    return (
+      <div className="mt-6 space-y-3">
+        <div className="rounded-md border border-destructive/40 bg-destructive/5 p-3 text-xs text-destructive">
+          {guestError}
+        </div>
+        <Link
+          to={`/auth/sign-in?next=${encodeURIComponent(`/invite/${token}`)}`}
+          className={buttonVariants({ variant: "outline", className: "w-full" })}
+        >
+          Sign in with an account
+        </Link>
+      </div>
+    );
+  }
+
   return (
     <div className="mt-6">
       <Button disabled className="w-full">
-        {accepting ? "Accepting…" : "Accepting…"}
+        {accepting ? "Starting…" : "Starting…"}
       </Button>
     </div>
   );
@@ -192,33 +289,96 @@ function AuthenticatedAccept({
 
 function UnauthenticatedPath({
   token,
+  meta,
+  guestStarting,
+  onGuestStart,
 }: {
   token: string;
   meta: InviteMeta;
+  guestStarting: boolean;
+  onGuestStart: (info: GuestInfo) => void;
 }) {
   const navigate = useNavigate();
 
-  // Guest acceptance is intentionally gated behind sign-in until the
-  // reviewSessions pipeline supports guestIdentityId end-to-end. The schema
-  // + invitations.acceptAsGuest path are in place; the review deck isn't.
+  // Owner/editor and org invites genuinely need an account — keep the gate.
+  if (!roleAllowsGuest(meta.role)) {
+    return (
+      <div className="mt-6 space-y-3">
+        <p className="text-sm text-muted-foreground">
+          Sign in to accept this invitation. If you don't have an account,
+          you'll be prompted to create one.
+        </p>
+        <Button
+          className="w-full"
+          onClick={() =>
+            navigate(
+              `/auth/sign-in?next=${encodeURIComponent(`/invite/${token}`)}`,
+            )
+          }
+        >
+          Sign in to continue
+        </Button>
+      </div>
+    );
+  }
+
+  // M30: reviewer invites — no account required.
+  return <GuestStartCard starting={guestStarting} onStart={onGuestStart} />;
+}
+
+function GuestStartCard({
+  starting,
+  onStart,
+}: {
+  starting: boolean;
+  onStart: (info: GuestInfo) => void;
+}) {
+  const [name, setName] = useState("");
+
   return (
-    <div className="mt-6 space-y-3">
-      <p className="text-sm text-muted-foreground">
-        Sign in to accept this invitation. If you don't have an account,
-        you'll be prompted to create one.
-      </p>
-      <Button
-        className="w-full"
-        onClick={() =>
-          navigate(
-            `/auth/sign-in?next=${encodeURIComponent(`/invite/${token}`)}`,
-          )
-        }
-      >
-        Sign in to continue
+    <form
+      className="mt-6 space-y-4"
+      onSubmit={(e) => {
+        e.preventDefault();
+        if (starting) return;
+        onStart({ displayName: name.trim() || undefined });
+      }}
+    >
+      <div className="space-y-1.5">
+        <Label htmlFor="guest-name" className="text-xs">
+          Your name <span className="text-muted-foreground">(optional)</span>
+        </Label>
+        <Input
+          id="guest-name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="So the author knows whose feedback this is"
+          maxLength={80}
+          autoComplete="name"
+          disabled={starting}
+        />
+      </div>
+      <Button type="submit" className="w-full" disabled={starting}>
+        {starting ? "Starting…" : "Start reviewing"}
       </Button>
-    </div>
+      <p className="text-center text-xs text-muted-foreground">
+        No account needed. Your progress saves as you go.
+      </p>
+    </form>
   );
+}
+
+// M30: guests are always routed to a review surface, never the authoring
+// app. Owner/editor/org scopes are unreachable here — the accept gate rejects
+// them for anonymous users.
+function routeForGuestAccepted(res: {
+  scope: "org" | "project" | "cycle";
+  scopeId: string;
+}): string {
+  if (res.scope === "cycle") {
+    return `/review/start/cycle/${res.scopeId}`;
+  }
+  return `/review/${res.scopeId}`;
 }
 
 function routeForAccepted(

--- a/src/routes/review/SessionDeck.tsx
+++ b/src/routes/review/SessionDeck.tsx
@@ -583,10 +583,12 @@ function CompleteView({
   return (
     <div className="mx-auto flex max-w-2xl flex-col gap-6 px-4 py-8 sm:px-6 sm:py-12">
       <div>
-        <h1 className="font-heading text-2xl font-semibold">Review complete</h1>
+        <h1 className="font-heading text-2xl font-semibold">
+          Thanks — you're all done
+        </h1>
         <p className="mt-1 text-sm text-muted-foreground">
-          Feedback has been saved to the session. The project author can see it
-          in the feedback dashboard.
+          Your ratings and comments have been sent to the author. Nothing else
+          is needed — you can close this tab.
         </p>
       </div>
 


### PR DESCRIPTION
## Summary

Makes the **no-account, link-based blind review** path actually work — Blind Bench's sharpest differentiator, which until now was disabled behind a sign-in gate. A "guest" reviewer is now an **anonymous Convex Auth user** (`isAnonymous: true`) that gets provisioned as a blind **evaluator** collaborator on accept. Because the guest is a real `users` row, the *entire* existing review pipeline (`requireProjectRole` / `isBlindReviewer` / review sessions, ratings, matchups) works unchanged — this is "Approach C".

This also retires the half-built parallel **guest principal** abstraction (`guestIdentities` / `resolvePrincipal` / `acceptAsGuest`) rather than finishing it.

## What changed

**Auth + gate**
- `convex/auth.ts`: enable the `Anonymous` provider. A bare anon user has **no memberships** and can see/do nothing — authorization comes *solely* from the invite-validated evaluator row, so enabling the provider does not widen access.
- `convex/invitations.ts` — `acceptInviteAsGuest`: the real gate. Runs as the anon user, **hard-restricts to reviewer roles** (`cycle_reviewer`, `project_evaluator`) so a guest can never escalate to owner/editor/org access; validates status/expiry/`maxAccepts`; writes exactly one `evaluator` collaborator (+ `cycleEvaluators` status row) via the existing per-scope acceptors. Real signed-in users are bounced to `acceptWithAuth`.

**Frontend**
- `src/routes/invite/InviteLanding.tsx`: replaced the sign-in gate with a one-click **guest-accept card** (optional name) for reviewer invites; sign-in is still required for owner/editor/org invites. The authenticated-accept path branches on `isAnonymous` and routes guests to a review surface only.
- `src/components/InviteDialog.tsx`: the "continue as a guest" promise is now true — copy sharpened.

**Lifecycle / abuse**
- `convex/anonCleanup.ts` + `convex/crons.ts`: daily cron reaps **orphan** anon accounts (signed in, never accepted an invite) older than 24h, cascading their auth sessions/accounts/tokens. Shareable-link abuse is bounded by `maxAccepts` + expiry.

**Cleanup (retire guest principal)**
- Dropped `resolvePrincipal`/`Principal` (`convex/lib/auth.ts`), `acceptAsGuest`, the `guestIdentities` table, the `acceptedByGuestId` field, and every `guestIdentityId` field + `by_guest_status` index. `reviewSessions.userId` is required again. Removed `guestIdentities` from the admin wipe list. (No backfill — pre-launch wipe policy.)

**Non-dev polish**
- Plain-English blind/open explainer + a Blind/Open badge on the invite preview; warmer "Thanks — you're all done" completion screen; "No account needed. Your progress saves as you go." reassurance.

**Tests** (`convex/tests/guestReview.test.ts`)
- Guest accept provisions exactly one evaluator collaborator (+ cycle evaluator); shareable bumps `acceptCount` without marking accepted; **privilege gate** rejects non-reviewer roles and real users; `maxAccepts`/expired/revoked enforced; bare anon user is denied from starting a review; an accepted guest can start a blind session as an `evaluator`.

## ⚠️ Verification note

This dev environment has **no Convex deployment configured** and `convex/_generated` is absent, so I could **not** run `tsc -b` or `vitest` locally (every module imports the generated API/schema). I avoided running `npx convex dev`, since that would push the schema changes (required `reviewSessions.userId`, dropped `guestIdentities`) to your shared deployment. I verified by close manual review + a full grep sweep for dangling references to all removed symbols (none remain). **CI / `npm run build:deploy` (which runs `convex deploy` then `tsc`) is the real typecheck.**

## Test plan

- [ ] `npm run build:deploy` (or `npx convex dev` once) typechecks clean and codegen succeeds
- [ ] `npx vitest run convex/tests/guestReview.test.ts` passes
- [ ] Incognito: open a shareable **cycle** invite link → "Start reviewing" with no account → complete Phase 1 + Phase 2 → see the "you're all done" screen
- [ ] Owner sees the guest's ratings/comments feeding the feedback dashboard / optimizer
- [ ] Open a **project_evaluator** shareable link as a guest → lands on `/review/:projectId`
- [ ] An **org / project-owner** invite still requires sign-in (gate intact)
- [ ] Re-verify the 13 blind-eval rules (UX Spec §10) hold for an anonymous evaluator

🤖 Generated with [Claude Code](https://claude.com/claude-code)