### PR TITLE
Add review promotion workflow

### DIFF
--- a/docs/review-promotion-workflow.md
+++ b/docs/review-promotion-workflow.md
@@ -1,0 +1,56 @@
+# Review → promotion workflow (local slice)
+
+Minimal, local-only implementation of the human-review side of issue #234. No
+UI, no Convex, no network — just pure functions over the eval-case schema so a
+reviewer (or a CLI) can turn a reviewed case into a regression or training
+candidate while respecting the gates in
+[`tenancy-consent-data-isolation.md`](./tenancy-consent-data-isolation.md).
+
+Code: `src/lib/evals/reviewWorkflow.ts` · tests: `reviewWorkflow.test.ts`.
+
+## Flow
+
+```text
+eval case  ─┐
+            ├─ reviewer labels (outcome / reason_tag / notes / evidence)
+            │
+            ├─ canPromoteToRegression? → promoteToRegression() → frozen regression candidate
+            └─ canApproveForTraining?  → approveForTraining()   → training-export candidate
+```
+
+## Pieces
+
+- **`ReviewDecision`** — `case_id`, `reviewer_id`, `outcome`
+  (`pass|fail|better|worse|tie|ignore`), `reason_tag`, optional `notes`,
+  `reviewed_at`, and `evidence_spans` (reusing the scorer `EvidenceSpan`).
+  `ignore` is how a reviewer declines a case; it blocks all promotion.
+- **`PromotionPolicy`** — the source `classification`
+  (`synthetic|redacted_prod|prod_sensitive|training_approved`) plus the consent
+  booleans `review_allowed`, `regression_allowed`, and `training_allowed`.
+  All booleans default to `false` — **default-deny**. Redaction is upstream work:
+  a source that is still classified `prod_sensitive` cannot enter a regression set.
+
+## Gates
+
+| Function | Allowed only when |
+| --- | --- |
+| `canPromoteToRegression` | not ignored · `review_allowed` · `regression_allowed` · classification is `synthetic` or `redacted_prod` |
+| `canApproveForTraining` | not ignored · `review_allowed` · `training_allowed` · `classification == training_approved` |
+
+Synthetic cases promote to regression when the gate is open, but are **never**
+training-approved by default. `regressionDenialReason` / `trainingDenialReason`
+return the specific reason (for CLI messaging); the `promote*` / `approve*`
+functions throw that reason if a gate fails.
+
+## Freezing
+
+`promoteToRegression` / `approveForTraining` deep-clone and recursively freeze
+the case `input` / `expected` / `scorer_assignments` / `metadata` into the candidate's `snapshot`. Later
+mutation of the source trace/case cannot change an already-promoted regression
+candidate (covered by a test).
+
+## What this slice does not do
+
+Persistence, the reviewer UI, and trace-mutation plumbing are out of scope —
+this is the pure-logic core that those layers call. Callers pass `promoted_at` /
+`approved_at` so promotion is deterministic.

