### PR TITLE
Add agent harness trace normalization

### DIFF
--- a/docs/agent-harness-traces.md
+++ b/docs/agent-harness-traces.md
@@ -1,0 +1,123 @@
+# Agent harness trace capture
+
+Blind Bench needs to evaluate agentic Pennie workflows such as Jeeves / Pennie Systems AI, not only single chat-completion calls. This document defines the first normalized agent-run trace shape and the first concrete ingest path.
+
+## First source path: Jeeves / Clog run export
+
+The first supported input is a permissive JSON export from a Clog-managed Jeeves-style run:
+
+```ts
+normalizeJeevesClogRun(raw)
+```
+
+Expected fields are intentionally simple:
+
+```json
+{
+  "run_id": "JEEVES-RUN-TEST-001",
+  "product": "jeeves",
+  "module": "systems_agent",
+  "harness": { "name": "jeeves_clog", "version": "TEST-v1", "sdk": "clog" },
+  "model": "claude-sonnet-4-0",
+  "messages": [{ "role": "user", "content": "..." }],
+  "steps": [
+    { "type": "tool_call", "id": "tool-1", "name": "lookup_account", "args": {} },
+    { "type": "tool_result", "id": "tool-1", "name": "lookup_account", "result": {} },
+    { "type": "policy_event", "policy": "no_destructive_action", "action": "allow" }
+  ],
+  "final_answer": "...",
+  "usage": { "cost_usd": 0.01, "duration_ms": 2100, "total_tokens": 900 }
+}
+```
+
+No SDK integration is required yet. The capture path is intentionally export/import first.
+
+## Normalized shape
+
+`AgentRunTrace` captures:
+
+- source trace/run IDs
+- harness name/version/SDK
+- product/module/environment/model
+- ordered steps
+- messages
+- tool calls
+- tool results
+- policy events
+- state snapshots
+- final answer
+- cost/latency/tokens
+- privacy class and redaction notes
+
+## Privacy and redaction
+
+Tool arguments, tool results, and state snapshots may contain sensitive payloads. The normalizer creates both raw and redacted variants for sensitive step types.
+
+Default reviewer/scorer projection uses:
+
+```ts
+toScorerVisibleAgentRun(trace, "blind_view")
+```
+
+This redacts keys matching sensitive categories such as:
+
+- SSN / social
+- phone
+- email
+- address
+- token / secret / password
+- account number
+- card
+- DOB
+
+Internal view is explicit:
+
+```ts
+toScorerVisibleAgentRun(trace, "internal_view")
+```
+
+Only use internal view in controlled Pennie-scoped debugging. Blind/evaluator views should not expose raw tool payloads by default.
+
+## Scorer-visible projection
+
+Scorers should read the projected view, not the raw trace:
+
+```ts
+{
+  trace_id,
+  harness,
+  product,
+  model,
+  messages,
+  tool_calls: [{ tool_call_id, name, args, index }],
+  tool_results: [{ tool_call_id, name, result, index }],
+  policy_events: [{ policy, action, reason, index }],
+  final_answer
+}
+```
+
+This preserves enough evidence for:
+
+- expected tool use
+- forbidden tool use
+- escalation / handoff behavior
+- cross-context leakage checks
+- policy event checks
+- final answer quality review
+
+## Eval-case seed
+
+Agent runs can be turned into replay eval-case seeds:
+
+```ts
+agentTraceToEvalCase(trace)
+```
+
+The eval case stores messages and scorer-visible tool/policy context while keeping raw sensitive payloads out of the default review surface.
+
+## Non-goals
+
+- No LangGraph/LangSmith/Phoenix replacement.
+- No sandboxed agent execution yet.
+- No automatic capture from production Jeeves agents yet.
+- No Pennie production data committed to the repo.

--- a/docs/agent-harness-traces.md
+++ b/docs/agent-harness-traces.md
@@ -1,6 +1,6 @@
 # Agent harness trace capture
 
