### PR TITLE
Add Gateway onboarding app page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ const SignIn = lazy(() => import("./routes/auth/SignIn").then(m => ({ default: m
 const Onboarding = lazy(() => import("./routes/Onboarding").then(m => ({ default: m.Onboarding })));
 const WelcomeFirstRun = lazy(() => import("./routes/welcome/WelcomeFirstRun").then(m => ({ default: m.WelcomeFirstRun })));
 const OrgHome = lazy(() => import("./routes/orgs/OrgHome").then(m => ({ default: m.OrgHome })));
+const GatewayOnboarding = lazy(() => import("./routes/orgs/GatewayOnboarding").then(m => ({ default: m.GatewayOnboarding })));
 const OrgSettings = lazy(() => import("./routes/orgs/settings/OrgSettings").then(m => ({ default: m.OrgSettings })));
 const OrgMembers = lazy(() => import("./routes/orgs/settings/OrgMembers").then(m => ({ default: m.OrgMembers })));
 const OpenRouterKey = lazy(() => import("./routes/orgs/settings/OpenRouterKey").then(m => ({ default: m.OpenRouterKey })));
@@ -72,6 +73,7 @@ export function App() {
           <Route path="/review/:projectId" element={<ProjectReview />} />
           <Route path="/orgs/:orgSlug" element={<OrgLayout />}>
             <Route index element={<OrgHome />} />
+            <Route path="gateway-onboarding" element={<GatewayOnboarding />} />
             <Route path="settings" element={<OrgSettings />} />
             <Route path="settings/members" element={<OrgMembers />} />
             <Route path="settings/openrouter-key" element={<OpenRouterKey />} />

--- a/src/components/SideNavContent.tsx
+++ b/src/components/SideNavContent.tsx
@@ -3,7 +3,7 @@ import { NavLink } from "react-router-dom";
 import { api } from "../../convex/_generated/api";
 import { useOrg } from "@/contexts/OrgContext";
 import { cn } from "@/lib/utils";
-import { FolderOpen, Key, Settings, Users, Plus } from "lucide-react";
+import { FolderOpen, Key, Settings, Users, Plus, Plug } from "lucide-react";
 import { NextActionRing } from "@/components/copilot/NextActionRing";
 
 interface SideNavContentProps {
@@ -77,6 +77,20 @@ export function SideNavContent({
           </NavLink>
         ))
       )}
+
+      <div className="mt-4 px-2 pb-1">
+        <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+          Workspace
+        </span>
+      </div>
+      <NavLink
+        to={`/orgs/${org.slug}/gateway-onboarding`}
+        className={linkClass}
+        onClick={onNavigate}
+      >
+        <Plug className="h-4 w-4 shrink-0" />
+        Gateway onboarding
+      </NavLink>
 
       {role === "owner" && (
         <>

--- a/src/routes/orgs/GatewayOnboarding.tsx
+++ b/src/routes/orgs/GatewayOnboarding.tsx
@@ -1,0 +1,333 @@
+import { Link } from "react-router-dom";
+import { useOrg } from "@/contexts/OrgContext";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import {
+  Plug,
+  ListChecks,
+  Tags,
+  Download,
+  PlayCircle,
+  GitPullRequestArrow,
+  FileBarChart,
+  KeyRound,
+  ShieldAlert,
+  Terminal,
+  MousePointerClick,
+  ExternalLink,
+} from "lucide-react";
+
+const STEPS = [
+  {
+    icon: ListChecks,
+    title: "Choose products & use cases",
+    detail:
+      "Pick the AI surfaces to onboard first. Start with one or two high-traffic prompts per product so the baseline is meaningful.",
+  },
+  {
+    icon: Tags,
+    title: "Add metadata to Gateway requests",
+    detail:
+      "Tag each request with the conventions below so logs can be grouped by product, module, and prompt version when they land in Blind Bench.",
+  },
+  {
+    icon: Download,
+    title: "Export / import Gateway logs",
+    detail:
+      "Pull logs from Cloudflare AI Gateway (dashboard export or API) and import them as test cases. Synthetic or redacted samples only in this slice.",
+  },
+  {
+    icon: PlayCircle,
+    title: "Run a baseline eval",
+    detail:
+      "Run the imported cases against the current production prompt to establish a baseline scorecard you can compare candidates to.",
+  },
+  {
+    icon: GitPullRequestArrow,
+    title: "Review & promote cases",
+    detail:
+      "Blind-review outputs, then promote the strongest cases into a durable review set the team can re-run on every change.",
+  },
+  {
+    icon: FileBarChart,
+    title: "Publish a scorecard",
+    detail:
+      "Generate a customer-facing quality scorecard from the baseline run and share it as the handoff artifact.",
+  },
+  {
+    icon: KeyRound,
+    title: "Add Fireworks credentials & candidate model (later)",
+    detail:
+      "Once a baseline exists, wire a Fireworks-hosted candidate model to A/B against production. Not required for this slice — see the callout below.",
+    later: true,
+  },
+] as const;
+
+const PRODUCTS = [
+  {
+    name: "Migo",
+    blurb: "Conversational assistant surface.",
+    cases: [
+      "intent classification on inbound messages",
+      "grounded answer drafting from a knowledge snippet",
+      "tone / safety rewrite before send",
+    ],
+    metadata: { product: "migo", module: "assistant", variant: "control" },
+  },
+  {
+    name: "Eavesly",
+    blurb: "Summarization & extraction surface.",
+    cases: [
+      "call / thread summarization",
+      "structured field extraction into JSON",
+      "follow-up action suggestion",
+    ],
+    metadata: { product: "eavesly", module: "summarizer", variant: "control" },
+  },
+] as const;
+
+const METADATA_FIELDS = [
+  { key: "product", desc: "Top-level product, e.g. migo / eavesly." },
+  { key: "module", desc: "Sub-surface within the product, e.g. assistant / summarizer." },
+  { key: "prompt_version", desc: "Version tag of the prompt that produced the output." },
+  { key: "variant", desc: "control / candidate (which arm of an A/B)." },
+  { key: "release", desc: "App release or deploy identifier." },
+  { key: "environment", desc: "prod / staging / dev — keep prod data customer-scoped." },
+  { key: "trace_id", desc: "Request trace id, where available, to correlate with app logs." },
+  { key: "session_id", desc: "Conversation / session id, where available." },
+] as const;
+
+const CLI_SNIPPET = `# Request path: attach compact metadata before the AI Gateway call
+METADATA='{"product":"migo","module":"assistant","prompt_version":"2026-06-01","variant":"control","environment":"prod","trace_id":"<trace>"}'
+curl https://gateway.ai.cloudflare.com/v1/<account>/<gateway>/openai/chat/completions
+  -H "cf-aig-metadata: $METADATA"
+  -d '{ "model": "gpt-4o-mini", "messages": [ ... ] }'
+
+# Import path: export Gateway logs, then normalize them into Blind Bench
+curl "https://api.cloudflare.com/client/v4/accounts/<account>/ai-gateway/gateways/<gateway>/logs"
+
+# Then run the local importer / eval runner for the selected pack.`
+
+export function GatewayOnboarding() {
+  const { org } = useOrg();
+  const base = `/orgs/${org.slug}`;
+
+  return (
+    <div className="mx-auto max-w-3xl p-6">
+      <header>
+        <div className="flex items-center gap-2">
+          <Plug aria-hidden="true" className="h-5 w-5 text-primary" />
+          <h1 className="text-2xl font-bold">Gateway onboarding</h1>
+        </div>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Feed Cloudflare AI Gateway logs into Blind Bench so production prompt
+          traffic becomes a measurable, reviewable eval set.
+        </p>
+      </header>
+
+      {/* Data boundary — management-safe */}
+      <Card className="mt-6 border-amber-500/40 bg-amber-500/5">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-base">
+            <ShieldAlert aria-hidden="true" className="h-4 w-4 text-amber-600" />
+            Data boundary
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2 text-sm text-muted-foreground">
+          <p>
+            <strong className="text-foreground">Repo & demo:</strong> synthetic or
+            redacted samples only. Never commit real prompts, outputs, or customer
+            content.
+          </p>
+          <p>
+            <strong className="text-foreground">prod_sensitive:</strong> real
+            production logs must stay customer-scoped inside the workspace. They
+            cannot be committed to the repo or shared outside the engagement.
+          </p>
+        </CardContent>
+      </Card>
+
+      {/* Checklist */}
+      <section className="mt-8" aria-labelledby="checklist-heading">
+        <h2 id="checklist-heading" className="text-lg font-semibold">
+          Onboarding checklist
+        </h2>
+        <ol className="mt-3 space-y-3">
+          {STEPS.map((step, i) => (
+            <li
+              key={step.title}
+              className="flex gap-3 rounded-lg border p-4"
+            >
+              <step.icon aria-hidden="true" className="mt-0.5 h-5 w-5 shrink-0 text-muted-foreground" />
+              <div>
+                <div className="flex items-center gap-2">
+                  <h3 className="text-sm font-medium">
+                    {i + 1}. {step.title}
+                  </h3>
+                  {"later" in step && step.later && (
+                    <Badge variant="secondary">later</Badge>
+                  )}
+                </div>
+                <p className="mt-1 text-sm text-muted-foreground">{step.detail}</p>
+              </div>
+            </li>
+          ))}
+        </ol>
+      </section>
+
+      {/* Product examples */}
+      <section className="mt-8" aria-labelledby="products-heading">
+        <h2 id="products-heading" className="text-lg font-semibold">
+          Example products & use cases
+        </h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Synthetic examples to model your own onboarding. Replace with your real
+          surfaces inside the workspace.
+        </p>
+        <div className="mt-3 grid gap-4 sm:grid-cols-2">
+          {PRODUCTS.map((p) => (
+            <Card key={p.name}>
+              <CardHeader>
+                <CardTitle className="text-base">{p.name}</CardTitle>
+                <p className="text-xs text-muted-foreground">{p.blurb}</p>
+              </CardHeader>
+              <CardContent className="space-y-3 text-sm">
+                <ul className="list-disc space-y-1 pl-4 text-muted-foreground">
+                  {p.cases.map((c) => (
+                    <li key={c}>{c}</li>
+                  ))}
+                </ul>
+                <pre className="overflow-x-auto rounded bg-muted p-2 text-xs">
+                  {JSON.stringify(p.metadata, null, 2)}
+                </pre>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </section>
+
+      {/* Metadata conventions */}
+      <section className="mt-8" aria-labelledby="metadata-heading">
+        <h2 id="metadata-heading" className="text-lg font-semibold">
+          Metadata conventions
+        </h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Attach these keys to every Gateway request. AI Gateway custom metadata
+          is limited in count and size — keep values short and put anything larger
+          (full prompt text, long ids, structured context) in a{" "}
+          <strong className="text-foreground">sidecar record</strong> keyed by{" "}
+          <code className="text-foreground">trace_id</code> rather than inline.
+        </p>
+        <dl className="mt-3 divide-y rounded-lg border">
+          {METADATA_FIELDS.map((f) => (
+            <div key={f.key} className="grid grid-cols-3 gap-2 px-4 py-2 text-sm">
+              <dt className="font-mono text-xs text-foreground">{f.key}</dt>
+              <dd className="col-span-2 text-muted-foreground">{f.desc}</dd>
+            </div>
+          ))}
+        </dl>
+      </section>
+
+      {/* Required permissions */}
+      <section className="mt-8" aria-labelledby="perms-heading">
+        <h2 id="perms-heading" className="text-lg font-semibold">
+          Required Cloudflare permissions
+        </h2>
+        <ul className="mt-3 list-disc space-y-1 pl-5 text-sm text-muted-foreground">
+          <li>
+            <strong className="text-foreground">AI Gateway — Read</strong> to export
+            request logs.
+          </li>
+          <li>
+            <strong className="text-foreground">AI Gateway — Edit</strong> if you
+            configure gateways or metadata rules.
+          </li>
+          <li>
+            An <strong className="text-foreground">API token</strong> scoped to the
+            specific account and gateway — not a global key.
+          </li>
+        </ul>
+      </section>
+
+      {/* Two paths */}
+      <section className="mt-8" aria-labelledby="paths-heading">
+        <h2 id="paths-heading" className="text-lg font-semibold">
+          Two ways to feed logs in
+        </h2>
+        <div className="mt-3 grid gap-4 sm:grid-cols-2">
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-base">
+                <MousePointerClick aria-hidden="true" className="h-4 w-4" />
+                No-code / manual
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="text-sm text-muted-foreground">
+              <ol className="list-decimal space-y-1 pl-4">
+                <li>Open the AI Gateway dashboard for the account.</li>
+                <li>Filter logs by product / time window.</li>
+                <li>Export the log set (CSV/JSON).</li>
+                <li>Import as test cases in a Blind Bench project.</li>
+              </ol>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-base">
+                <Terminal aria-hidden="true" className="h-4 w-4" />
+                CLI / API
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <pre className="overflow-x-auto rounded bg-muted p-3 text-xs leading-relaxed">
+                {CLI_SNIPPET}
+              </pre>
+            </CardContent>
+          </Card>
+        </div>
+      </section>
+
+      {/* Fireworks — later */}
+      <Card className="mt-8 border-primary/30 bg-primary/5">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-base">
+            <KeyRound aria-hidden="true" className="h-4 w-4 text-primary" />
+            Where Fireworks credentials enter (later)
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2 text-sm text-muted-foreground">
+          <p>
+            After a baseline scorecard exists, a Fireworks-hosted candidate model
+            is added to run head-to-head against production. That step needs a
+            Fireworks API key configured in the workspace.
+          </p>
+          <p>
+            <strong className="text-foreground">This slice does not require
+            Fireworks credentials.</strong>{" "}
+            You can complete every step above — including export, baseline, review,
+            and scorecard — before adding a candidate-model key.
+          </p>
+        </CardContent>
+      </Card>
+
+      {/* Footer links */}
+      <div className="mt-8 flex flex-wrap gap-4 border-t pt-4 text-sm">
+        <Link
+          to={`${base}/settings/openrouter-key`}
+          className="inline-flex items-center gap-1 text-primary hover:underline"
+        >
+          BYOK / model key settings
+        </Link>
+        <a
+          href="https://developers.cloudflare.com/ai-gateway/"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-1 text-primary hover:underline"
+        >
+          Cloudflare AI Gateway docs
+          <ExternalLink aria-hidden="true" className="h-3 w-3" />
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/src/routes/orgs/OrgHome.tsx
+++ b/src/routes/orgs/OrgHome.tsx
@@ -5,7 +5,7 @@ import { useOrg } from "@/contexts/OrgContext";
 import { useOrgLayout } from "@/components/layouts/OrgLayout";
 import { EmptyState } from "@/components/EmptyState";
 import { Skeleton } from "@/components/ui/skeleton";
-import { ClipboardCheck, FolderOpen, ChevronRight } from "lucide-react";
+import { ClipboardCheck, FolderOpen, ChevronRight, Plug } from "lucide-react";
 
 export function OrgHome() {
   const { org, orgId } = useOrg();
@@ -46,6 +46,22 @@ export function OrgHome() {
           ))}
         </div>
       )}
+
+      <Link
+        to={`/orgs/${org.slug}/gateway-onboarding`}
+        className="mt-4 flex items-center justify-between rounded-lg border px-4 py-3 hover:bg-accent transition-colors"
+      >
+        <div className="flex items-center gap-3">
+          <Plug className="h-4 w-4 text-primary shrink-0" />
+          <div>
+            <div className="text-sm font-medium">Gateway onboarding</div>
+            <div className="text-xs text-muted-foreground">
+              Feed Cloudflare AI Gateway logs into Blind Bench.
+            </div>
+          </div>
+        </div>
+        <ChevronRight className="h-4 w-4 text-muted-foreground" />
+      </Link>
 
       <div className="mt-6">
         {projects === undefined ? (


### PR DESCRIPTION
## Summary

Adds the first visible app-side onboarding surface for the Cloudflare AI Gateway → Blind Bench pilot loop.

- Adds authenticated org route `/orgs/:orgSlug/gateway-onboarding`.
- Adds a visible "Gateway onboarding" workspace nav item for all org roles.
- Adds an org-home card so the onboarding flow is discoverable before or after prompts exist.
- Documents the app-side flow for:
  - choosing product/use-case surfaces
  - Migo and Eavesly synthetic example use cases
  - required metadata conventions despite Gateway metadata limits
  - manual/no-code export path and CLI/API path
  - baseline eval → review/promote → scorecard handoff
  - where Fireworks credentials enter later, without requiring them for this slice
- Includes management-safe data-boundary callouts: repo/demo use synthetic or redacted samples only; `prod_sensitive` logs stay customer-scoped and must not be committed.

Addresses #232 for the static/app-side onboarding slice.

## Verification

- ✅ `env -u NODE_ENV npx esbuild src/routes/orgs/GatewayOnboarding.tsx --bundle --platform=browser --format=esm --jsx=automatic --external:react --external:react/jsx-runtime --external:react-router-dom --external:lucide-react --external:@/* --outfile=/tmp/gateway-onboarding.js`
- ✅ `env -u NODE_ENV npm run test:evals` — 8 files / 68 tests passed
- ✅ `git diff --check` — clean
- ⚠️ `env -u NODE_ENV npm run build` still blocked locally by missing generated Convex bindings (`convex/_generated/*`); `npx convex codegen --typecheck disable` reports `No CONVEX_DEPLOYMENT set`. This is the existing local environment blocker, not introduced by this PR.

## Claude Code review

Claude Code reviewed the final diff and approved. I fixed its important copy/rendering finding before committing: the CLI snippet now avoids broken shell line-continuations, and decorative icons are `aria-hidden`.