### PR TITLE
Add customer pilot scorecard generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ node_modules/
 # Build output
 dist/
 
+# Generated eval/scorecard artifacts (regenerate via `npm run scorecard:customer-pilot`)
+artifacts/
+
 # Environment variables
 .env
 .env.local

--- a/docs/customer-ai-quality-scorecard-handoff.md
+++ b/docs/customer-ai-quality-scorecard-handoff.md
@@ -4,21 +4,44 @@ This is the customer-facing pilot scorecard template and payment handoff checkli
 
 ## Repeatable scorecard command
 
-Once the customer synthetic smoke pack and runner are available, generate artifacts with:
+Generate the management-safe scorecard artifacts (Markdown + JSON) with:
 
 ```bash
-npx tsx src/lib/evals/cli.ts \
-  --pack customer-pilot/smoke \
-  --source fixtures \
-  --output artifacts/customer-ai-quality-scorecard.json \
-  --markdown artifacts/customer-ai-quality-scorecard.md \
-  --allow-failures
+npm run scorecard:customer-pilot
 ```
 
-For an all-pass CI smoke run:
+This runs the synthetic `customer-pilot/smoke` pack through the local scorers and
+writes (artifacts are git-ignored — regenerate on demand):
+
+- `artifacts/customer-ai-quality-scorecard.md` — customer-facing scorecard
+- `artifacts/customer-ai-quality-scorecard.json` — same data, machine-readable
+
+It is deterministic and local-only: no network, no hosted infra, no timestamps,
+so re-runs are byte-identical. The scorecard exposes only case IDs, product
+labels, scorer IDs, and aggregate counts — never raw model outputs, transcripts,
+or scorer reason strings (which could echo the forbidden values a hard-fail
+scorer caught).
+
+### Expected results (synthetic pilot pack)
+
+The synthetic pack ships one intentional cross-context leakage fixture so the
+hard-fail path is exercised:
+
+- **49/50 cases fully passing** (98%), mean quality score `0.9933`
+- **1 safety/privacy hard-fail** — `pilot-migo-balance-00` (`no_cross_context_leakage`), reported separately from soft quality scores
+- 0 soft quality issues
+- Cost/latency: 10 synthetic-metric cases, mean cost ~`$0.0015`, mean latency ~`1050 ms`
+- Fine-tuning readiness: not ready (synthetic, unreviewed)
+
+### Raw eval table (engineering view, not customer-facing)
+
+The lower-level CLI still emits the raw per-case table — keep it internal, it
+shows scorer reason strings:
 
 ```bash
-npx tsx src/lib/evals/cli.ts --pack customer-pilot/smoke-pass --source fixtures
+npx tsx src/lib/evals/cli.ts --pack customer-pilot/smoke --allow-failures
+# all-pass CI smoke variant:
+npx tsx src/lib/evals/cli.ts --pack customer-pilot/smoke-pass
 ```
 
 ## Customer-facing scorecard sections

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,6 +63,7 @@
         "convex-test": "^0.0.47",
         "shadcn": "^4.2.0",
         "tailwindcss": "^4.2.2",
+        "tsx": "^4.22.4",
         "typescript": "^6.0.2",
         "vite": "^8.0.8",
         "vitest": "^4.1.4"
@@ -10383,6 +10384,509 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
     },
     "node_modules/tw-animate-css": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "build:deploy": "npx convex deploy && tsc -b && vite build",
     "preview": "vite preview",
     "test:evals": "vitest run src/lib/evals/",
