### PR TITLE
fix(test): unbreak main — drop unused binding in guest-review test

### DIFF
--- a/convex/tests/guestReview.test.ts
+++ b/convex/tests/guestReview.test.ts
@@ -294,7 +294,7 @@ describe("acceptInviteAsGuest — privilege gate", () => {
 
 describe("guest review pipeline", () => {
   test("a bare anonymous user (no invite accepted) cannot start a review", async () => {
-    const { t, ids, asGuest } = await seedGuestEnv();
+    const { ids, asGuest } = await seedGuestEnv();
     await expect(
       asGuest.mutation(api.reviewSessions.start, { cycleId: ids.cycleId }),
     ).rejects.toThrow(/Permission denied/);


### PR DESCRIPTION
## Summary

`main` is currently failing the Vercel build at the `tsc -b` step (the Convex deploy before it succeeded). The only error:

```
convex/tests/guestReview.test.ts(297,13): error TS6133: 't' is declared but its value is never read.
```

The bare-anonymous-user test destructured `t` but only uses `ids` and `asGuest`. This removes the unused binding. Zero behavior change.

## Test plan

- [ ] Vercel build on this branch goes green (`convex deploy` + `tsc -b` + `vite build`)
- [ ] Merge to unbreak `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)