--- a/docs/tenancy-consent-data-isolation.md
+++ b/docs/tenancy-consent-data-isolation.md
@@ -67,6 +67,8 @@ Raw trace
   → export only if class == training_approved
 ```
 
+A local, pure-function implementation of the label → regression/training gates lives in [`review-promotion-workflow.md`](./review-promotion-workflow.md) (`src/lib/evals/reviewWorkflow.ts`).
+
 Training export metadata should include:
 
 - source trace ID / hash

--- a/src/lib/evals/reviewWorkflow.test.ts
+++ b/src/lib/evals/reviewWorkflow.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from "vitest";
+import { EvalCase, type EvalCase as EvalCaseT } from "./evalCase";
+import { customerPilotSmokeCases } from "./packs/customerPilot";
+import {
+  PromotionPolicy,
+  ReviewDecision,
+  approveForTraining,
+  canApproveForTraining,
+  canPromoteToRegression,
+  promoteToRegression,
+  type PromotionPolicyInput,
+  type ReviewOutcome,
+} from "./reviewWorkflow";
+
+// A synthetic reviewed case + reviewer — no real customer data anywhere.
+const syntheticCase = (): EvalCaseT =>
+  EvalCase.parse(customerPilotSmokeCases[0]);
+
+const review = (
+  outcome: ReviewOutcome,
+  over: Partial<ReturnType<typeof ReviewDecision.parse>> = {},
+) =>
+  ReviewDecision.parse({
+    case_id: "pilot-eavesly-payoff-00",
+    reviewer_id: "reviewer-TEST-1",
+    outcome,
+    reason_tag: "looks_correct",
+    reviewed_at: "2026-06-24T00:00:00Z",
+    ...over,
+  });
+
+const policy = (over: Partial<PromotionPolicyInput>) =>
+  PromotionPolicy.parse({ classification: "synthetic", ...over });
+
+describe("regression promotion", () => {
+  for (const outcome of ["pass", "fail"] as const) {
+    it(`promotes a ${outcome}-labeled synthetic case when the gate is open`, () => {
+      const c = syntheticCase();
+      const r = review(outcome);
+      const p = policy({ regression_allowed: true, review_allowed: true });
+      expect(canPromoteToRegression(r, p)).toBe(true);
+      const cand = promoteToRegression(c, r, p, "2026-06-24T01:00:00Z");
+      expect(cand.kind).toBe("regression");
+      expect(cand.source_case_id).toBe(c.id);
+      expect(cand.classification).toBe("synthetic");
+      expect(cand.promoted_at).toBe("2026-06-24T01:00:00Z");
+    });
+  }
+
+  it("refuses to promote when the review gate is closed (default-deny)", () => {
+    const p = policy({ regression_allowed: true });
+    expect(canPromoteToRegression(review("pass"), p)).toBe(false);
+    expect(() => promoteToRegression(syntheticCase(), review("pass"), p)).toThrow(
+      /review gate not granted/,
+    );
+  });
+
+  it("refuses to promote when the regression gate is closed", () => {
+    const p = policy({ review_allowed: true });
+    expect(canPromoteToRegression(review("pass"), p)).toBe(false);
+    expect(() => promoteToRegression(syntheticCase(), review("pass"), p)).toThrow(
+      /regression gate not granted/,
+    );
+  });
+
+  it("ignored cases cannot promote even with the gate open", () => {
+    const p = policy({ regression_allowed: true, review_allowed: true });
+    expect(canPromoteToRegression(review("ignore"), p)).toBe(false);
+    expect(() =>
+      promoteToRegression(syntheticCase(), review("ignore"), p),
+    ).toThrow(/ignored/);
+  });
+
+  it("prod_sensitive cannot promote; caller must reclassify redacted data first", () => {
+    const blocked = policy({
+      classification: "prod_sensitive",
+      regression_allowed: true, review_allowed: true,
+    });
+    expect(canPromoteToRegression(review("pass"), blocked)).toBe(false);
+    expect(() =>
+      promoteToRegression(syntheticCase(), review("pass"), blocked),
+    ).toThrow(/redacted and reclassified/);
+
+    const allowed = policy({
+      classification: "redacted_prod",
+      regression_allowed: true, review_allowed: true,
+    });
+    expect(canPromoteToRegression(review("pass"), allowed)).toBe(true);
+
+    const trainingOnly = policy({
+      classification: "training_approved",
+      regression_allowed: true, review_allowed: true,
+    });
+    expect(canPromoteToRegression(review("pass"), trainingOnly)).toBe(false);
+    expect(() =>
+      promoteToRegression(syntheticCase(), review("pass"), trainingOnly),
+    ).toThrow(/not eligible for regression/);
+  });
+
+  it("rejects a synthetic classification for a non-synthetic source case", () => {
+    const c = syntheticCase();
+    c.source = "production_log";
+    expect(() =>
+      promoteToRegression(c, review("pass"), policy({ classification: "synthetic", regression_allowed: true, review_allowed: true })),
+    ).toThrow(/synthetic classification/);
+  });
+});
+
+describe("training export approval", () => {
+  it("requires both training_approved classification and the training gate", () => {
+    const r = review("pass");
+    // synthetic is never training-approved by default
+    expect(canApproveForTraining(r, policy({ training_allowed: true, review_allowed: true }))).toBe(
+      false,
+    );
+    // right class but gate closed
+    expect(
+      canApproveForTraining(r, policy({ classification: "training_approved", review_allowed: true })),
+    ).toBe(false);
+    // both satisfied
+    const ok = policy({
+      classification: "training_approved",
+      review_allowed: true,
+      training_allowed: true,
+    });
+    expect(canApproveForTraining(r, ok)).toBe(true);
+    const cand = approveForTraining(syntheticCase(), r, ok, "2026-06-24T02:00:00Z");
+    expect(cand.kind).toBe("training_export");
+    expect(cand.approver).toBe("reviewer-TEST-1");
+    expect(cand.approved_at).toBe("2026-06-24T02:00:00Z");
+  });
+
+  it("ignored cases cannot be approved for training", () => {
+    const ok = policy({
+      classification: "training_approved",
+      review_allowed: true,
+      training_allowed: true,
+    });
+    expect(canApproveForTraining(review("ignore"), ok)).toBe(false);
+    expect(() =>
+      approveForTraining(syntheticCase(), review("ignore"), ok),
+    ).toThrow(/ignored/);
+  });
+});
+
+describe("promotion freezes the snapshot", () => {
+  it("is independent from later mutation of the source case", () => {
+    const c = syntheticCase();
+    const r = review("pass");
+    const cand = promoteToRegression(
+      c,
+      r,
+      policy({ regression_allowed: true, review_allowed: true }),
+    );
+    const before = cand.snapshot.expected.must.slice();
+
+    // Mutate the original after promotion.
+    c.expected.must.push("a brand new requirement");
+    c.input.variables = { tampered: true };
+    r.notes = "mutated after promotion";
+
+    expect(cand.snapshot.expected.must).toEqual(before);
+    expect(cand.snapshot.input).not.toHaveProperty("variables.tampered");
+    expect(cand.review.notes).not.toBe("mutated after promotion");
+    // snapshot and candidate are frozen, so writes throw in strict mode / are no-ops otherwise
+    expect(Object.isFrozen(cand)).toBe(true);
+    expect(Object.isFrozen(cand.snapshot)).toBe(true);
+    expect(Object.isFrozen(cand.snapshot.expected.must)).toBe(true);
+  });
+});
+
+describe("fixtures carry no real customer data", () => {
+  it("uses only synthetic TEST identifiers", () => {
+    const blob = JSON.stringify({
+      review: review("pass"),
+      cand: promoteToRegression(
+        syntheticCase(),
+        review("pass"),
+        policy({ regression_allowed: true, review_allowed: true }),
+      ),
+    });
+    expect(blob).toMatch(/TEST/);
+    expect(blob).not.toMatch(/\b\d{3}-\d{2}-\d{4}\b/); // no SSN-shaped strings
+    expect(blob).not.toMatch(/@/); // no emails
+  });
+});

--- a/src/lib/evals/reviewWorkflow.ts
+++ b/src/lib/evals/reviewWorkflow.ts
@@ -1,0 +1,225 @@
+/**
+ * Minimal local human-review → promotion workflow (issue #234, non-UI slice).
+ *
+ * Turns a reviewed eval case into either a frozen customer-scoped regression
+ * candidate or a training-export candidate, gated by the data-classification /
+ * consent model in `docs/tenancy-consent-data-isolation.md`. Default-deny: a
+ * missing gate is treated as denied.
+ *
+ * Pure functions only — no UI, no persistence, no network. The caller supplies
+ * `promoted_at` / `approved_at` so promotion is deterministic and testable.
+ */
+import { z } from "zod/v4";
+import { EvidenceSpan, type EvalCase } from "./evalCase";
+
+// --- Review label ------------------------------------------------------------
+
+/**
+ * Reviewer verdict. `ignore` marks a case the reviewer explicitly declines to
+ * promote (noise/dupe/out-of-scope); the pairwise verdicts (`better`/`worse`/
+ * `tie`) support A-vs-B comparisons. Only `ignore` blocks promotion.
+ */
+export const ReviewOutcome = z.enum([
+  "pass",
+  "fail",
+  "better",
+  "worse",
+  "tie",
+  "ignore",
+]);
+export type ReviewOutcome = z.infer<typeof ReviewOutcome>;
+
+export const ReviewDecision = z.object({
+  /** Eval case (or trace) being reviewed. */
+  case_id: z.string(),
+  /** Reviewer identity; synthetic/test ids are fine for fixtures. */
+  reviewer_id: z.string(),
+  outcome: ReviewOutcome,
+  /** Stable categorical reason, e.g. "hallucinated_amount", "good_escalation". */
+  reason_tag: z.string(),
+  notes: z.string().optional(),
+  /** ISO-8601; set by the caller, not derived here. */
+  reviewed_at: z.string().optional(),
+  /** Optional citations supporting the verdict, reusing the scorer EvidenceSpan. */
+  evidence_spans: z.array(EvidenceSpan).optional(),
+});
+export type ReviewDecision = z.infer<typeof ReviewDecision>;
+
+// --- Data classification + consent gates -------------------------------------
+
+/** Mirrors docs/tenancy-consent-data-isolation.md. */
+export const DataClassification = z.enum([
+  "synthetic",
+  "redacted_prod",
+  "prod_sensitive",
+  "training_approved",
+]);
+export type DataClassification = z.infer<typeof DataClassification>;
+
+/**
+ * Per-source consent gates. Booleans default to `false` (default-deny).
+ * Redaction must happen before this module sees a case. A source that is still
+ * `prod_sensitive` cannot be promoted into regression; classify the redacted
+ * result as `redacted_prod` first.
+ */
+export const PromotionPolicy = z.object({
+  classification: DataClassification,
+  review_allowed: z.boolean().default(false),
+  regression_allowed: z.boolean().default(false),
+  training_allowed: z.boolean().default(false),
+});
+export type PromotionPolicy = z.infer<typeof PromotionPolicy>;
+export type PromotionPolicyInput = z.input<typeof PromotionPolicy>;
+
+// --- Promotion result rows ---------------------------------------------------
+
+/** Frozen copy of the parts of an eval case a regression must pin. */
+export interface CaseSnapshot {
+  input: EvalCase["input"];
+  expected: EvalCase["expected"];
+  scorer_assignments: EvalCase["scorer_assignments"];
+  metadata: EvalCase["metadata"];
+}
+
+export interface RegressionCandidate {
+  kind: "regression";
+  source_case_id: string;
+  product: string;
+  classification: DataClassification;
+  review: ReviewDecision;
+  /** Deep-frozen so later mutation of the source case can't change the dataset. */
+  snapshot: CaseSnapshot;
+  promoted_at?: string;
+}
+
+export interface TrainingExportCandidate {
+  kind: "training_export";
+  source_case_id: string;
+  product: string;
+  classification: DataClassification;
+  approver: string;
+  review: ReviewDecision;
+  snapshot: CaseSnapshot;
+  approved_at?: string;
+}
+
+// --- Gates -------------------------------------------------------------------
+
+const isReviewed = (review: ReviewDecision) => review.outcome !== "ignore";
+
+/**
+ * Why a regression promotion is denied, or null if allowed. Public so a CLI can
+ * surface the reason without a try/catch.
+ */
+export function regressionDenialReason(
+  review: ReviewDecision,
+  policy: PromotionPolicy,
+): string | null {
+  if (!isReviewed(review)) return "case is ignored or unreviewed";
+  if (!policy.review_allowed) return "review gate not granted";
+  if (!policy.regression_allowed) return "regression gate not granted";
+  if (policy.classification === "prod_sensitive")
+    return "prod_sensitive source must be redacted and reclassified before promotion";
+  if (policy.classification !== "synthetic" && policy.classification !== "redacted_prod")
+    return "classification not eligible for regression; use synthetic or redacted_prod";
+  return null;
+}
+
+export const canPromoteToRegression = (
+  review: ReviewDecision,
+  policy: PromotionPolicy,
+): boolean => regressionDenialReason(review, policy) === null;
+
+/** Why a training approval is denied, or null if allowed. */
+export function trainingDenialReason(
+  review: ReviewDecision,
+  policy: PromotionPolicy,
+): string | null {
+  if (!isReviewed(review)) return "case is ignored or unreviewed";
+  if (!policy.review_allowed) return "review gate not granted";
+  if (!policy.training_allowed) return "training gate not granted";
+  if (policy.classification !== "training_approved")
+    return "data is not classified training_approved";
+  return null;
+}
+
+export const canApproveForTraining = (
+  review: ReviewDecision,
+  policy: PromotionPolicy,
+): boolean => trainingDenialReason(review, policy) === null;
+
+// --- Promotion ---------------------------------------------------------------
+
+/** Deep-clone then recursively freeze, so the snapshot is immutable + detached. */
+function frozenSnapshot(evalCase: EvalCase): CaseSnapshot {
+  return deepFreeze({
+    input: structuredClone(evalCase.input),
+    expected: structuredClone(evalCase.expected),
+    scorer_assignments: structuredClone(evalCase.scorer_assignments),
+    metadata: structuredClone(evalCase.metadata),
+  });
+}
+
+function deepFreeze<T>(obj: T): T {
+  if (obj && typeof obj === "object") {
+    for (const v of Object.values(obj)) deepFreeze(v);
+    Object.freeze(obj);
+  }
+  return obj;
+}
+
+function casePolicyDenialReason(evalCase: EvalCase, policy: PromotionPolicy): string | null {
+  if (policy.classification === "synthetic" && evalCase.source !== "synthetic") {
+    return "synthetic classification requires a synthetic eval case source";
+  }
+  return null;
+}
+
+/**
+ * Freeze a reviewed case into a customer-scoped regression candidate. Throws if
+ * any gate fails (check `canPromoteToRegression` first to avoid the throw).
+ */
+export function promoteToRegression(
+  evalCase: EvalCase,
+  review: ReviewDecision,
+  policy: PromotionPolicy,
+  promoted_at?: string,
+): RegressionCandidate {
+  const denied = regressionDenialReason(review, policy);
+  if (denied) throw new Error(`regression promotion denied: ${denied}`);
+  const caseDenied = casePolicyDenialReason(evalCase, policy);
+  if (caseDenied) throw new Error(`regression promotion denied: ${caseDenied}`);
+  return deepFreeze({
+    kind: "regression",
+    source_case_id: evalCase.id,
+    product: evalCase.product,
+    classification: policy.classification,
+    review: structuredClone(review),
+    snapshot: frozenSnapshot(evalCase),
+    promoted_at,
+  });
+}
+
+/**
+ * Approve a reviewed case for training export. Throws unless the source is
+ * `training_approved` and the training gate is granted.
+ */
+export function approveForTraining(
+  evalCase: EvalCase,
+  review: ReviewDecision,
+  policy: PromotionPolicy,
+  approved_at?: string,
+): TrainingExportCandidate {
+  const denied = trainingDenialReason(review, policy);
+  if (denied) throw new Error(`training approval denied: ${denied}`);
+  return deepFreeze({
+    kind: "training_export",
+    source_case_id: evalCase.id,
+    product: evalCase.product,
+    classification: policy.classification,
+    approver: review.reviewer_id,
+    review: structuredClone(review),
+    snapshot: frozenSnapshot(evalCase),
+    approved_at,
+  });
+}


### PR DESCRIPTION
## Summary

Adds the minimal local review → promotion workflow for the customer AI Quality Bench milestone.

- Adds pure review-gating functions for converting reviewed eval cases into frozen regression candidates.
- Adds training-export approval gates that require `classification == training_approved` plus explicit review/training consent.
- Enforces default-deny gates: `review_allowed`, `regression_allowed`, `training_allowed` all default false.
- Blocks `prod_sensitive` regression promotion; callers must redact and reclassify to `redacted_prod` before promotion.
- Deep-clones/freezes snapshots so promoted regression candidates cannot drift if the source case mutates later.
- Documents the non-UI workflow and links it from the tenancy/consent model.

Closes #234 for the non-UI/local workflow slice.

## Verification

- ✅ `env -u NODE_ENV npm run test:evals` — 7 files / 61 tests passed
- ✅ `env -u NODE_ENV npx tsc --ignoreConfig --noEmit --skipLibCheck --module ESNext --moduleResolution bundler --target ES2022 --types node --strict --noUnusedLocals --noUnusedParameters --noUncheckedIndexedAccess src/lib/evals/*.ts src/lib/evals/packs/*.ts` — clean
- ✅ `git diff --check` — clean

## Notes

This is intentionally local/pure only: no UI, Convex persistence, live Cloudflare calls, or Fireworks exports. All tests use the existing synthetic customer-pilot pack; no real customer data, transcripts, phone numbers, account IDs, emails, or secrets are introduced.