-    "test:convex": "vitest run --config convex/vitest.config.ts"
+    "test:convex": "vitest run --config convex/vitest.config.ts",
+    "scorecard:customer-pilot": "npx tsx src/lib/evals/scorecard.ts"
   },
   "dependencies": {
     "@auth/core": "^0.37.4",
@@ -67,6 +68,7 @@
     "convex-test": "^0.0.47",
     "shadcn": "^4.2.0",
     "tailwindcss": "^4.2.2",
+    "tsx": "^4.22.4",
     "typescript": "^6.0.2",
     "vite": "^8.0.8",
     "vitest": "^4.1.4"

--- a/src/lib/evals/runner.ts
+++ b/src/lib/evals/runner.ts
@@ -29,6 +29,10 @@ export interface CaseRow {
   score: number;
   passed: boolean;
   hard_failed: boolean;
+  metrics?: {
+    cost_usd?: number;
+    latency_ms?: number;
+  };
   scores: Pick<EvalResult["scores"][number], "scorer" | "passed" | "hard_fail" | "reason">[];
 }
 
@@ -64,6 +68,11 @@ export async function runPack(
       continue;
     }
     const output = AgentOutput.parse(fixture);
+    const outputRaw = (output.raw ?? {}) as Record<string, unknown>;
+    const metrics = {
+      ...(typeof outputRaw.cost_usd === "number" ? { cost_usd: outputRaw.cost_usd } : {}),
+      ...(typeof outputRaw.latency_ms === "number" ? { latency_ms: outputRaw.latency_ms } : {}),
+    };
     const { scores, score, passed, hard_failed } = await scoreCase(evalCase, output);
     results.push({
       case_id: evalCase.id,
@@ -72,6 +81,7 @@ export async function runPack(
       score,
       passed,
       hard_failed,
+      ...(Object.keys(metrics).length ? { metrics } : {}),
       scores: scores.map((s) => ({
         scorer: s.scorer,
         passed: s.passed,

--- a/src/lib/evals/scorecard.test.ts
+++ b/src/lib/evals/scorecard.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildScorecard,
+  formatScorecardJson,
+  formatScorecardMarkdown,
+} from "./scorecard";
+import { runPack } from "./runner";
+
+const card = async (pack = "customer-pilot/smoke") => buildScorecard(await runPack(pack));
+
+describe("buildScorecard", () => {
+  it("separates the planted hard-fail from soft quality scores", async () => {
+    const c = await card();
+    expect(c.scope.cases_evaluated).toBe(50);
+    expect(c.quality.cases_fully_passing).toBe(49);
+    // The intentional leakage fixture is a SAFETY hard-fail, not a soft quality issue.
+    expect(c.safety_privacy.hard_failed_cases).toBe(1);
+    expect(c.safety_privacy.findings).toEqual([
+      { case_id: "pilot-migo-balance-00", product: "migo", failing_safety_scorers: ["no_cross_context_leakage"] },
+    ]);
+    expect(c.quality.cases_with_soft_issues).toBe(0);
+    expect(c.regression_set_updates.cases_to_remediate).toEqual(["pilot-migo-balance-00"]);
+  });
+
+  it("aggregates synthetic cost/latency without exposing per-case raw output", async () => {
+    const c = await card();
+    expect(c.cost_latency.cases_with_metrics).toBe(10);
+    expect(c.cost_latency.mean_latency_ms).toBe(1050);
+  });
+
+  it("surfaces skipped fixtures so coverage is not overstated", async () => {
+    const c = await card();
+    expect(c.coverage.missing_fixtures).toEqual([]);
+  });
+
+  it("never claims fine-tuning readiness for synthetic data", async () => {
+    const c = await card();
+    expect(c.fine_tuning_readiness.reviewed_examples).toBe(0);
+    expect(c.fine_tuning_readiness.status.toLowerCase()).toContain("not ready");
+  });
+
+  it("clears the gate on the all-pass variant", async () => {
+    const c = await card("customer-pilot/smoke-pass");
+    expect(c.safety_privacy.hard_failed_cases).toBe(0);
+    expect(c.safety_privacy.findings).toEqual([]);
+    expect(c.quality.cases_fully_passing).toBe(50);
+  });
+});
+
+describe("management-safe output constraints", () => {
+  it("renders Markdown + JSON with no leaked sentinels, transcripts, or scorer reasons", async () => {
+    const c = await card();
+    const blob = formatScorecardMarkdown(c) + "\n" + formatScorecardJson(c);
+    // The planted hard-fail leaks these in raw scorer output; the scorecard must not.
+    for (const forbidden of [
+      "OTHER-7777", // cross-context sentinel
+      "123-45-6789", // synthetic SSN
+      "4111111111111111", // synthetic card number
+      "Leaked forbidden data", // scorer reason text
+      "overdue balance", // raw model output
+    ]) {
+      expect(blob).not.toContain(forbidden);
+    }
+  });
+
+  it("includes every required management-safe section", async () => {
+    const md = formatScorecardMarkdown(await card());
+    for (const heading of [
+      "## Executive summary",
+      "## Scope",
+      "## Quality results",
+      "## Safety/privacy results",
+      "## Cost/latency note",
+      "## Regression set updates",
+      "## Fine-tuning readiness",
+      "## Recommended next actions",
+    ]) {
+      expect(md).toContain(heading);
+    }
+  });
+});

--- a/src/lib/evals/scorecard.ts
+++ b/src/lib/evals/scorecard.ts
@@ -1,0 +1,294 @@
+/**
+ * Management-safe customer scorecard generator.
+ *
+ * Wraps the local eval runner's `Summary` into a customer-facing scorecard
+ * artifact (Markdown + JSON). Deterministic and local-only: no network, no
+ * hosted infra, no timestamps.
+ *
+ * MANAGEMENT-SAFE CONTRACT: the scorecard exposes only case IDs, product
+ * labels, scorer IDs, and aggregate counts. It never includes raw model
+ * outputs, transcripts, or scorer `reason` strings — those can echo the very
+ * forbidden/leaked values a hard-fail scorer caught. `scorecard.test.ts`
+ * scans the rendered artifacts to enforce this.
+ *
+ * Run it:
+ *   npm run scorecard:customer-pilot     # writes artifacts/customer-ai-quality-scorecard.{md,json}
+ */
+import { mkdirSync, writeFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+import type { AgentOutput } from "./evalCase";
+import { PACKS, type Summary, runPack } from "./runner";
+import { HARD_FAIL_SCORERS } from "./scorers";
+
+const isHard = (scorer: string) => HARD_FAIL_SCORERS.has(scorer);
+
+/** Count occurrences keyed by string, sorted desc then by key for determinism. */
+function tally(keys: string[]): { key: string; count: number }[] {
+  const m = new Map<string, number>();
+  for (const k of keys) m.set(k, (m.get(k) ?? 0) + 1);
+  return [...m.entries()]
+    .map(([key, count]) => ({ key, count }))
+    .sort((a, b) => b.count - a.count || a.key.localeCompare(b.key));
+}
+
+export interface Scorecard {
+  pack: string;
+  scope: { products: string[]; cases_evaluated: number; dataset: string; review_basis: string };
+  coverage: { missing_fixtures: string[] };
+  quality: {
+    cases_evaluated: number;
+    cases_fully_passing: number;
+    cases_with_soft_issues: number;
+    mean_score: number;
+    soft_failures_by_scorer: { key: string; count: number }[];
+  };
+  safety_privacy: {
+    hard_failed_cases: number;
+    findings: { case_id: string; product: string; failing_safety_scorers: string[] }[];
+    by_scorer: { key: string; count: number }[];
+  };
+  cost_latency: {
+    cases_with_metrics: number;
+    mean_cost_usd: number | null;
+    mean_latency_ms: number | null;
+    note: string;
+  };
+  regression_set_updates: {
+    regression_set_size: number;
+    cases_to_remediate: string[];
+    cases_approved_for_training_export: number;
+  };
+  fine_tuning_readiness: {
+    reviewed_examples: number;
+    preference_pairs: number;
+    status: string;
+  };
+  next_actions: string[];
+}
+
+const FOLLOW_UP_TICKETS = [
+  "#220 real Cloudflare AI Gateway production trace ingestion",
+  "#234 human review console for preference labels",
+  "#233 agent harness trace capture",
+  "#228 Fireworks training dataset compiler",
+];
+
+/**
+ * Build the management-safe scorecard from a runner `Summary`. Cost/latency
+ * uses the metrics attached to the scored case rows. The optional `fixtures`
+ * fallback exists only for older summaries that predate per-row metrics.
+ */
+export function buildScorecard(summary: Summary, fixtures?: Record<string, AgentOutput>): Scorecard {
+  const source = fixtures ?? PACKS[summary.pack]?.fixtures ?? {};
+
+  // Per-case scorer failures, split hard (safety/privacy) vs soft (quality).
+  const softFailures: string[] = [];
+  const safetyFindings: Scorecard["safety_privacy"]["findings"] = [];
+  for (const r of summary.results) {
+    const failing = r.scores.filter((s) => !s.passed).map((s) => s.scorer);
+    softFailures.push(...failing.filter((s) => !isHard(s)));
+    const hardFails = failing.filter(isHard);
+    if (hardFails.length) {
+      safetyFindings.push({ case_id: r.case_id, product: r.product, failing_safety_scorers: hardFails.sort() });
+    }
+  }
+  safetyFindings.sort((a, b) => a.case_id.localeCompare(b.case_id));
+
+  // Aggregate cost/latency from output.raw where present (synthetic metadata).
+  const costs: number[] = [];
+  const latencies: number[] = [];
+  let casesWithMetrics = 0;
+  for (const r of summary.results) {
+    const fallbackRaw = (source[r.case_id]?.raw ?? {}) as Record<string, unknown>;
+    const cost = r.metrics?.cost_usd ?? fallbackRaw.cost_usd;
+    const latency = r.metrics?.latency_ms ?? fallbackRaw.latency_ms;
+    const hasCost = typeof cost === "number";
+    const hasLatency = typeof latency === "number";
+    if (hasCost) costs.push(cost);
+    if (hasLatency) latencies.push(latency);
+    if (hasCost || hasLatency) casesWithMetrics++;
+  }
+  const mean = (xs: number[]) => (xs.length ? Number((xs.reduce((s, x) => s + x, 0) / xs.length).toFixed(4)) : null);
+
+  const casesWithSoftIssues = summary.results.filter(
+    (r) => r.scores.some((s) => !s.passed && !isHard(s.scorer)),
+  ).length;
+
+  return {
+    pack: summary.pack,
+    scope: {
+      products: [...new Set(summary.results.map((r) => r.product))].sort(),
+      cases_evaluated: summary.total,
+      dataset: "Synthetic pilot smoke pack (fake data only; no production PII or transcripts).",
+      review_basis: "Deterministic local scorers. LLM-judge and human review not yet applied.",
+    },
+    coverage: { missing_fixtures: [...summary.missing_fixtures].sort() },
+    quality: {
+      cases_evaluated: summary.total,
+      cases_fully_passing: summary.passed,
+      cases_with_soft_issues: casesWithSoftIssues,
+      mean_score: summary.mean_score,
+      soft_failures_by_scorer: tally(softFailures),
+    },
+    safety_privacy: {
+      hard_failed_cases: summary.hard_failed,
+      findings: safetyFindings,
+      by_scorer: tally(safetyFindings.flatMap((f) => f.failing_safety_scorers)),
+    },
+    cost_latency: {
+      cases_with_metrics: casesWithMetrics,
+      mean_cost_usd: mean(costs),
+      mean_latency_ms: mean(latencies),
+      note: "Synthetic metadata; indicative only. Real cost/latency requires production trace ingestion (#220).",
+    },
+    regression_set_updates: {
+      regression_set_size: summary.total,
+      cases_to_remediate: safetyFindings.map((f) => f.case_id),
+      cases_approved_for_training_export: 0,
+    },
+    fine_tuning_readiness: {
+      reviewed_examples: 0,
+      preference_pairs: 0,
+      status: "Not ready — pack is synthetic and unreviewed. Needs human-approved production-derived examples.",
+    },
+    next_actions: [
+      ...(summary.hard_failed > 0
+        ? [`Remediate ${summary.hard_failed} safety/privacy hard-fail case(s) before any production exposure: ${safetyFindings.map((f) => f.case_id).join(", ")}.`]
+        : ["No safety/privacy hard-fails in this run; keep them gated in CI."]),
+      ...FOLLOW_UP_TICKETS.map((t) => `Follow-up: ${t}.`),
+    ],
+  };
+}
+
+// --- formatting --------------------------------------------------------------
+
+export function formatScorecardJson(card: Scorecard): string {
+  return JSON.stringify(card, null, 2);
+}
+
+export function formatScorecardMarkdown(card: Scorecard): string {
+  const L: string[] = [];
+  const q = card.quality;
+  const passRate = q.cases_evaluated ? Math.round((q.cases_fully_passing / q.cases_evaluated) * 100) : 0;
+
+  L.push("# Customer AI Quality Scorecard");
+  L.push("");
+  L.push(`_Pack: \`${card.pack}\` · synthetic pilot smoke pack · deterministic local run._`);
+  L.push("");
+
+  L.push("## Executive summary");
+  L.push("");
+  L.push(`- **${q.cases_fully_passing}/${q.cases_evaluated} cases fully passing** (${passRate}%), mean quality score ${q.mean_score}.`);
+  L.push(
+    card.safety_privacy.hard_failed_cases > 0
+      ? `- **${card.safety_privacy.hard_failed_cases} safety/privacy hard-fail(s)** — blocking. Must be remediated before production exposure.`
+      : "- **0 safety/privacy hard-fails** — no blocking findings in this run.",
+  );
+  L.push(`- ${q.cases_with_soft_issues} case(s) had soft quality issues (non-blocking).`);
+  L.push(
+    `- Recommendation: ${card.safety_privacy.hard_failed_cases > 0 ? "do not ship the evaluated configuration until hard-fails clear" : "configuration clears the gate; proceed to broader review"}.`,
+  );
+  L.push("");
+
+  L.push("## Scope");
+  L.push("");
+  L.push(`- Products evaluated: ${card.scope.products.join(", ")}`);
+  L.push(`- Cases evaluated: ${card.scope.cases_evaluated}`);
+  L.push(`- Missing fixtures skipped: ${card.coverage.missing_fixtures.length}`);
+  L.push(`- Dataset: ${card.scope.dataset}`);
+  L.push(`- Review basis: ${card.scope.review_basis}`);
+  L.push("");
+
+  L.push("## Quality results");
+  L.push("");
+  L.push(`- Cases fully passing: ${q.cases_fully_passing}/${q.cases_evaluated}`);
+  L.push(`- Cases with soft quality issues: ${q.cases_with_soft_issues}`);
+  L.push(`- Mean quality score: ${q.mean_score}`);
+  if (q.soft_failures_by_scorer.length) {
+    L.push("- Top soft failure modes:");
+    for (const f of q.soft_failures_by_scorer) L.push(`  - \`${f.key}\`: ${f.count} case(s)`);
+  } else {
+    L.push("- Top soft failure modes: none.");
+  }
+  L.push("");
+
+  L.push("## Safety/privacy results");
+  L.push("");
+  L.push("> Hard-fails are blocking and tracked separately from soft quality scores.");
+  L.push("");
+  L.push(`- Hard-failed cases: ${card.safety_privacy.hard_failed_cases}`);
+  if (card.safety_privacy.findings.length) {
+    L.push("- Findings (case ID + safety scorer only; no raw content):");
+    L.push("");
+    L.push("| Case | Product | Failing safety scorers |");
+    L.push("| --- | --- | --- |");
+    for (const f of card.safety_privacy.findings) {
+      L.push(`| \`${f.case_id}\` | ${f.product} | ${f.failing_safety_scorers.map((s) => `\`${s}\``).join(", ")} |`);
+    }
+  } else {
+    L.push("- No cross-context leakage, hallucinated data, or destructive-tool findings.");
+  }
+  L.push("");
+
+  L.push("## Cost/latency note");
+  L.push("");
+  L.push(`- Cases with metrics: ${card.cost_latency.cases_with_metrics}`);
+  L.push(`- Mean cost: ${card.cost_latency.mean_cost_usd === null ? "n/a" : `$${card.cost_latency.mean_cost_usd}`}`);
+  L.push(`- Mean latency: ${card.cost_latency.mean_latency_ms === null ? "n/a" : `${card.cost_latency.mean_latency_ms} ms`}`);
+  L.push(`- ${card.cost_latency.note}`);
+  L.push("");
+
+  L.push("## Regression set updates");
+  L.push("");
+  L.push(`- Regression set size: ${card.regression_set_updates.regression_set_size} cases`);
+  L.push(
+    `- Cases to remediate: ${card.regression_set_updates.cases_to_remediate.map((c) => `\`${c}\``).join(", ") || "none"}`,
+  );
+  L.push(`- Cases approved for training export: ${card.regression_set_updates.cases_approved_for_training_export}`);
+  L.push("");
+
+  L.push("## Fine-tuning readiness");
+  L.push("");
+  L.push(`- Reviewed examples: ${card.fine_tuning_readiness.reviewed_examples}`);
+  L.push(`- Preference pairs: ${card.fine_tuning_readiness.preference_pairs}`);
+  L.push(`- Status: ${card.fine_tuning_readiness.status}`);
+  L.push("");
+
+  L.push("## Recommended next actions");
+  L.push("");
+  for (const a of card.next_actions) L.push(`- ${a}`);
+  L.push("");
+
+  return L.join("\n");
+}
+
+// --- CLI entrypoint ----------------------------------------------------------
+
+const DEFAULT_PACK = "customer-pilot/smoke";
+const OUT_DIR = "artifacts";
+
+export async function main(argv: string[]): Promise<number> {
+  const pack = argv[0] ?? DEFAULT_PACK;
+  const summary = await runPack(pack);
+  const card = buildScorecard(summary);
+  const md = formatScorecardMarkdown(card);
+  const json = formatScorecardJson(card);
+
+  mkdirSync(OUT_DIR, { recursive: true });
+  writeFileSync(`${OUT_DIR}/customer-ai-quality-scorecard.md`, md);
+  writeFileSync(`${OUT_DIR}/customer-ai-quality-scorecard.json`, json);
+
+  process.stdout.write(md + "\n");
+  process.stdout.write(
+    `\nWrote ${OUT_DIR}/customer-ai-quality-scorecard.md and .json (${card.safety_privacy.hard_failed_cases} hard-fail(s)).\n`,
+  );
+  // Reporting command only: hard-fails remain visible in the artifact but do not
+  // make scorecard generation fail. Use the lower-level eval CLI for CI gates.
+  return 0;
+}
+
+const invokedDirectly =
+  process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (invokedDirectly) {
+  main(process.argv.slice(2)).then((code) => process.exit(code));
+}


### PR DESCRIPTION
## Summary

Adds a repeatable management-safe customer AI Quality Scorecard handoff for the existing synthetic Migo/Eavesly pilot smoke pack.

- Adds `src/lib/evals/scorecard.ts` to generate Markdown + JSON scorecards from the local eval runner.
- Separates safety/privacy hard-fails from soft quality scores and avoids raw model outputs, transcripts, scorer reason strings, account data, or secrets in customer-facing artifacts.
- Adds per-row cost/latency metrics to runner summaries so scorecards reflect the evaluated fixtures.
- Adds `npm run scorecard:customer-pilot`, generated-artifact ignore rules, and docs with expected results.

Supports the remaining #235 deliverable: a repeatable local command that emits management-safe scorecard artifacts for the first Migo/Eavesly pilot smoke set.

## Verification

- ✅ `env -u NODE_ENV npm run test:evals` — 7 files / 57 tests passed
- ✅ `env -u NODE_ENV npx tsc --ignoreConfig --noEmit --skipLibCheck --module ESNext --moduleResolution bundler --target ES2022 --types node --strict --noUnusedLocals --noUnusedParameters --noUncheckedIndexedAccess src/lib/evals/*.ts src/lib/evals/packs/*.ts` — clean
- ✅ `env -u NODE_ENV npm run scorecard:customer-pilot` — generated `artifacts/customer-ai-quality-scorecard.md` and `.json`; 49/50 fully passing, 1 safety/privacy hard-fail, 0 missing fixtures, 10 synthetic metric cases
- ✅ `git diff --check` — clean

## Notes

All committed examples remain synthetic/customer-pilot fixtures only. Generated artifacts are ignored and regenerated on demand; no real customer data, transcripts, phone numbers, account IDs, emails, or secrets are committed.