### PR TITLE
Add privacy-safe product event tracking

### DIFF
--- a/docs/observability-events.md
+++ b/docs/observability-events.md
@@ -1,0 +1,48 @@
+# Observability & Events
+
+Three tools, three jobs. Keep them separate.
+
+| Tool | Job | Where |
+| --- | --- | --- |
+| **PostHog** | GTM + product funnel (acquisition → activation → usage). Source of truth for "what did users do." | App: `src/lib/posthog.ts` + `src/lib/analytics.ts`. Landing: inline snippet in `Base.astro` + `landing/src/lib/analytics.ts`. |
+| **Sentry** | Product health: errors and `product` breadcrumbs for triage. **Not** a funnel — `tracesSampleRate: 0` in both app and landing, no replay. | App: `src/lib/sentry.ts`. Landing: `landing/src/lib/sentry.ts`. |
+| **Vercel Analytics** | Traffic + web vitals (page views, Core Web Vitals). Zero-config, no custom events. | Landing: `<Analytics />` in `Base.astro`. |
+
+Every product event goes through the `track()` / `trackLandingEvent()` wrappers, which fire PostHog **and** drop a matching Sentry breadcrumb. Don't call `posthog.capture` directly.
+
+## Privacy rules (non-negotiable)
+
+Props must be closed and low-cardinality. **Never** put any of these in an event:
+
+- Raw Convex IDs (`sessionId`, run/result/output IDs, etc.)
+- Prompt text, model outputs, annotation comments, or any free-form user input
+- Emails, names, API keys
+- URLs containing invite tokens or other opaque secrets
+
+Allowed: booleans, counts, and closed enums — `scope`, `role`, `phase`, `outputCount`, `matchupCount`, `reasonTagCount`, `selectedWinner`, `guestAllowed`, `blindMode`, `target`, `source`, etc. The TypeScript schemas in the two `analytics.ts` files enforce this at the call site; if you need a new field, add it to the schema first.
+
+## Naming conventions
+
+- Event names: `snake_case`, `noun_verb` past tense for completed actions (`review_session_completed`), `noun_noun` for surfaces (`invite_landing_viewed`).
+- Prop keys: `camelCase`.
+- One closed schema per surface (`ProductEventProps` in the app, `LandingEventProps` on the landing). Adding an event = adding a key to the interface.
+
+## Initial event list
+
+### App (`src/lib/analytics.ts`)
+
+| Event | Fired from | Key props |
+| --- | --- | --- |
+| `review_session_started` | `SessionDeck` (once per session load) | `scope`, `role`, `outputCount`, `requirePhase1`, `requirePhase2` |
+| `review_phase1_submitted` | `SessionDeck` | `scope`, `role`, `outputCount`, `matchupCount`, `advancedTo` |
+| `review_phase2_matchup_recorded` | `SessionDeck` | `scope`, `role`, `selectedWinner`, `reasonTagCount` |
+| `review_session_completed` | `SessionDeck` | `scope`, `role`, `outputCount` |
+| `invite_landing_viewed` | `InviteLanding` (once per resolved invite) | `scope`, `role`, `guestAllowed`, `status`, `blindMode` |
+| `next_action_clicked` | `NextActionRing` | `target` |
+| `copilot_panel_opened` | `CopilotPanel` (expand from collapsed) | `source` |
+
+### Landing (`landing/src/lib/analytics.ts`)
+
+| Event | Fired from | Key props |
+| --- | --- | --- |
+| `hero_cta_click` | `Hero.astro` | `ctaLabel`, `rotatorPersona` |

--- a/landing/src/components/Hero.astro
+++ b/landing/src/components/Hero.astro
@@ -175,10 +175,13 @@ const APP_URL = 'https://app.blindbench.dev';
 </style>
 
 <script>