-Blind Bench needs to evaluate agentic Pennie workflows such as Jeeves / Pennie Systems AI, not only single chat-completion calls. This document defines the first normalized agent-run trace shape and the first concrete ingest path.
+Blind Bench needs to evaluate agentic customer workflows such as support and operations agents, not only single chat-completion calls. This document defines the first normalized agent-run trace shape and the first concrete ingest path.
 
 ## First source path: Jeeves / Clog run export
 
@@ -76,7 +76,7 @@ Internal view is explicit:
 toScorerVisibleAgentRun(trace, "internal_view")
 ```
 
-Only use internal view in controlled Pennie-scoped debugging. Blind/evaluator views should not expose raw tool payloads by default.
+Only use internal view in controlled customer-scoped debugging. Blind/evaluator views should not expose raw tool payloads by default.
 
 ## Scorer-visible projection
 
@@ -120,4 +120,4 @@ The eval case stores messages and scorer-visible tool/policy context while keepi
 - No LangGraph/LangSmith/Phoenix replacement.
 - No sandboxed agent execution yet.
 - No automatic capture from production Jeeves agents yet.
-- No Pennie production data committed to the repo.
+- No customer production data committed to the repo.

--- a/docs/eval-case-schema.md
+++ b/docs/eval-case-schema.md
@@ -1,6 +1,6 @@
 # Eval case schema & scorer contract
 
-Portable foundation for grading agent behavior across Pennie / Eavesly / Migo and
+Portable foundation for grading agent behavior across support, voice, chat, and agentic workflows and
 future Blind Bench customers. Source of truth: `src/lib/evals/evalCase.ts` (zod).
 Types are inferred from the zod schemas; JSON Schema artifacts are exported for
 non-TypeScript consumers (`schemas/*.schema.json`).
@@ -57,7 +57,7 @@ expected {
 - **`privacy_class`** — `public` | `internal` | `confidential` | `pii` | `phi`.
   Real data must be classed honestly so a runner can gate where outputs are stored.
 - **Synthetic cases must use fake data.** The example cases tag fake identifiers with
-  `TEST`; a test enforces `source === "synthetic"`. Do not commit real Pennie/customer PII.
+  `TEST`; a test enforces `source === "synthetic"`. Do not commit real customer PII.
 - **`data_policy`** declares which data the agent may read/emit and a retention
   expectation (e.g. `ephemeral`, `do_not_store_call_audio`); labels are open strings so
   each product names its own sources.

--- a/src/lib/evals/agentTrace.test.ts
+++ b/src/lib/evals/agentTrace.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import { EvalCase } from "./evalCase";
+import {
+  agentTraceToEvalCase,
+  normalizeJeevesClogRun,
+  toScorerVisibleAgentRun,
+  type JeevesClogRunExport,
+} from "./agentTrace";
+
+const passingRun: JeevesClogRunExport = {
+  run_id: "JEEVES-RUN-TEST-001",
+  product: "jeeves",
+  module: "systems_agent",
+  environment: "staging",
+  harness: { name: "jeeves_clog", version: "TEST-v1", sdk: "clog" },
+  model: "claude-sonnet-4-0",
+  messages: [{ role: "user", content: "Can you check whether the synthetic account needs escalation?" }],
+  steps: [
+    { type: "tool_call", id: "tool-1", name: "lookup_account", args: { account_id: "ACCT-TEST-AGENT-001", phone: "+15550101010" } },
+    { type: "tool_result", id: "tool-1", name: "lookup_account", result: { status: "active", account_number: "TEST-SECRET-0001" } },
+    { type: "policy_event", policy: "no_destructive_action", action: "allow", reason: "read_only_lookup" },
+    { type: "tool_call", id: "tool-2", name: "create_escalation", args: { reason: "synthetic_hardship" } },
+  ],
+  final_answer: "I found the synthetic account and routed it to a specialist for review.",
+  usage: { cost_usd: 0.01, duration_ms: 2100, total_tokens: 900 },
+};
+
+const failingRun: JeevesClogRunExport = {
+  ...passingRun,
+  run_id: "JEEVES-RUN-TEST-002",
+  steps: [
+    { type: "tool_call", id: "tool-1", name: "delete_account", args: { account_id: "ACCT-TEST-AGENT-002", ssn: "123-45-6789" } },
+    { type: "tool_result", id: "tool-1", name: "delete_account", result: { ok: false, secret_token: "TEST-TOKEN-DO-NOT-SHOW" } },
+  ],
+  final_answer: "I tried to delete the account but it failed.",
+};
+
+describe("agent trace normalization", () => {
+  it("normalizes ordered agent steps with tool calls/results/final answer", () => {
+    const trace = normalizeJeevesClogRun(passingRun);
+    expect(trace.source).toBe("agent_harness");
+    expect(trace.steps).toHaveLength(4);
+    expect(trace.steps[0]?.type).toBe("tool_call");
+    expect(trace.final_answer).toContain("routed");
+    expect(trace.harness.name).toBe("jeeves_clog");
+  });
+
+  it("redacts sensitive tool args/results for blind scorer-visible view", () => {
+    const trace = normalizeJeevesClogRun(failingRun);
+    const visible = toScorerVisibleAgentRun(trace, "blind_view");
+    expect(visible.tool_calls[0]?.args).toMatchObject({ account_id: "ACCT-TEST-AGENT-002", ssn: "[REDACTED]" });
+    expect(visible.tool_results[0]?.result).toMatchObject({ ok: false, secret_token: "[REDACTED]" });
+    expect(JSON.stringify(visible)).not.toContain("123-45-6789");
+    expect(JSON.stringify(visible)).not.toContain("TEST-TOKEN-DO-NOT-SHOW");
+  });
+
+  it("keeps internal view available for controlled Pennie-only debugging", () => {
+    const trace = normalizeJeevesClogRun(failingRun);
+    const visible = toScorerVisibleAgentRun(trace, "internal_view");
+    expect(JSON.stringify(visible)).toContain("123-45-6789");
+  });
+
+  it("produces scorer-visible tool-call evidence for forbidden-tool checks", () => {
+    const trace = normalizeJeevesClogRun(failingRun);
+    const visible = toScorerVisibleAgentRun(trace);
+    expect(visible.tool_calls.map((t) => t.name)).toContain("delete_account");
+  });
+
+  it("converts agent trace into replay eval case seed", () => {
+    const trace = normalizeJeevesClogRun(passingRun);
+    const evalCase = EvalCase.parse(agentTraceToEvalCase(trace));
+    expect(evalCase.source).toBe("replay");
+    expect(evalCase.tags).toContain("agent-harness");
+    expect(JSON.stringify(evalCase.input.context)).toContain("create_escalation");
+  });
+
+  it("fixtures are synthetic TEST data only", () => {
+    const blob = JSON.stringify({ passingRun, failingRun });
+    for (const id of blob.match(/\b(?:ACCT|JEEVES-RUN)-[A-Z0-9-]+/g) ?? []) {
+      expect(id).toContain("TEST");
+    }
+  });
+});

--- a/src/lib/evals/agentTrace.test.ts
+++ b/src/lib/evals/agentTrace.test.ts
@@ -54,7 +54,7 @@ describe("agent trace normalization", () => {
     expect(JSON.stringify(visible)).not.toContain("TEST-TOKEN-DO-NOT-SHOW");
   });
 
-  it("keeps internal view available for controlled Pennie-only debugging", () => {
+  it("keeps internal view available for controlled customer-scoped debugging", () => {
     const trace = normalizeJeevesClogRun(failingRun);
     const visible = toScorerVisibleAgentRun(trace, "internal_view");
     expect(JSON.stringify(visible)).toContain("123-45-6789");

--- a/src/lib/evals/agentTrace.ts
+++ b/src/lib/evals/agentTrace.ts
@@ -1,0 +1,278 @@
+/**
+ * Normalized multi-step agent run traces for Jeeves/Pennie Systems style harnesses.
+ *
+ * This is capture/normalization only: no sandboxed agent execution and no provider
+ * SDK dependency. The concrete first ingest path is a permissive "Jeeves/Clog run"
+ * JSON export shape with messages, tool calls/results, policy events, and final answer.
+ */
+import { createHash } from "node:crypto";
+import { z } from "zod/v4";
+import type { EvalCaseInput } from "./evalCase";
+
+const JsonRecord = z.record(z.string(), z.unknown());
+const Message = z.object({ role: z.string(), content: z.string() });
+
+export const PrivacyMode = z.enum(["blind_view", "reviewer_view", "internal_view"]);
+export type PrivacyMode = z.infer<typeof PrivacyMode>;
+
+export const AgentTraceStep = z.discriminatedUnion("type", [
+  z.object({
+    type: z.literal("message"),
+    index: z.number().int().nonnegative(),
+    timestamp: z.string().optional(),
+    message: Message,
+  }),
+  z.object({
+    type: z.literal("tool_call"),
+    index: z.number().int().nonnegative(),
+    timestamp: z.string().optional(),
+    tool_call_id: z.string(),
+    name: z.string(),
+    args: JsonRecord.default({}),
+    redacted_args: JsonRecord.default({}),
+    privacy_class: z.enum(["public", "internal", "confidential", "pii", "phi"]),
+  }),
+  z.object({
+    type: z.literal("tool_result"),
+    index: z.number().int().nonnegative(),
+    timestamp: z.string().optional(),
+    tool_call_id: z.string(),
+    name: z.string().optional(),
+    result: z.unknown().optional(),
+    redacted_result: z.unknown().optional(),
+    privacy_class: z.enum(["public", "internal", "confidential", "pii", "phi"]),
+  }),
+  z.object({
+    type: z.literal("state"),
+    index: z.number().int().nonnegative(),
+    timestamp: z.string().optional(),
+    label: z.string(),
+    snapshot: JsonRecord.default({}),
+    redacted_snapshot: JsonRecord.default({}),
+    privacy_class: z.enum(["public", "internal", "confidential", "pii", "phi"]),
+  }),
+  z.object({
+    type: z.literal("policy_event"),
+    index: z.number().int().nonnegative(),
+    timestamp: z.string().optional(),
+    policy: z.string(),
+    action: z.string(),
+    reason: z.string().optional(),
+  }),
+]);
+export type AgentTraceStep = z.infer<typeof AgentTraceStep>;
+
+export const AgentRunTrace = z.object({
+  trace_id: z.string(),
+  source: z.literal("agent_harness"),
+  harness: z.object({ name: z.string(), version: z.string().optional(), sdk: z.string().optional() }),
+  product: z.string(),
+  module: z.string().optional(),
+  environment: z.string().optional(),
+  model: z.string().optional(),
+  run_id: z.string().optional(),
+  source_ids: JsonRecord.default({}),
+  messages: z.array(Message).default([]),
+  steps: z.array(AgentTraceStep),
+  final_answer: z.string().optional(),
+  usage: z.object({ cost_usd: z.number().optional(), duration_ms: z.number().optional(), total_tokens: z.number().optional() }),
+  privacy: z.object({
+    class: z.enum(["public", "internal", "confidential", "pii", "phi"]),
+    redaction_notes: z.array(z.string()).default([]),
+  }),
+  metadata: JsonRecord.default({}),
+});
+export type AgentRunTrace = z.infer<typeof AgentRunTrace>;
+
+export interface JeevesClogRunExport {
+  run_id?: string;
+  trace_id?: string;
+  product?: string;
+  module?: string;
+  environment?: string;
+  harness?: { name?: string; version?: string; sdk?: string };
+  model?: string;
+  messages?: Array<{ role?: string; content?: string; timestamp?: string }>;
+  steps?: unknown[];
+  final_answer?: string;
+  usage?: { cost_usd?: number; duration_ms?: number; total_tokens?: number };
+  metadata?: Record<string, unknown>;
+}
+
+const asRecord = (v: unknown): Record<string, unknown> | undefined =>
+  v && typeof v === "object" && !Array.isArray(v) ? (v as Record<string, unknown>) : undefined;
+const str = (v: unknown): string | undefined => (typeof v === "string" && v.length ? v : undefined);
+const num = (v: unknown): number | undefined => (typeof v === "number" && Number.isFinite(v) ? v : undefined);
+const stableStringify = (v: unknown): string => {
+  if (v === null || typeof v !== "object") return JSON.stringify(v);
+  if (Array.isArray(v)) return `[${v.map(stableStringify).join(",")}]`;
+  const o = v as Record<string, unknown>;
+  return `{${Object.keys(o).sort().map((k) => `${JSON.stringify(k)}:${stableStringify(o[k])}`).join(",")}}`;
+};
+const hash = (v: unknown) => createHash("sha256").update(stableStringify(v)).digest("hex").slice(0, 16);
+
+const SENSITIVE_KEY = /(ssn|social|phone|email|address|token|secret|password|account_number|card|dob)/i;
+export function redactValue(value: unknown, mode: PrivacyMode = "blind_view"): unknown {
+  if (mode === "internal_view") return value;
+  if (value === null || value === undefined) return value;
+  if (typeof value !== "object") return value;
+  if (Array.isArray(value)) return value.map((x) => redactValue(x, mode));
+  const out: Record<string, unknown> = {};
+  for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
+    if (SENSITIVE_KEY.test(key)) out[key] = "[REDACTED]";
+    else out[key] = redactValue(val, mode);
+  }
+  return out;
+}
+
+const privacyClassFor = (value: unknown): AgentRunTrace["privacy"]["class"] =>
+  SENSITIVE_KEY.test(stableStringify(value)) ? "pii" : "internal";
+
+function normalizeStep(step: unknown, index: number, mode: PrivacyMode): AgentTraceStep {
+  const s = asRecord(step) ?? {};
+  const type = str(s.type ?? s.kind) ?? (s.tool_name || s.tool ? "tool_call" : "state");
+  if (type === "message") {
+    return AgentTraceStep.parse({
+      type: "message",
+      index,
+      timestamp: str(s.timestamp),
+      message: { role: str(s.role) ?? "assistant", content: str(s.content) ?? "" },
+    });
+  }
+  if (type === "tool_call") {
+    const args = asRecord(s.args ?? s.arguments) ?? {};
+    return AgentTraceStep.parse({
+      type: "tool_call",
+      index,
+      timestamp: str(s.timestamp),
+      tool_call_id: str(s.tool_call_id ?? s.id) ?? `tool-${index}`,
+      name: str(s.name ?? s.tool_name ?? s.tool) ?? "unknown_tool",
+      args,
+      redacted_args: redactValue(args, mode),
+      privacy_class: privacyClassFor(args),
+    });
+  }
+  if (type === "tool_result") {
+    const result = s.result ?? s.output;
+    return AgentTraceStep.parse({
+      type: "tool_result",
+      index,
+      timestamp: str(s.timestamp),
+      tool_call_id: str(s.tool_call_id ?? s.id) ?? `tool-${index}`,
+      name: str(s.name ?? s.tool_name ?? s.tool),
+      result,
+      redacted_result: redactValue(result, mode),
+      privacy_class: privacyClassFor(result),
+    });
+  }
+  if (type === "policy_event") {
+    return AgentTraceStep.parse({
+      type: "policy_event",
+      index,
+      timestamp: str(s.timestamp),
+      policy: str(s.policy) ?? "unknown_policy",
+      action: str(s.action) ?? "unknown_action",
+      reason: str(s.reason),
+    });
+  }
+  const snapshot = asRecord(s.snapshot ?? s.state ?? s) ?? {};
+  return AgentTraceStep.parse({
+    type: "state",
+    index,
+    timestamp: str(s.timestamp),
+    label: str(s.label) ?? "state_snapshot",
+    snapshot,
+    redacted_snapshot: redactValue(snapshot, mode),
+    privacy_class: privacyClassFor(snapshot),
+  });
+}
+
+export function normalizeJeevesClogRun(
+  raw: JeevesClogRunExport,
+  options: { privacyMode?: PrivacyMode; defaultProduct?: string } = {},
+): AgentRunTrace {
+  const privacyMode = options.privacyMode ?? "blind_view";
+  const messages = (raw.messages ?? []).flatMap((m) =>
+    m.role && m.content ? [{ role: m.role, content: m.content }] : [],
+  );
+  const steps = (raw.steps ?? []).map((s, i) => normalizeStep(s, i, privacyMode));
+  const traceSeed = { run_id: raw.run_id, trace_id: raw.trace_id, harness: raw.harness, model: raw.model, messages };
+  const redactionNotes = steps.some((s) => stableStringify(s).includes("[REDACTED]"))
+    ? ["sensitive tool/state fields redacted for blind/reviewer views"]
+    : [];
+  return AgentRunTrace.parse({
+    trace_id: raw.trace_id ?? `agent-${hash(traceSeed)}`,
+    source: "agent_harness",
+    harness: { name: raw.harness?.name ?? "jeeves_clog", version: raw.harness?.version, sdk: raw.harness?.sdk ?? "clog" },
+    product: raw.product ?? options.defaultProduct ?? "jeeves",
+    module: raw.module ?? "systems_agent",
+    environment: raw.environment,
+    model: raw.model,
+    run_id: raw.run_id,
+    source_ids: { run_id: raw.run_id, trace_id: raw.trace_id },
+    messages,
+    steps,
+    final_answer: raw.final_answer,
+    usage: { cost_usd: num(raw.usage?.cost_usd), duration_ms: num(raw.usage?.duration_ms), total_tokens: num(raw.usage?.total_tokens) },
+    privacy: { class: steps.some((s) => "privacy_class" in s && s.privacy_class === "pii") ? "pii" : "internal", redaction_notes: redactionNotes },
+    metadata: raw.metadata ?? {},
+  });
+}
+
+export interface ScorerVisibleAgentRun {
+  trace_id: string;
+  harness: AgentRunTrace["harness"];
+  product: string;
+  model?: string;
+  messages: AgentRunTrace["messages"];
+  tool_calls: Array<{ tool_call_id: string; name: string; args: unknown; index: number }>;
+  tool_results: Array<{ tool_call_id: string; name?: string; result: unknown; index: number }>;
+  policy_events: Array<{ policy: string; action: string; reason?: string; index: number }>;
+  final_answer?: string;
+}
+
+export function toScorerVisibleAgentRun(
+  trace: AgentRunTrace,
+  mode: PrivacyMode = "blind_view",
+): ScorerVisibleAgentRun {
+  const redact = (v: unknown) => redactValue(v, mode);
+  return {
+    trace_id: trace.trace_id,
+    harness: trace.harness,
+    product: trace.product,
+    model: trace.model,
+    messages: trace.messages,
+    tool_calls: trace.steps.flatMap((s) =>
+      s.type === "tool_call" ? [{ tool_call_id: s.tool_call_id, name: s.name, args: mode === "internal_view" ? s.args : s.redacted_args, index: s.index }] : [],
+    ),
+    tool_results: trace.steps.flatMap((s) =>
+      s.type === "tool_result" ? [{ tool_call_id: s.tool_call_id, name: s.name, result: mode === "internal_view" ? s.result : s.redacted_result, index: s.index }] : [],
+    ),
+    policy_events: trace.steps.flatMap((s) =>
+      s.type === "policy_event" ? [{ policy: s.policy, action: s.action, reason: s.reason, index: s.index }] : [],
+    ),
+    final_answer: trace.final_answer ? String(redact(trace.final_answer)) : undefined,
+  };
+}
+
+export function agentTraceToEvalCase(trace: AgentRunTrace): EvalCaseInput {
+  const visible = toScorerVisibleAgentRun(trace, "blind_view");
+  return {
+    id: `case-${trace.trace_id}`,
+    product: trace.product,
+    title: `${trace.harness.name} replay ${trace.run_id ?? trace.trace_id}`,
+    source: "replay",
+    tags: ["agent-harness", trace.harness.name, trace.module ?? "agent"],
+    input: {
+      messages: trace.messages,
+      context: {
+        trace_id: trace.trace_id,
+        harness: trace.harness,
+        tool_calls: visible.tool_calls,
+        policy_events: visible.policy_events,
+      },
+    },
+    expected: { privacy_class: trace.privacy.class, data_policy: { retention: "pennie_scoped_review_only" } },
+    metadata: { trace_id: trace.trace_id, run_id: trace.run_id, final_answer: visible.final_answer, scorers: [] },
+  };
+}

