### PR TITLE
fix(grainient): guard against unavailable WebGL2 context

### DIFF
--- a/landing/src/components/Grainient.astro
+++ b/landing/src/components/Grainient.astro
@@ -153,6 +153,17 @@ void main(){
   function init(container: HTMLElement) {
     if (container.dataset.initialized === '1') return;
     if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+
+    // The Grainient is purely decorative. If WebGL2 is unavailable (hardware
+    // acceleration off, GPU blocklist, too many live contexts, older/locked-down
+    // browsers), bail gracefully instead of letting OGL's Renderer throw on a
+    // null context. See Sentry BLIND-BENCH-LANDING-1.
+    try {
+      if (!document.createElement('canvas').getContext('webgl2')) return;
+    } catch {
+      return;
+    }
+
     container.dataset.initialized = '1';
 
     const timeSpeed = parseFloat(container.dataset.timeSpeed || '0.25');
@@ -162,12 +173,18 @@ void main(){
     const zoom = parseFloat(container.dataset.zoom || '0.9');
     const contrast = parseFloat(container.dataset.contrast || '1.5');
 
-    const renderer = new Renderer({
-      webgl: 2,
-      alpha: true,
-      antialias: false,
-      dpr: Math.min(window.devicePixelRatio || 1, 2),
-    });
+    let renderer: Renderer;
+    try {
+      renderer = new Renderer({
+        webgl: 2,
+        alpha: true,
+        antialias: false,
+        dpr: Math.min(window.devicePixelRatio || 1, 2),
+      });
+    } catch {
+      // OGL couldn't acquire a context; skip the effect.
+      return;
+    }
 
     const gl = renderer.gl;
     const canvas = gl.canvas as HTMLCanvasElement;

--- a/src/components/Grainient.tsx
+++ b/src/components/Grainient.tsx
@@ -159,12 +159,28 @@ const Grainient: React.FC<GrainientProps> = ({
   useEffect(() => {
     if (!containerRef.current) return;
 
-    const renderer = new Renderer({
-      webgl: 2,
-      alpha: true,
-      antialias: false,
-      dpr: Math.min(window.devicePixelRatio || 1, 2),
-    });
+    // The Grainient is purely decorative. If WebGL2 is unavailable (hardware
+    // acceleration off, GPU blocklist, too many live contexts, older/locked-down
+    // browsers), bail gracefully instead of letting OGL's Renderer throw on a
+    // null context. See Sentry BLIND-BENCH-LANDING-1.
+    try {
+      if (!document.createElement('canvas').getContext('webgl2')) return;
+    } catch {
+      return;
+    }
+
+    let renderer: Renderer;
+    try {
+      renderer = new Renderer({
+        webgl: 2,
+        alpha: true,
+        antialias: false,
+        dpr: Math.min(window.devicePixelRatio || 1, 2),
+      });
+    } catch {
+      // OGL couldn't acquire a context; skip the effect.
+      return;
+    }
 
     const gl = renderer.gl;
     const canvas = gl.canvas as HTMLCanvasElement;


### PR DESCRIPTION
## Summary

Fixes the Sentry error [`BLIND-BENCH-LANDING-1`](https://mogil-ventures.sentry.io/issues/BLIND-BENCH-LANDING-1) — `TypeError: Cannot set properties of null (setting 'renderer')` on `www.blindbench.dev`.

**Root cause:** OGL's `Renderer` constructor logs `"unable to create webgl context"` and then unconditionally does `this.gl.renderer = this`, which throws when `canvas.getContext('webgl2')` returns `null`. That happens on clients without a usable WebGL2 context (hardware acceleration disabled, GPU on a driver blocklist, too many live contexts, older/locked-down browsers). The unguarded `new Renderer({ webgl: 2, ... })` call let the error reach the global `onerror` handler and report to Sentry.

## Changes

Identical guard applied to both copies of the component:
- `landing/src/components/Grainient.astro` (the landing-site source of the Sentry error)
- `src/components/Grainient.tsx` (the in-app version, which had the same gap)

Each now:
1. Probes for a `webgl2` context up front and returns early if unavailable.
2. Wraps `new Renderer(...)` in `try/catch` as a backstop.

The Grainient is purely decorative (`aria-hidden`), so skipping it degrades cleanly — the page renders fine without the background gradient.

## Verification

Type-safe by inspection (`renderer` is explicitly typed and definitely-assigned before use; `catch` paths `return`). Full `tsc`/`astro check` runs in Vercel CI on build — local type-checking isn't available without the Convex deployment / optional astro-check deps. Real-world confirmation is the Sentry issue staying quiet after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)