### PR TITLE
Add Cloudflare AI Gateway ingestion adapter

### DIFF
--- a/docs/cloudflare-first-eval-architecture.md
+++ b/docs/cloudflare-first-eval-architecture.md
@@ -6,7 +6,7 @@ Blind Bench should sit above Cloudflare AI Gateway rather than replace it. Cloud
 
 ```mermaid
 flowchart LR
-  A[Pennie AI apps\nMigo / Eavesly / Jeeves] --> B[Cloudflare AI Gateway]
+  A[Customer AI apps\nVoice / chat / agent workflows] --> B[Cloudflare AI Gateway]
   B --> C[AI Gateway logs / Logpush / API export]
   C --> D[Blind Bench CF adapter\nnormalize JSONL]
   D --> E[Normalized trace rows]
@@ -25,9 +25,9 @@ flowchart LR
 | Raw request/response logs | Cloudflare AI Gateway | Source of raw model-call facts, provider/model, token/cost/latency, DLP, feedback, log IDs. |
 | Trace normalization | Blind Bench | Convert heterogeneous AI Gateway exports into stable portable trace rows. |
 | Eval semantics | Blind Bench | Expected behavior, scorer assignments, regression packs, review state, scorecards. |
-| Pennie domain labels | Pennie-scoped Blind Bench workspace | Pennie data stays scoped to Pennie and is not generalized into reusable Blind Bench assets. |
+| Customer domain labels | Customer-scoped Blind Bench workspace | customer data stays scoped to customer and is not generalized into reusable Blind Bench assets. |
 | Scorer execution | Blind Bench local/CI runner | Deterministic by default; LLM judges behind explicit provider adapters. |
-| Fine-tuning data | Pennie-scoped exports | Export only reviewed/approved examples or preference data. |
+| Fine-tuning data | Customer-scoped exports | Export only reviewed/approved examples or preference data. |
 
 ## Raw Cloudflare fields vs normalized fields
 
@@ -58,9 +58,9 @@ flowchart LR
 | `metadata.release` | `release` |
 | `metadata.environment` | `environment` |
 
-## Pennie metadata conventions
+## Customer metadata conventions
 
-Pennie AI calls should attach metadata where possible:
+Customer AI calls should attach metadata where possible:
 
 ```json
 {
@@ -77,11 +77,11 @@ Recommended app-specific conventions:
 
 - **Eavesly**: `module` should name the QA or alerting module, e.g. `disposition_review`, `qa_summary`, `manager_insights`.
 - **Migo**: `module` should name the summary/chat workflow, e.g. `summary`, `tradelines`, `customer_sms`.
-- **Jeeves / Pennie Systems AI**: include `module: "systems_agent"` plus sidecar metadata for harness name/version and tool policy when Cloudflare metadata is too small.
+- **Agent harnesses**: include `module: "systems_agent"` plus sidecar metadata for harness name/version and tool policy when Cloudflare metadata is too small.
 
 ## Metadata sidecar
 
-Cloudflare custom metadata may be too small for rich eval context. Store large or sensitive context in a Pennie-controlled sidecar keyed by one or more stable source IDs:
+Cloudflare custom metadata may be too small for rich eval context. Store large or sensitive context in a customer-controlled sidecar keyed by one or more stable source IDs:
 
 ```text
 trace_sidecar[log_id | event_id | trace_id] = {
@@ -96,15 +96,15 @@ trace_sidecar[log_id | event_id | trace_id] = {
 }
 ```
 
-The adapter supports a `metadataSidecar` map so normalized trace rows can merge Cloudflare metadata with Pennie-owned context without forcing everything into Cloudflare.
+The adapter supports a `metadataSidecar` map so normalized trace rows can merge Cloudflare metadata with customer-owned context without forcing everything into Cloudflare.
 
 ## Data boundaries
 
-- Do not commit real Pennie traces, call transcripts, account data, phone numbers, emails, or secrets to the Blind Bench repo.
-- Pennie-specific eval packs and reviewed examples remain Pennie-scoped.
+- Do not commit real customer traces, call transcripts, account data, phone numbers, emails, or secrets to the Blind Bench repo.
+- Customer-specific eval packs and reviewed examples remain customer-scoped.
 - Reusable Blind Bench assets should be generic scorer code, schemas, docs, and synthetic examples only.
 - Production traces become eval cases only after redaction/scope review.
-- Fine-tuning exports should contain only reviewed/approved Pennie-scoped examples.
+- Fine-tuning exports should contain only reviewed/approved customer-scoped examples.
 
 ## Build-vs-buy
 
@@ -127,7 +127,7 @@ Use Blind Bench for:
 - CI gates
 - fine-tuning-ready exports
 
-Add **Braintrust** or **Langfuse** only if Blind Bench needs a borrowed observability/annotation layer that Cloudflare + the Blind Bench review workflow cannot cover. They should not become the canonical source of Pennie eval semantics by default.
+Add **Braintrust** or **Langfuse** only if Blind Bench needs a borrowed observability/annotation layer that Cloudflare + the Blind Bench review workflow cannot cover. They should not become the canonical source of customer eval semantics by default.
 
 ## Current MVP source path
 

--- a/docs/cloudflare-first-eval-architecture.md
+++ b/docs/cloudflare-first-eval-architecture.md
@@ -1,0 +1,143 @@
+# Cloudflare-first eval architecture
+
+Blind Bench should sit above Cloudflare AI Gateway rather than replace it. Cloudflare remains the raw model-call observability layer; Blind Bench owns eval semantics, human review, regression datasets, scorecards, and CI gates.
+
+## Component flow
+
+```mermaid
+flowchart LR
+  A[Pennie AI apps\nMigo / Eavesly / Jeeves] --> B[Cloudflare AI Gateway]
+  B --> C[AI Gateway logs / Logpush / API export]
+  C --> D[Blind Bench CF adapter\nnormalize JSONL]
+  D --> E[Normalized trace rows]
+  E --> F[Eval case seeds]
+  F --> G[Human review + dataset curation]
+  G --> H[Regression packs]
+  H --> I[Local/CI runner + scorers]
+  I --> J[Scorecards + deploy decisions]
+  G --> K[Fine-tuning-ready exports]
+```
+
+## Ownership boundaries
+
+| Layer | Owner | Notes |
+| --- | --- | --- |
+| Raw request/response logs | Cloudflare AI Gateway | Source of raw model-call facts, provider/model, token/cost/latency, DLP, feedback, log IDs. |
+| Trace normalization | Blind Bench | Convert heterogeneous AI Gateway exports into stable portable trace rows. |
+| Eval semantics | Blind Bench | Expected behavior, scorer assignments, regression packs, review state, scorecards. |
+| Pennie domain labels | Pennie-scoped Blind Bench workspace | Pennie data stays scoped to Pennie and is not generalized into reusable Blind Bench assets. |
+| Scorer execution | Blind Bench local/CI runner | Deterministic by default; LLM judges behind explicit provider adapters. |
+| Fine-tuning data | Pennie-scoped exports | Export only reviewed/approved examples or preference data. |
+
+## Raw Cloudflare fields vs normalized fields
+
+| Cloudflare / export field family | Normalized Blind Bench field |
+| --- | --- |
+| `account_id`, `account.id` | `source_ids.account_id` |
+| `gateway_id`, `gateway.id` | `source_ids.gateway_id` |
+| `log_id`, `id`, `log.id` | `source_ids.log_id` |
+| `event_id`, `event.id` | `source_ids.event_id` |
+| `timestamp`, `created_at`, `datetime` | `timestamp` |
+| `provider` | `provider` |
+| `model`, `request.model`, `response.model` | `model` |
+| `status`, `response.status`, `error.type` | `status` |
+| `request`, `request_body`, `payload.request` | `messages[]` plus redaction notes |
+| `response`, `response_body`, `payload.response` | `output_text` plus redaction notes |
+| `usage.input_tokens`, `tokens_in` | `usage.input_tokens` |
+| `usage.output_tokens`, `tokens_out` | `usage.output_tokens` |
+| `usage.total_tokens`, `tokens_total` | `usage.total_tokens` |
+| `cost`, `cost_usd`, `usage.cost_usd` | `cost_usd` |
+| `duration`, `duration_ms`, `latency_ms` | `duration_ms` |
+| `cached`, `cache.cached` | `cached` |
+| `dlp.action`, `dlp.flagged` | `dlp` |
+| `feedback`, `human_feedback`, `feedback.rating` | `human_feedback` |
+| `metadata.product` | `product` |
+| `metadata.module` | `module` |
+| `metadata.prompt_version` | `prompt_version` |
+| `metadata.variant` | `variant` |
+| `metadata.release` | `release` |
+| `metadata.environment` | `environment` |
+
+## Pennie metadata conventions
+
+Pennie AI calls should attach metadata where possible:
+
+```json
+{
+  "product": "eavesly|migo|jeeves",
+  "module": "payoff_summary|qa_review|migo_summary|systems_agent",
+  "prompt_version": "pv_...",
+  "variant": "control|candidate|experiment_name",
+  "release": "rel_...",
+  "environment": "staging|production"
+}
+```
+
+Recommended app-specific conventions:
+
+- **Eavesly**: `module` should name the QA or alerting module, e.g. `disposition_review`, `qa_summary`, `manager_insights`.
+- **Migo**: `module` should name the summary/chat workflow, e.g. `summary`, `tradelines`, `customer_sms`.
+- **Jeeves / Pennie Systems AI**: include `module: "systems_agent"` plus sidecar metadata for harness name/version and tool policy when Cloudflare metadata is too small.
+
+## Metadata sidecar
+
+Cloudflare custom metadata may be too small for rich eval context. Store large or sensitive context in a Pennie-controlled sidecar keyed by one or more stable source IDs:
+
+```text
+trace_sidecar[log_id | event_id | trace_id] = {
+  prompt_template_id,
+  prompt_version,
+  app_record_id_hash,
+  harness_name,
+  harness_version,
+  tool_policy_id,
+  reviewer_assignment,
+  redaction_notes
+}
+```
+
+The adapter supports a `metadataSidecar` map so normalized trace rows can merge Cloudflare metadata with Pennie-owned context without forcing everything into Cloudflare.
+
+## Data boundaries
+
+- Do not commit real Pennie traces, call transcripts, account data, phone numbers, emails, or secrets to the Blind Bench repo.
+- Pennie-specific eval packs and reviewed examples remain Pennie-scoped.
+- Reusable Blind Bench assets should be generic scorer code, schemas, docs, and synthetic examples only.
+- Production traces become eval cases only after redaction/scope review.
+- Fine-tuning exports should contain only reviewed/approved Pennie-scoped examples.
+
+## Build-vs-buy
+
+Use Cloudflare for:
+
+- raw model-call logging
+- cost/latency/provider/model metadata
+- DLP and feedback fields
+- Logpush/API/export plumbing
+- operational cost/speed views
+
+Use Blind Bench for:
+
+- trace normalization
+- eval-case creation
+- human review
+- regression datasets
+- scorer assignments and execution
+- JSON/Markdown scorecards
+- CI gates
+- fine-tuning-ready exports
+
+Add **Braintrust** or **Langfuse** only if Blind Bench needs a borrowed observability/annotation layer that Cloudflare + the Blind Bench review workflow cannot cover. They should not become the canonical source of Pennie eval semantics by default.
+
+## Current MVP source path
+
+The first implemented source path is exported JSONL:
+
+```ts
+parseCloudflareAiGatewayJsonl(text)
+  -> NormalizedBlindBenchTrace[]
+  -> toJsonl(rows)
+  -> convertTraceToEvalCase(row)
+```
+
+This is enough for Logpush/API snapshots and CI tests without live Cloudflare credentials.

--- a/docs/eval-case-schema.md
+++ b/docs/eval-case-schema.md
@@ -1,6 +1,6 @@
 # Eval case schema & scorer contract
 
-Portable foundation for grading agent behavior across Pennie / Eavesly / Migo and
+Portable foundation for grading agent behavior across support, voice, chat, and agentic workflows and
 future Blind Bench customers. Source of truth: `src/lib/evals/evalCase.ts` (zod).
 Types are inferred from the zod schemas; JSON Schema artifacts are exported for
 non-TypeScript consumers (`schemas/*.schema.json`).
@@ -59,7 +59,7 @@ expected {
 - **`privacy_class`** — `public` | `internal` | `confidential` | `pii` | `phi`.
   Real data must be classed honestly so a runner can gate where outputs are stored.
 - **Synthetic cases must use fake data.** The example cases tag fake identifiers with
-  `TEST`; a test enforces `source === "synthetic"`. Do not commit real Pennie/customer PII.
+  `TEST`; a test enforces `source === "synthetic"`. Do not commit real customer PII.
 - **`data_policy`** declares which data the agent may read/emit and a retention
   expectation (e.g. `ephemeral`, `do_not_store_call_audio`); labels are open strings so
   each product names its own sources.

--- a/docs/eval-case-schema.md
+++ b/docs/eval-case-schema.md
@@ -5,7 +5,9 @@ future Blind Bench customers. Source of truth: `src/lib/evals/evalCase.ts` (zod)
 Types are inferred from the zod schemas; JSON Schema artifacts are exported for
 non-TypeScript consumers (`schemas/*.schema.json`).
 
-This is foundation only — no runner, CLI, or UI yet.
+This is the portable schema foundation. See also:
+
+- [Cloudflare-first eval architecture](./cloudflare-first-eval-architecture.md)
 
 ## Files
 

--- a/src/lib/evals/cloudflareAiGateway.test.ts
+++ b/src/lib/evals/cloudflareAiGateway.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+import { EvalCase } from "./evalCase";
+import {
+  convertTraceToEvalCase,
+  normalizeCloudflareAiGatewayLog,
+  parseCloudflareAiGatewayJsonl,
+  stableStringify,
+  toJsonl,
+  type CloudflareAiGatewayLog,
+} from "./cloudflareAiGateway";
+
+const chatRecord: CloudflareAiGatewayLog = {
+  account_id: "acct_TEST_cloudflare",
+  gateway_id: "gw_TEST_pennie",
+  log_id: "log_TEST_001",
+  event_id: "evt_TEST_001",
+  timestamp: "2026-06-23T12:00:00Z",
+  provider: "anthropic",
+  model: "claude-sonnet-4-0",
+  status: "success",
+  cached: false,
+  request: {
+    messages: [
+      { role: "system", content: "You are a synthetic support assistant." },
+      { role: "user", content: "What is my synthetic payoff?" },
+    ],
+  },
+  response: { choices: [{ message: { content: "Your synthetic payoff is $123.45." } }] },
+  usage: { input_tokens: 42, output_tokens: 12, total_tokens: 54, cost_usd: 0.0021 },
+  duration_ms: 1180,
+  metadata: {
+    product: "eavesly",
+    module: "payoff_summary",
+    prompt_version: "pv_TEST_001",
+    variant: "control",
+    release: "rel_TEST_2026_06",
+    environment: "staging",
+  },
+};
+
+const redactedRecord: CloudflareAiGatewayLog = {
+  account_id: "acct_TEST_cloudflare",
+  gateway_id: "gw_TEST_pennie",
+  log_id: "log_TEST_002",
+  timestamp: "2026-06-23T12:01:00Z",
+  provider: "openai",
+  model: "gpt-4.1-mini",
+  status: "success",
+  request: { redacted: true },
+  response: undefined,
+  metadata: { product: "migo", module: "summary", environment: "staging" },
+};
+
+const feedbackDlpRecord: CloudflareAiGatewayLog = {
+  account_id: "acct_TEST_cloudflare",
+  gateway_id: "gw_TEST_pennie",
+  log_id: "log_TEST_003",
+  event_id: "evt_TEST_003",
+  timestamp: "2026-06-23T12:02:00Z",
+  provider: "anthropic",
+  model: "claude-haiku-4-0",
+  status: "success",
+  request: { prompt: "Summarize synthetic call TEST-CALL-003" },
+  response: { text: "Synthetic summary created." },
+  tokens_in: 30,
+  tokens_out: 8,
+  cost: 0.0007,
+  duration: 640,
+  dlp: { action: "allow", flagged: false },
+  human_feedback: { value: "thumbs_down", rating: 0 },
+  metadata: { product: "eavesly", module: "qa_review" },
+};
+
+describe("Cloudflare AI Gateway adapter", () => {
+  it("normalizes a synthetic chat-completion log", () => {
+    const row = normalizeCloudflareAiGatewayLog(chatRecord);
+    expect(row.trace_id).toMatch(/^cf-aigw-/);
+    expect(row.product).toBe("eavesly");
+    expect(row.module).toBe("payoff_summary");
+    expect(row.prompt_version).toBe("pv_TEST_001");
+    expect(row.messages).toHaveLength(2);
+    expect(row.output_text).toBe("Your synthetic payoff is $123.45.");
+    expect(row.cost_usd).toBe(0.0021);
+    expect(row.duration_ms).toBe(1180);
+    expect(row.redaction.request_missing).toBe(false);
+    expect(row.redaction.response_missing).toBe(false);
+  });
+
+  it("handles redacted/missing request and response safely", () => {
+    const row = normalizeCloudflareAiGatewayLog(redactedRecord);
+    expect(row.product).toBe("migo");
+    expect(row.messages).toEqual([]);
+    expect(row.output_text).toBeUndefined();
+    expect(row.redaction.request_missing).toBe(true);
+    expect(row.redaction.response_missing).toBe(true);
+    expect(row.redaction.notes).toContain("request_has_no_messages");
+    expect(row.redaction.notes).toContain("response_missing_or_redacted");
+  });
+
+  it("maps DLP and human feedback fields", () => {
+    const row = normalizeCloudflareAiGatewayLog(feedbackDlpRecord);
+    expect(row.dlp).toEqual({ action: "allow", flagged: false });
+    expect(row.human_feedback).toEqual({ value: "thumbs_down", rating: 0 });
+    expect(row.usage.input_tokens).toBe(30);
+    expect(row.usage.output_tokens).toBe(8);
+  });
+
+  it("parses exported JSONL and writes deterministic normalized JSONL", () => {
+    const input = [chatRecord, feedbackDlpRecord].map((r) => JSON.stringify(r)).join("\n");
+    const rows = parseCloudflareAiGatewayJsonl(input);
+    expect(rows).toHaveLength(2);
+    expect(toJsonl(rows)).toBe(toJsonl(rows));
+    expect(toJsonl(rows)).toContain("cf-aigw-");
+  });
+
+  it("generates stable ids independent of object key order", () => {
+    const a = normalizeCloudflareAiGatewayLog(chatRecord).trace_id;
+    const b = normalizeCloudflareAiGatewayLog(JSON.parse(stableStringify(chatRecord))).trace_id;
+    expect(a).toBe(b);
+  });
+
+  it("merges sidecar metadata when Cloudflare metadata is too small", () => {
+    const row = normalizeCloudflareAiGatewayLog(
+      { ...chatRecord, metadata: { product: "eavesly" } },
+      { metadataSidecar: { log_TEST_001: { module: "sidecar_module", prompt_version: "sidecar_prompt" } } },
+    );
+    expect(row.module).toBe("sidecar_module");
+    expect(row.prompt_version).toBe("sidecar_prompt");
+  });
+
+  it("converts a normalized trace into a production-log eval case seed", () => {
+    const row = normalizeCloudflareAiGatewayLog(chatRecord);
+    const evalCase = EvalCase.parse(convertTraceToEvalCase(row, { tags: ["smoke"] }));
+    expect(evalCase.source).toBe("production_log");
+    expect(evalCase.product).toBe("eavesly");
+    expect(evalCase.input.messages).toHaveLength(2);
+    expect(evalCase.tags).toContain("cloudflare-ai-gateway");
+  });
+});

--- a/src/lib/evals/cloudflareAiGateway.test.ts
+++ b/src/lib/evals/cloudflareAiGateway.test.ts
@@ -11,7 +11,7 @@ import {
 
 const chatRecord: CloudflareAiGatewayLog = {
   account_id: "acct_TEST_cloudflare",
-  gateway_id: "gw_TEST_pennie",
+  gateway_id: "gw_TEST_customer",
   log_id: "log_TEST_001",
   event_id: "evt_TEST_001",
   timestamp: "2026-06-23T12:00:00Z",
@@ -40,7 +40,7 @@ const chatRecord: CloudflareAiGatewayLog = {
 
 const redactedRecord: CloudflareAiGatewayLog = {
   account_id: "acct_TEST_cloudflare",
-  gateway_id: "gw_TEST_pennie",
+  gateway_id: "gw_TEST_customer",
   log_id: "log_TEST_002",
   timestamp: "2026-06-23T12:01:00Z",
   provider: "openai",
@@ -53,7 +53,7 @@ const redactedRecord: CloudflareAiGatewayLog = {
 
 const feedbackDlpRecord: CloudflareAiGatewayLog = {
   account_id: "acct_TEST_cloudflare",
-  gateway_id: "gw_TEST_pennie",
+  gateway_id: "gw_TEST_customer",
   log_id: "log_TEST_003",
   event_id: "evt_TEST_003",
   timestamp: "2026-06-23T12:02:00Z",

--- a/src/lib/evals/cloudflareAiGateway.ts
+++ b/src/lib/evals/cloudflareAiGateway.ts
@@ -228,7 +228,7 @@ export function convertTraceToEvalCase(
     expected: {
       privacy_class: trace.redaction.request_missing ? "internal" : "confidential",
       must: trace.output_text ? ["Review candidate output against the original production output."] : [],
-      data_policy: { retention: "pennie_scoped_review_only" },
+      data_policy: { retention: "customer_scoped_review_only" },
     },
     metadata: {
       suite_id: options.suiteId ?? "cloudflare-ai-gateway-import",

--- a/src/lib/evals/cloudflareAiGateway.ts
+++ b/src/lib/evals/cloudflareAiGateway.ts
@@ -1,0 +1,241 @@
+/**
+ * Cloudflare AI Gateway exported-log adapter.
+ *
+ * Supported source path for this MVP: local/exported JSONL records (Logpush/API export
+ * snapshots). No network calls and no Convex/UI coupling.
+ */
+import { createHash } from "node:crypto";
+import { z } from "zod/v4";
+import type { EvalCaseInput } from "./evalCase";
+
+const JsonRecord = z.record(z.string(), z.unknown());
+
+export const CloudflareAiGatewayLog = JsonRecord;
+export type CloudflareAiGatewayLog = z.infer<typeof CloudflareAiGatewayLog>;
+
+export const NormalizedBlindBenchTrace = z.object({
+  trace_id: z.string(),
+  source: z.literal("cloudflare_ai_gateway"),
+  source_ids: z.object({
+    account_id: z.string().optional(),
+    gateway_id: z.string().optional(),
+    log_id: z.string().optional(),
+    event_id: z.string().optional(),
+  }),
+  product: z.string().optional(),
+  module: z.string().optional(),
+  prompt_version: z.string().optional(),
+  variant: z.string().optional(),
+  release: z.string().optional(),
+  environment: z.string().optional(),
+  timestamp: z.string().optional(),
+  provider: z.string().optional(),
+  model: z.string().optional(),
+  status: z.string().optional(),
+  request_type: z.string().optional(),
+  messages: z.array(z.object({ role: z.string(), content: z.string() })).default([]),
+  output_text: z.string().optional(),
+  usage: z.object({
+    input_tokens: z.number().optional(),
+    output_tokens: z.number().optional(),
+    total_tokens: z.number().optional(),
+  }),
+  cost_usd: z.number().optional(),
+  duration_ms: z.number().optional(),
+  cached: z.boolean().optional(),
+  dlp: z.object({ action: z.string().optional(), flagged: z.boolean().optional() }),
+  human_feedback: z.object({ value: z.string().optional(), rating: z.number().optional() }),
+  redaction: z.object({ request_missing: z.boolean(), response_missing: z.boolean(), notes: z.array(z.string()) }),
+  metadata: JsonRecord,
+  raw_field_paths: z.object({ request: z.string().optional(), response: z.string().optional() }),
+});
+export type NormalizedBlindBenchTrace = z.infer<typeof NormalizedBlindBenchTrace>;
+
+export interface NormalizeOptions {
+  defaultProduct?: string;
+  defaultEnvironment?: string;
+  metadataSidecar?: Record<string, Record<string, unknown>>;
+}
+
+const asRecord = (v: unknown): Record<string, unknown> | undefined =>
+  v && typeof v === "object" && !Array.isArray(v) ? (v as Record<string, unknown>) : undefined;
+const asArray = (v: unknown): unknown[] => (Array.isArray(v) ? v : []);
+const str = (v: unknown): string | undefined => (typeof v === "string" && v.length ? v : undefined);
+const num = (v: unknown): number | undefined => (typeof v === "number" && Number.isFinite(v) ? v : undefined);
+const bool = (v: unknown): boolean | undefined => (typeof v === "boolean" ? v : undefined);
+
+const get = (obj: unknown, paths: string[]): unknown => {
+  for (const path of paths) {
+    let cur: unknown = obj;
+    for (const key of path.split(".")) cur = asRecord(cur)?.[key];
+    if (cur !== undefined && cur !== null) return cur;
+  }
+  return undefined;
+};
+
+const getRecord = (obj: unknown, paths: string[]) => asRecord(get(obj, paths));
+const getStr = (obj: unknown, paths: string[]) => str(get(obj, paths));
+const getNum = (obj: unknown, paths: string[]) => num(get(obj, paths));
+const getBool = (obj: unknown, paths: string[]) => bool(get(obj, paths));
+
+const stableHash = (value: unknown): string =>
+  createHash("sha256").update(stableStringify(value)).digest("hex").slice(0, 16);
+
+export function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(",")}]`;
+  const obj = value as Record<string, unknown>;
+  return `{${Object.keys(obj).sort().map((k) => `${JSON.stringify(k)}:${stableStringify(obj[k])}`).join(",")}}`;
+}
+
+function extractMessages(request: unknown): { messages: { role: string; content: string }[]; notes: string[] } {
+  const notes: string[] = [];
+  const req = asRecord(request);
+  if (!req) return { messages: [], notes: ["request_missing_or_redacted"] };
+  const input = asRecord(req.input);
+  const rawMessages = asArray(req.messages ?? input?.messages);
+  const messages = rawMessages.flatMap((m) => {
+    const rec = asRecord(m);
+    const role = str(rec?.role);
+    const content = str(rec?.content);
+    return role && content ? [{ role, content }] : [];
+  });
+  if (messages.length === 0) {
+    const prompt = str(req.prompt ?? req.input);
+    if (prompt) messages.push({ role: "user", content: prompt });
+  }
+  if (messages.length === 0) notes.push("request_has_no_messages");
+  return { messages, notes };
+}
+
+function extractOutput(response: unknown): { text?: string; notes: string[] } {
+  const notes: string[] = [];
+  const res = asRecord(response);
+  if (!res) return { notes: ["response_missing_or_redacted"] };
+  const direct = str(res.output_text ?? res.text ?? res.content);
+  if (direct) return { text: direct, notes };
+  const choice0 = asRecord(asArray(res.choices)[0]);
+  const msg = asRecord(choice0?.message);
+  const text = str(msg?.content ?? choice0?.text);
+  if (!text) notes.push("response_has_no_text");
+  return { text, notes };
+}
+
+function sidecarKey(record: CloudflareAiGatewayLog): string | undefined {
+  return getStr(record, ["log_id", "id", "event.id", "event_id", "cf.ray_id"]);
+}
+
+export function normalizeCloudflareAiGatewayLog(
+  record: CloudflareAiGatewayLog,
+  options: NormalizeOptions = {},
+): NormalizedBlindBenchTrace {
+  const request = get(record, ["request", "request_body", "payload.request", "event.request"]);
+  const response = get(record, ["response", "response_body", "payload.response", "event.response"]);
+  const logId = getStr(record, ["log_id", "id", "log.id"]);
+  const eventId = getStr(record, ["event_id", "event.id", "cf.event_id"]);
+  const accountId = getStr(record, ["account_id", "account.id"]);
+  const gatewayId = getStr(record, ["gateway_id", "gateway.id"]);
+  const metadata = {
+    ...(getRecord(record, ["metadata", "request.metadata", "event.metadata"]) ?? {}),
+    ...(sidecarKey(record) ? (options.metadataSidecar?.[sidecarKey(record)!] ?? {}) : {}),
+  };
+  const { messages, notes: requestNotes } = extractMessages(request);
+  const { text: outputText, notes: responseNotes } = extractOutput(response);
+  const seed = { accountId, gatewayId, logId, eventId, ts: getStr(record, ["timestamp", "created_at", "datetime"]), model: getStr(record, ["model", "request.model", "response.model"]), request_hash: stableHash(request ?? "missing") };
+
+  return NormalizedBlindBenchTrace.parse({
+    trace_id: `cf-aigw-${stableHash(seed)}`,
+    source: "cloudflare_ai_gateway",
+    source_ids: { account_id: accountId, gateway_id: gatewayId, log_id: logId, event_id: eventId },
+    product: str(metadata.product) ?? options.defaultProduct,
+    module: str(metadata.module),
+    prompt_version: str(metadata.prompt_version),
+    variant: str(metadata.variant),
+    release: str(metadata.release),
+    environment: str(metadata.environment) ?? options.defaultEnvironment,
+    timestamp: getStr(record, ["timestamp", "created_at", "datetime"]),
+    provider: getStr(record, ["provider", "request.provider", "response.provider"]),
+    model: getStr(record, ["model", "request.model", "response.model"]),
+    status: getStr(record, ["status", "response.status", "error.type"]),
+    request_type: getStr(record, ["request_type", "type"]),
+    messages,
+    output_text: outputText,
+    usage: {
+      input_tokens: getNum(record, ["tokens_in", "usage.input_tokens", "usage.prompt_tokens"]),
+      output_tokens: getNum(record, ["tokens_out", "usage.output_tokens", "usage.completion_tokens"]),
+      total_tokens: getNum(record, ["tokens_total", "usage.total_tokens"]),
+    },
+    cost_usd: getNum(record, ["cost", "cost_usd", "usage.cost_usd"]),
+    duration_ms: getNum(record, ["duration", "duration_ms", "latency_ms"]),
+    cached: getBool(record, ["cached", "cache.cached"]),
+    dlp: {
+      action: getStr(record, ["dlp.action", "dlp_action"]),
+      flagged: getBool(record, ["dlp.flagged", "dlp_flagged"]),
+    },
+    human_feedback: {
+      value: getStr(record, ["feedback", "human_feedback.value", "feedback.value"]),
+      rating: getNum(record, ["human_feedback.rating", "feedback.rating"]),
+    },
+    redaction: {
+      request_missing: messages.length === 0,
+      response_missing: outputText === undefined,
+      notes: [...requestNotes, ...responseNotes],
+    },
+    metadata,
+    raw_field_paths: {
+      request: request === undefined ? undefined : "request|request_body|payload.request|event.request",
+      response: response === undefined ? undefined : "response|response_body|payload.response|event.response",
+    },
+  });
+}
+
+export function parseCloudflareAiGatewayJsonl(
+  text: string,
+  options: NormalizeOptions = {},
+): NormalizedBlindBenchTrace[] {
+  return text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => normalizeCloudflareAiGatewayLog(CloudflareAiGatewayLog.parse(JSON.parse(line)), options));
+}
+
+export function toJsonl(rows: NormalizedBlindBenchTrace[]): string {
+  return rows.map((r) => stableStringify(r)).join("\n") + (rows.length ? "\n" : "");
+}
+
+export function convertTraceToEvalCase(
+  trace: NormalizedBlindBenchTrace,
+  options: { suiteId?: string; title?: string; tags?: string[] } = {},
+): EvalCaseInput {
+  return {
+    id: `case-${trace.trace_id}`,
+    product: trace.product ?? "unknown",
+    title: options.title ?? `${trace.product ?? "AI Gateway"} replay ${trace.trace_id}`,
+    description: "Replay seed generated from a normalized Cloudflare AI Gateway trace.",
+    source: "production_log",
+    tags: ["cloudflare-ai-gateway", "replay-seed", ...(options.tags ?? [])],
+    input: {
+      messages: trace.messages,
+      context: {
+        trace_id: trace.trace_id,
+        module: trace.module ?? null,
+        prompt_version: trace.prompt_version ?? null,
+        provider: trace.provider ?? null,
+        model: trace.model ?? null,
+      },
+    },
+    expected: {
+      privacy_class: trace.redaction.request_missing ? "internal" : "confidential",
+      must: trace.output_text ? ["Review candidate output against the original production output."] : [],
+      data_policy: { retention: "pennie_scoped_review_only" },
+    },
+    metadata: {
+      suite_id: options.suiteId ?? "cloudflare-ai-gateway-import",
+      trace_id: trace.trace_id,
+      source_ids: trace.source_ids,
+      output_text: trace.output_text,
+      scorers: [],
+    },
+  };
+}

--- a/src/lib/evals/evalCase.ts
+++ b/src/lib/evals/evalCase.ts
@@ -14,7 +14,7 @@
  *
  * Deliberately platform-agnostic: `product`, tool names, data-policy labels, and
  * input shape are open strings/records, not closed enums, so the same schema
- * serves Pennie / Eavesly / Migo and future Blind Bench customers.
+ * serves support, voice, chat, and agentic workflows and future Blind Bench customers.
  */
 // zod 3.25 exposes the v4 API on this subpath; use it for JSON Schema export.
 import { z } from "zod/v4";

--- a/src/lib/evals/examples.ts
+++ b/src/lib/evals/examples.ts
@@ -1,5 +1,5 @@
 /**
- * SYNTHETIC eval cases — fake data ONLY. No real Pennie/customer/PII content.
+ * SYNTHETIC eval cases — fake data ONLY. No real customer/PII content.
  *
  * Two worked examples (one Eavesly, one Migo) demonstrating the EvalCase schema
  * across scenario sources, expected tool calls, escalation, data policy, and


### PR DESCRIPTION
## Summary

Adds the Cloudflare-first ingestion foundation for Blind Bench as a customer-generic SaaS capability.

- Adds a local/exported JSONL adapter for Cloudflare AI Gateway logs.
- Normalizes permissive AI Gateway records into deterministic Blind Bench trace rows.
- Maps request/response, provider/model, timestamp/status, usage, cost, duration, cache, DLP, human feedback, and metadata.
- Handles missing/redacted prompts and responses safely with redaction notes instead of throwing.
- Supports sidecar metadata keyed by log/event IDs when Cloudflare custom metadata is insufficient.
- Converts normalized traces into replay/eval-case seeds using the #237 eval schema.
- Adds synthetic Cloudflare fixtures and tests.
- Adds Cloudflare-first architecture doc with component flow, field mapping, customer metadata conventions, build-vs-buy boundaries, and customer data-scope rules.

Closes #220
Closes #221

## Verification

- ✅ `npm run test:evals` — 21 tests passed on this branch
- ✅ focused TypeScript check for eval files:
  `npx tsc --ignoreConfig --noEmit --skipLibCheck --module ESNext --moduleResolution bundler --target ES2022 --types node --strict --noUnusedLocals --noUnusedParameters --noUncheckedIndexedAccess src/lib/evals/*.ts`

## Notes

No live Cloudflare calls are made. This supports the first concrete source path via exported JSONL / Logpush-style snapshots only. All fixtures are synthetic `TEST` records; no customer data or secrets are included.