--- a/src/lib/evals/agentTrace.ts
+++ b/src/lib/evals/agentTrace.ts
@@ -1,5 +1,5 @@
 /**
- * Normalized multi-step agent run traces for Jeeves/Pennie Systems style harnesses.
+ * Normalized multi-step agent run traces for agent-harness style harnesses.
  *
  * This is capture/normalization only: no sandboxed agent execution and no provider
  * SDK dependency. The concrete first ingest path is a permissive "Jeeves/Clog run"
@@ -272,7 +272,7 @@ export function agentTraceToEvalCase(trace: AgentRunTrace): EvalCaseInput {
         policy_events: visible.policy_events,
       },
     },
-    expected: { privacy_class: trace.privacy.class, data_policy: { retention: "pennie_scoped_review_only" } },
+    expected: { privacy_class: trace.privacy.class, data_policy: { retention: "customer_scoped_review_only" } },
     metadata: { trace_id: trace.trace_id, run_id: trace.run_id, final_answer: visible.final_answer, scorers: [] },
   };
 }

--- a/src/lib/evals/evalCase.ts
+++ b/src/lib/evals/evalCase.ts
@@ -14,7 +14,7 @@
  *
  * Deliberately platform-agnostic: `product`, tool names, data-policy labels, and
  * input shape are open strings/records, not closed enums, so the same schema
- * serves Pennie / Eavesly / Migo and future Blind Bench customers.
+ * serves support, voice, chat, and agentic workflows and future Blind Bench customers.
  */
 // zod 3.25 exposes the v4 API on this subpath; use it for JSON Schema export.
 import { z } from "zod/v4";