-  type PostHogGlobal = {
-    capture: (event: string, props?: Record<string, unknown>) => void;
-  };
-  const w = window as Window & { posthog?: PostHogGlobal };
+  import { trackLandingEvent } from '../lib/analytics';
+
+  const ROTATOR_PERSONAS = ['PMs', 'legal', 'marketing', 'customers', 'experts'] as const;
+
+  function normalizePersona(value: string | undefined) {
+    return ROTATOR_PERSONAS.find((persona) => persona === value) ?? 'unknown';
+  }
 
   const rotator = document.querySelector<HTMLElement>('[data-hero-rotator]');
   const rotatorActive = rotator?.querySelector<HTMLElement>(
@@ -186,7 +189,7 @@ const APP_URL = 'https://app.blindbench.dev';
   );
 
   if (rotator && rotatorActive) {
-    const ROLES = ['PMs', 'legal', 'marketing', 'customers', 'experts'];
+    const ROLES = ROTATOR_PERSONAS;
     const DWELL_MS = 2000;
     const STAGGER_MS = 25; // matches React Bits staggerDuration 0.025
     const ENTER_MS = 420;
@@ -292,11 +295,11 @@ const APP_URL = 'https://app.blindbench.dev';
     .querySelectorAll<HTMLElement>('[data-hero-cta]')
     .forEach((el) => {
       el.addEventListener('click', () => {
-        const persona = rotator?.dataset.current ?? 'unknown';
-        const label = el.getAttribute('data-hero-cta') ?? 'unknown';
-        w.posthog?.capture('hero_cta_click', {
-          rotator_persona: persona,
-          cta_label: label,
+        const persona = normalizePersona(rotator?.dataset.current);
+        const label = el.getAttribute('data-hero-cta');
+        trackLandingEvent('hero_cta_click', {
+          ctaLabel: label === 'see_how' ? 'see_how' : 'get_started',
+          rotatorPersona: persona,
         });
       });
     });

--- a/landing/src/env.d.ts
+++ b/landing/src/env.d.ts
@@ -8,3 +8,10 @@ interface ImportMetaEnv {
 interface ImportMeta {
   readonly env: ImportMetaEnv;
 }
+
+interface Window {
+  /** PostHog snippet loaded inline in Base.astro; absent without a key/host. */
+  posthog?: {
+    capture: (event: string, props?: Record<string, unknown>) => void;
+  };
+}

--- a/landing/src/lib/analytics.ts
+++ b/landing/src/lib/analytics.ts
@@ -1,0 +1,34 @@
+import * as Sentry from '@sentry/browser';
+
+/**
+ * Landing-site analytics. PostHog is the GTM funnel source of truth; Sentry
+ * gets a parallel `product` breadcrumb for health/error triage. See
+ * `docs/observability-events.md`.
+ *
+ * Props are closed and low-cardinality — never raw IDs, emails, or free-form
+ * input. PostHog is loaded inline in Base.astro and exposed on `window`;
+ * `addBreadcrumb` is a safe no-op when Sentry has no DSN.
+ */
+
+/** Closed schema: event name → its allowed props. */
+export interface LandingEventProps {
+  hero_cta_click: {
+    ctaLabel: 'get_started' | 'see_how';
+    rotatorPersona: 'PMs' | 'legal' | 'marketing' | 'customers' | 'experts' | 'unknown';
+  };
+}
+
+export type LandingEvent = keyof LandingEventProps;
+
+export function trackLandingEvent<E extends LandingEvent>(
+  event: E,
+  props: LandingEventProps[E],
+): void {
+  window.posthog?.capture(event, props);
+  Sentry.addBreadcrumb({
+    category: 'product',
+    level: 'info',
+    message: event,
+    data: props,
+  });
+}

--- a/src/components/CopilotPanel.tsx
+++ b/src/components/CopilotPanel.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { useMutation, useQuery } from "convex/react";
 import { toast } from "sonner";
 import { friendlyError } from "@/lib/errors";
+import { track } from "@/lib/analytics";
 import {
   Check,
   ChevronRight,
@@ -183,7 +184,10 @@ export function CopilotPanel() {
             render={
               <button
                 type="button"
-                onClick={() => void setCollapsed({ collapsed: false })}
+                onClick={() => {
+                  track("copilot_panel_opened", { source: "expand" });
+                  void setCollapsed({ collapsed: false });
+                }}
                 className="flex h-9 w-9 items-center justify-center rounded-md hover:bg-muted"
                 aria-label="Expand setup co-pilot"
               />

--- a/src/components/copilot/NextActionRing.tsx
+++ b/src/components/copilot/NextActionRing.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState, type ReactNode } from "react";
 import { useMutation, useQuery } from "convex/react";
 import { api } from "../../../convex/_generated/api";
 import { useOrg } from "@/contexts/OrgContext";
+import { track } from "@/lib/analytics";
 
 // Step keys mirror CopilotPanel's STEPS — kept as a string union so callers
 // get autocomplete and so accidental typos break at the type level.
@@ -77,6 +78,7 @@ export function NextActionRing({
 
   const handleClickCapture = () => {
     if (!shouldShow) return;
+    track("next_action_clicked", { target });
     void dismissRing({ target });
   };
 

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,77 @@
+import { posthog } from "@/lib/posthog";
+import { Sentry } from "@/lib/sentry";
+import type { CopilotTarget } from "@/components/copilot/NextActionRing";
+
+/**
+ * Product + GTM analytics for the main app.
+ *
+ * PostHog is the funnel/activation source of truth; Sentry gets a parallel
+ * `product` breadcrumb so health/error triage has the same context without a
+ * second pipeline. See `docs/observability-events.md`.
+ *
+ * Props are deliberately closed and low-cardinality. Never pass raw Convex IDs,
+ * prompt/output text, emails, API keys, tokenized URLs, or free-form user input
+ * — only booleans, counts, and enums.
+ */
+
+type Scope = "run" | "cycle";
+
+/** Closed schema: event name → its allowed props. */
+export interface ProductEventProps {
+  review_session_started: {
+    scope: Scope;
+    role: string;
+    outputCount: number;
+    requirePhase1: boolean;
+    requirePhase2: boolean;
+  };
+  review_phase1_submitted: {
+    scope: Scope;
+    role: string;
+    outputCount: number;
+    matchupCount: number;
+    advancedTo: "phase2" | "complete";
+  };
+  review_phase2_matchup_recorded: {
+    scope: Scope;
+    role: string;
+    selectedWinner: "left" | "right" | "tie" | "skip";
+    reasonTagCount: number;
+  };
+  review_session_completed: {
+    scope: Scope;
+    role: string;
+    outputCount: number;
+  };
+  invite_landing_viewed: {
+    scope: "org" | "project" | "cycle";
+    role: string;
+    guestAllowed: boolean;
+    status: "pending" | "accepted" | "revoked" | "expired";
+    blindMode: boolean | null;
+  };
+  next_action_clicked: {
+    target: CopilotTarget;
+  };
+  copilot_panel_opened: {
+    source: "expand";
+  };
+}
+
+export type ProductEvent = keyof ProductEventProps;
+
+export function track<E extends ProductEvent>(
+  event: E,
+  props: ProductEventProps[E],
+): void {
+  // No-op safely when PostHog never initialized (no key/host in this env).
+  if (posthog.__loaded) {
+    posthog.capture(event, props);
+  }
+  Sentry.addBreadcrumb({
+    category: "product",
+    level: "info",
+    message: event,
+    data: props,
+  });
+}

--- a/src/routes/invite/InviteLanding.tsx
+++ b/src/routes/invite/InviteLanding.tsx
@@ -12,6 +12,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
 import { friendlyError } from "@/lib/errors";
+import { track } from "@/lib/analytics";
 
 // M30: reviewer-role invites can be accepted without an account — the guest
 // becomes an anonymous user that is registered as a blind evaluator.
@@ -62,6 +63,20 @@ function InviteContent({ token }: { token: string }) {
     | InviteMeta
     | null
     | undefined;
+
+  // Fire once per resolved invite — GTM activation funnel entry point.
+  const viewFiredRef = useRef(false);
+  useEffect(() => {
+    if (!meta || viewFiredRef.current) return;
+    viewFiredRef.current = true;
+    track("invite_landing_viewed", {
+      scope: meta.scope,
+      role: meta.role,
+      guestAllowed: roleAllowsGuest(meta.role),
+      status: meta.status,
+      blindMode: meta.blindMode ?? null,
+    });
+  }, [meta]);
 
   if (meta === undefined) {
     return (

--- a/src/routes/review/SessionDeck.tsx
+++ b/src/routes/review/SessionDeck.tsx
@@ -9,7 +9,7 @@ import type { Id } from "../../../convex/_generated/dataModel";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
-import { posthog } from "@/lib/posthog";
+import { track } from "@/lib/analytics";
 import { friendlyError } from "@/lib/errors";
 
 import { BattlePhase } from "./BattlePhase";
@@ -91,13 +91,12 @@ export function SessionDeck() {
     const sid = data.session.id;
     if (startedFiredRef.current === sid) return;
     startedFiredRef.current = sid;
-    posthog.capture("review_session_started", {
-      sessionId: sid,
+    track("review_session_started", {
       scope,
       role: data.session.role,
-      output_count: data.outputs.length,
-      require_phase1: data.session.requirePhase1,
-      require_phase2: data.session.requirePhase2,
+      outputCount: data.outputs.length,
+      requirePhase1: data.session.requirePhase1,
+      requirePhase2: data.session.requirePhase2,
     });
   }, [data, scope]);
 
@@ -260,12 +259,11 @@ export function SessionDeck() {
         reasonTags: tags,
       })
         .then(() => {
-          posthog.capture("review_phase2_matchup_recorded", {
-            sessionId: data.session.id,
+          track("review_phase2_matchup_recorded", {
             scope,
             role: data.session.role,
-            winner,
-            reason_tag_count: tags.length,
+            selectedWinner: winner,
+            reasonTagCount: tags.length,
           });
         })
         .catch((err) =>
@@ -279,13 +277,12 @@ export function SessionDeck() {
     if (!data) return;
     void submitPhase1({ sessionId: data.session.id })
       .then((res) => {
-        posthog.capture("review_phase1_submitted", {
-          sessionId: data.session.id,
+        track("review_phase1_submitted", {
           scope,
           role: data.session.role,
-          output_count: data.outputs.length,
-          matchups_generated: res.phase === "phase2" ? res.matchups : 0,
-          advanced_to: res.phase,
+          outputCount: data.outputs.length,
+          matchupCount: res.phase === "phase2" ? res.matchups : 0,
+          advancedTo: res.phase,
         });
         if (res.phase === "complete") {
           toast.success("Review complete");
@@ -302,11 +299,10 @@ export function SessionDeck() {
     if (!data) return;
     void complete({ sessionId: data.session.id })
       .then(() => {
-        posthog.capture("review_session_completed", {
-          sessionId: data.session.id,
+        track("review_session_completed", {
           scope,
           role: data.session.role,
-          output_count: data.outputs.length,
+          outputCount: data.outputs.length,
         });
         toast.success("Review complete");
       })


### PR DESCRIPTION
## Summary

Adds a small, privacy-safe event architecture for Blind Bench across the main app and landing site.

- Introduces typed `track()` / `trackLandingEvent()` wrappers with closed, low-cardinality event schemas.
- Keeps the split explicit: PostHog = GTM/product funnel source of truth; Sentry = error-only health with product breadcrumbs; Vercel Analytics = traffic/web vitals.
- Routes existing review-session events through the wrapper and removes raw `sessionId` props from PostHog events.
- Adds light activation instrumentation for invite landing views, next-action clicks, copilot panel opens, and landing hero CTA clicks.
- Documents event ownership, privacy rules, naming conventions, and the initial event list in `docs/observability-events.md`.

## Privacy / event-shape notes

- No raw Convex IDs, emails, prompt text, model output, comments, invite tokens, or user free-form input added to events.
- Event props are booleans/counts/enums like `scope`, `role`, `outputCount`, `matchupCount`, `selectedWinner`, `guestAllowed`, and closed landing CTA/persona values.
- Sentry tracing/replay remains off (`tracesSampleRate: 0` unchanged).

## Verification

- `npm --prefix landing run build` ✅
- `git diff --check` ✅
- `npm run build` blocked by existing local setup gap: missing Convex generated files (`convex/_generated/*`). `npx convex codegen` also blocks because no `CONVEX_DEPLOYMENT` is configured in this checkout. No reported build errors referenced the new analytics files before the generated-file cascade.

## Vercel preview status

- `blind-bench-landing` preview is Ready ✅ — https://blind-bench-landing-git-feat-simple-gtm-h-a5e421-mogil-ventures.vercel.app
- `blindbench` app preview is Error ❌. This matches the local app-build boundary above: app builds need Convex deployment/codegen configuration in the preview environment. Landing changes are independently green.

## Decision / assumption

Simple architecture chosen: keep PostHog as the product/GTM source of truth and use Sentry only for health breadcrumbs, rather than turning Sentry transactions/logs into funnel analytics.