### PR TITLE
fix(landing): filter browser-extension noise from Sentry

### DIFF
--- a/landing/src/lib/sentry.ts
+++ b/landing/src/lib/sentry.ts
@@ -8,9 +8,25 @@ let initialized = false;
  * - No-op when `PUBLIC_SENTRY_DSN` is unset (Astro only exposes PUBLIC_-prefixed
  *   vars to the client bundle).
  * - Tracing disabled (`tracesSampleRate: 0`); no Replay instrumentation.
+ * - `ignoreErrors`/`denyUrls` drop noise from visitors' browser extensions
+ *   (e.g. `runtime.sendMessage` rejections) that never originates in our code.
  * - `beforeSend` strips request headers/cookies/body and the user object to
  *   reduce PII risk.
  */
+
+/**
+ * Error messages thrown by browser extensions injected into the page, surfaced
+ * via `onunhandledrejection`. These are not our bugs — a visitor's extension is.
+ */
+const EXTENSION_NOISE = [
+  // WebExtensions messaging errors (chrome.runtime / browser.runtime)
+  /runtime\.sendMessage/i,
+  /Tab not found/i,
+  /Extension context invalidated/i,
+  /message channel closed/i,
+  /Could not establish connection\. Receiving end does not exist/i,
+];
+
 export function initSentry(): void {
   if (initialized) return;
   const dsn = import.meta.env.PUBLIC_SENTRY_DSN;
@@ -20,6 +36,12 @@ export function initSentry(): void {
     dsn,
     tracesSampleRate: 0,
     sendDefaultPii: false,
+    ignoreErrors: EXTENSION_NOISE,
+    denyUrls: [
+      /^chrome-extension:\/\//,
+      /^moz-extension:\/\//,
+      /^safari-(web-)?extension:\/\//,
+    ],
     beforeSend(event) {
       delete event.user;
       if (event.request) {


### PR DESCRIPTION
## What

Drops the `Invalid call to runtime.sendMessage(). Tab not found.` error (Sentry `BLIND-BENCH-LANDING-2`) and similar third-party noise from the landing-site Sentry dashboard.

## Why

That error is thrown inside a **visitor's browser extension** content script (`chrome.runtime`/`browser.runtime` WebExtensions API) and surfaces in our app via the global `onunhandledrejection` handler. It is **not a bug in our code**:

- No stacktrace (nothing in our bundle)
- 0 users impacted, 3 occurrences from a single visitor over a 14s window
- The landing page never calls `runtime.sendMessage`

It's functionally harmless, but left unfiltered this class of extension noise drowns out real errors.

## How

In `landing/src/lib/sentry.ts`:
- `ignoreErrors`: regexes for common WebExtension messaging errors (`runtime.sendMessage`, `Tab not found`, `Extension context invalidated`, `message channel closed`, `Could not establish connection…`)
- `denyUrls`: `chrome-extension://`, `moz-extension://`, `safari-extension://` origins

## Verification

`npm run build` in `landing/` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)