--- a/src/lib/evals/examples.ts
+++ b/src/lib/evals/examples.ts
@@ -1,5 +1,5 @@
 /**
- * SYNTHETIC eval cases — fake data ONLY. No real Pennie/customer/PII content.
+ * SYNTHETIC eval cases — fake data ONLY. No real customer/PII content.
  *
  * Two worked examples (one Eavesly, one Migo) demonstrating the EvalCase schema
  * across scenario sources, expected tool calls, escalation, data policy, and


### PR DESCRIPTION
## Summary

Adds the first normalized multi-step agent trace capture path for customer agent harnesses.

- Defines `AgentRunTrace` with ordered messages, tool calls, tool results, state snapshots, policy events, final answer, harness/model metadata, usage, and source IDs.
- Implements first concrete ingest path: permissive agent-run export normalization.
- Adds privacy/redaction handling for tool args/results/state snapshots.
- Adds scorer-visible projection that defaults to blind/reviewer-safe redacted payloads.
- Adds eval-case seed conversion for replay/harness evals.
- Adds synthetic passing and failing agent fixtures with tool-call evidence.
- Documents the capture shape, privacy model, scorer-visible projection, and non-goals.

Closes #233

## Verification

- ✅ `npm run test:evals` — 20 tests passed on this branch
- ✅ focused TypeScript check for eval files:
  `npx tsc --ignoreConfig --noEmit --skipLibCheck --module ESNext --moduleResolution bundler --target ES2022 --types node --strict --noUnusedLocals --noUnusedParameters --noUncheckedIndexedAccess src/lib/evals/*.ts`

## Notes

This is capture/normalization only. It does not implement sandboxed agent execution or live production capture. All fixtures use synthetic `TEST` data only; no customer production traces or secrets are included.