### PR TITLE
Add Fireworks training dataset compiler

### DIFF
--- a/docs/training-dataset-compiler.md
+++ b/docs/training-dataset-compiler.md
@@ -1,0 +1,105 @@
+# Training dataset compiler (Fireworks SFT)
+
+Local, deterministic compiler that turns explicitly **training-approved** review
+candidates into a Fireworks-compatible chat/SFT JSONL dataset with train /
+validation / test splits and a manifest.
+
+Source: `src/lib/evals/trainingDataset.ts` · Tests: `trainingDataset.test.ts`.
+
+It is **compiler + fixtures + tests only**: no network, no Convex, no Fireworks
+API call. The caller supplies `generated_at` so artifacts are byte-stable.
+
+## Run it
+
+```bash
+npm run dataset:customer-pilot            # uses a fixed default generated_at
+npm run dataset:customer-pilot 2026-06-24T00:00:00Z   # override timestamp
+```
+
+Writes (into the gitignored `artifacts/`):
+
+- `customer-pilot-training-dataset.train.jsonl`
+- `customer-pilot-training-dataset.validation.jsonl`
+- `customer-pilot-training-dataset.test.jsonl`
+- `customer-pilot-training-dataset.manifest.json`
+
+The pilot source is the **synthetic** customer-pilot smoke pack only — fake data.
+
+## Output shapes
+
+Each JSONL line is a **messages-only** Fireworks chat/SFT row — nothing else:
+
+```json
+{"messages":[{"role":"user","content":"…"},{"role":"assistant","content":"…"}]}
+```
+
+Messages are `transcript` + case `messages` + the safe assistant completion. Keys
+are stably sorted so JSONL is deterministic, and the row is strictly valid JSON for
+every row (no inline sidecar keys that could be `undefined`).
+
+**Per-row metadata lives in the manifest, not in the JSONL.** The manifest's
+`row_entries` maps each split to an array of `{ case_id, product, source,
+classification, privacy_class, split, approver, approved_at?, variant?,
+customer_scope?, hash }`, where `hash` is the SHA-256 of that row's messages-only
+JSONL line (so the manifest verifies exactly what was written). Optional fields are
+omitted when absent — `JSON.stringify` keeps the manifest valid JSON.
+
+The manifest also carries source filters, split ratios + counts, a `dataset_hash`,
+products, privacy classes, classifications, and every excluded row with its reason.
+
+### Split ratios
+
+`splits: { train, validation }` (test is the remainder). Both must be finite and
+non-negative, and `train + validation <= 1` (sum `== 1` is allowed — an intentionally
+empty test split). Invalid ratios throw before any row is compiled.
+
+### Forbidden-content safety gate
+
+Pass `blocked_substrings: string[]` to exclude any row whose input messages or
+completion contain a known forbidden sentinel (cross-tenant ids, PII markers). Blocked
+rows are reported in `manifest.excluded` with reason `forbidden_substring_blocked` (the
+matched value is never echoed) and never written to JSONL.
+
+## Data-boundary rules
+
+Mirrors [`tenancy-consent-data-isolation.md`](./tenancy-consent-data-isolation.md)
+and [`review-promotion-workflow.md`](./review-promotion-workflow.md). The compiler
+is **default-deny** — a row only exports if it clears every gate:
+
+1. **Approved by construction.** Inputs are `TrainingExportCandidate`s from
+   `approveForTraining()`. There is no other way to get a candidate, so a row
+   that never passed the training gate cannot be fed in.
+2. **Classification.** `prod_sensitive` and `redacted_prod` candidates are
+   blocked (`prod_sensitive_blocked` / `redacted_prod_not_exportable`). Only
+   `training_approved` exports.
+3. **Explicit policy approval for real data.** A non-`synthetic` source row
+   exports only when the caller passes `allow_training_approved_export: true`.
+   Synthetic rows always pass. Without the flag, real rows are excluded as
+   `training_approved_export_not_policy_approved`. **Never export raw prompt/
+   output text from `prod_sensitive` or unapproved production sources.**
+4. **Eval-set contamination prevention.** Rows marked `eval_only` (held-out)
+   never appear in train or validation. They reach the **test** split only when
+   `allow_in_test` is set; otherwise they are excluded
+   (`held_out_eval_only_excluded`).
+5. **Field redaction.** Only curated metadata is emitted (case id, product,
+   variant, classification, privacy class, split, approver, customer scope). The
+   raw snapshot, scorer config, and provider payloads are never written.
+
+## Ingesting Cloudflare AI Gateway traces
+
+Traces are not fed in directly. The path is:
+
+```
+normalizeCloudflareAiGatewayLog → convertTraceToEvalCase → review (ReviewDecision)
+  → approveForTraining(... training_approved policy ...) → TrainingExportCandidate
+  → TrainingDatasetSourceRow (with source: "production_log") → compileTrainingDataset
+```
+
+Real (production) rows still require `allow_training_approved_export: true`, which
+is the explicit per-customer policy-approval gate.
+
+## Filters
+
+`compileTrainingDataset(rows, { filters })` supports `products`, `variants`,
+`privacy_classes`, `classifications`, `customer_scopes`, `approvers`, `min_score`,
+and `min_rating`. Filtered rows appear in the manifest as `filtered_out:<axis>`.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "preview": "vite preview",
     "test:evals": "vitest run src/lib/evals/",
     "test:convex": "vitest run --config convex/vitest.config.ts",
-    "scorecard:customer-pilot": "npx tsx src/lib/evals/scorecard.ts"
+    "scorecard:customer-pilot": "npx tsx src/lib/evals/scorecard.ts",
+    "dataset:customer-pilot": "npx tsx src/lib/evals/trainingDataset.ts"
   },
   "dependencies": {
     "@auth/core": "^0.37.4",

--- a/src/lib/evals/trainingDataset.test.ts
+++ b/src/lib/evals/trainingDataset.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it } from "vitest";
+import { EvalCase } from "./evalCase";
+import { customerPilotSmokeCases } from "./packs/customerPilot";
+import {
+  PromotionPolicy,
+  ReviewDecision,
+  approveForTraining,
+  type TrainingExportCandidate,
+} from "./reviewWorkflow";
+import {
+  SPLITS,
+  compileTrainingDataset,
+  customerPilotTrainingSourceRows,
+  formatManifest,
+  toJsonl,
+  type TrainingDatasetSourceRow,
+} from "./trainingDataset";
+
+const GENERATED_AT = "2026-01-01T00:00:00Z";
+
+// Approve a synthetic case for training and wrap it as a source row.
+function syntheticRow(
+  i: number,
+  over: Partial<TrainingDatasetSourceRow> = {},
+): TrainingDatasetSourceRow {
+  const c = EvalCase.parse(customerPilotSmokeCases[i]);
+  const candidate = approveForTraining(
+    c,
+    ReviewDecision.parse({
+      case_id: c.id,
+      reviewer_id: "reviewer-TEST-1",
+      outcome: "pass",
+      reason_tag: "approved_for_training",
+    }),
+    PromotionPolicy.parse({
+      classification: "training_approved",
+      review_allowed: true,
+      training_allowed: true,
+    }),
+    GENERATED_AT,
+  );
+  return {
+    candidate,
+    source: c.source,
+    assistant_output: `Synthetic safe completion for ${c.id}.`,
+    metrics: { score: 1, rating: 5 },
+    ...over,
+  };
+}
+
+const compile = (rows: TrainingDatasetSourceRow[], opts = {}) =>
+  compileTrainingDataset(rows, { generated_at: GENERATED_AT, ...opts });
+
+describe("training approval gates", () => {
+  it("exports training_approved synthetic rows", () => {
+    const { manifest, splits } = compile([syntheticRow(0)]);
+    const total = SPLITS.reduce((n, s) => n + splits[s].length, 0);
+    expect(total).toBe(1);
+    expect(manifest.excluded).toEqual([]);
+    expect(manifest.classifications).toEqual(["training_approved"]);
+  });
+
+  it("blocks prod_sensitive candidates by construction", () => {
+    // Hand-built candidate (approveForTraining would never emit prod_sensitive).
+    const base = syntheticRow(0);
+    const candidate: TrainingExportCandidate = {
+      ...base.candidate,
+      classification: "prod_sensitive",
+    };
+    const { manifest, splits } = compile([{ ...base, candidate, source: "production_log" }]);
+    expect(SPLITS.every((s) => splits[s].length === 0)).toBe(true);
+    expect(manifest.excluded).toEqual([
+      { case_id: base.candidate.source_case_id, reason: "prod_sensitive_blocked" },
+    ]);
+  });
+
+  it("excludes unapproved production rows unless policy approval is explicit", () => {
+    const row = syntheticRow(1, { source: "production_log" });
+    expect(compile([row]).manifest.excluded[0]?.reason).toBe(
+      "training_approved_export_not_policy_approved",
+    );
+    // Explicit policy approval lets it through.
+    const ok = compile([row], { allow_training_approved_export: true });
+    expect(ok.manifest.excluded).toEqual([]);
+    expect(SPLITS.reduce((n, s) => n + ok.splits[s].length, 0)).toBe(1);
+  });
+});
+
+describe("eval-set contamination prevention", () => {
+  it("keeps held-out rows out of train/validation, test only when allowed", () => {
+    // eval_only without allow_in_test → excluded everywhere.
+    const blocked = compile([syntheticRow(0, { eval_only: true, split_hint: "train" })]);
+    expect(blocked.splits.train).toEqual([]);
+    expect(blocked.manifest.excluded[0]?.reason).toBe("held_out_eval_only_excluded");
+
+    // eval_only + allow_in_test → test ONLY, never train/validation, ignoring split_hint.
+    const allowed = compile([syntheticRow(0, { eval_only: true, allow_in_test: true, split_hint: "train" })]);
+    expect(allowed.splits.train).toEqual([]);
+    expect(allowed.splits.validation).toEqual([]);
+    expect(allowed.splits.test).toHaveLength(1);
+  });
+});
+
+describe("deterministic splits + manifest", () => {
+  it("produces identical splits, hashes, and JSONL across runs", () => {
+    const rows = customerPilotTrainingSourceRows();
+    const a = compile(rows);
+    const b = compile(rows);
+    expect(a.manifest.dataset_hash).toBe(b.manifest.dataset_hash);
+    expect(a.manifest.split_counts).toEqual(b.manifest.split_counts);
+    for (const s of SPLITS) expect(toJsonl(a.splits[s])).toBe(toJsonl(b.splits[s]));
+  });
+
+  it("every held-out pilot row lands in test, never train/validation", () => {
+    const { splits } = compile(customerPilotTrainingSourceRows());
+    const heldOut = customerPilotTrainingSourceRows()
+      .filter((r) => r.eval_only)
+      .map((r) => r.candidate.source_case_id);
+    const trainVal = [...splits.train, ...splits.validation].map((r) => r.metadata.case_id);
+    expect(heldOut.length).toBeGreaterThan(0);
+    expect(heldOut.some((id) => trainVal.includes(id))).toBe(false);
+  });
+
+  it("manifest counts reconcile with split sizes and source rows", () => {
+    const rows = customerPilotTrainingSourceRows();
+    const { manifest, splits } = compile(rows);
+    const exported = SPLITS.reduce((n, s) => n + splits[s].length, 0);
+    expect(exported + manifest.excluded.length).toBe(rows.length);
+    for (const s of SPLITS) expect(manifest.split_counts[s]).toBe(splits[s].length);
+  });
+});
+
+describe("filters", () => {
+  it("filters by product and min_rating", () => {
+    const rows = customerPilotTrainingSourceRows();
+    const { manifest } = compile(rows, { filters: { products: ["migo"] } });
+    expect(manifest.products).toEqual(["migo"]);
+    expect(manifest.excluded.some((e) => e.reason === "filtered_out:product")).toBe(true);
+
+    const lowRating = compile([syntheticRow(0, { metrics: { rating: 2 } })], {
+      filters: { min_rating: 4 },
+    });
+    expect(lowRating.manifest.excluded[0]?.reason).toBe("filtered_out:min_rating");
+  });
+});
+
+describe("output safety", () => {
+  it("emits messages-only JSONL that is valid JSON, no sidecar metadata inline", () => {
+    const { splits } = compile(customerPilotTrainingSourceRows());
+    const blob = SPLITS.map((s) => toJsonl(splits[s])).join("");
+    for (const line of blob.split("\n").filter(Boolean)) {
+      const row = JSON.parse(line); // throws if not strictly valid JSON
+      expect(Object.keys(row)).toEqual(["messages"]); // Fireworks chat/SFT shape only
+      expect(Array.isArray(row.messages)).toBe(true);
+      expect(row.messages.at(-1).role).toBe("assistant");
+      expect(row.metadata).toBeUndefined(); // metadata lives in the manifest
+    }
+  });
+
+  it("serializes valid JSONL even when approved_at/variant/customer_scope are absent", () => {
+    // A row missing every optional metadata field — the stableStringify undefined bug.
+    const base = syntheticRow(0);
+    const candidate: TrainingExportCandidate = { ...base.candidate, approved_at: undefined as never };
+    const { splits, manifest } = compile([
+      { ...base, candidate, variant: undefined, customer_scope: undefined },
+    ]);
+    const blob = SPLITS.map((s) => toJsonl(splits[s])).join("");
+    expect(blob).not.toContain("undefined"); // would appear if stableStringify hit an undefined value
+    for (const line of blob.split("\n").filter(Boolean)) {
+      expect(() => JSON.parse(line)).not.toThrow();
+    }
+    // Manifest is valid JSON too (JSON.stringify drops the absent optional keys).
+    const entry = SPLITS.flatMap((s) => manifest.row_entries[s])[0];
+    expect(entry?.approved_at).toBeUndefined();
+    expect(JSON.parse(formatManifest(manifest)).split_counts).toBeDefined();
+  });
+
+  it("blocks rows containing a forbidden sentinel and keeps it out of the JSONL", () => {
+    const dirty = syntheticRow(1, {
+      assistant_output: "Sure — the cross-tenant id is OTHER-7777, balance overdue.",
+    });
+    const clean = syntheticRow(2);
+    const { splits, manifest } = compile([dirty, clean], {
+      blocked_substrings: ["OTHER-7777", "overdue"],
+    });
+    // Dirty row excluded and reported; clean row exported.
+    expect(manifest.excluded).toContainEqual({
+      case_id: dirty.candidate.source_case_id,
+      reason: "forbidden_substring_blocked",
+    });
+    expect(SPLITS.reduce((n, s) => n + splits[s].length, 0)).toBe(1);
+    // The sentinel never reaches the JSONL.
+    const blob = SPLITS.map((s) => toJsonl(splits[s])).join("");
+    expect(blob).not.toContain("OTHER-7777");
+    expect(blob).not.toContain("overdue");
+  });
+});
+
+describe("split ratio validation", () => {
+  it("rejects negative, non-finite, or oversized ratios", () => {
+    const rows = [syntheticRow(0)];
+    expect(() => compile(rows, { splits: { train: -0.1, validation: 0.1 } })).toThrow(/non-negative/);
+    expect(() => compile(rows, { splits: { train: NaN, validation: 0.1 } })).toThrow(/finite/);
+    expect(() => compile(rows, { splits: { train: Infinity, validation: 0 } })).toThrow(/finite/);
+    expect(() => compile(rows, { splits: { train: 0.8, validation: 0.5 } })).toThrow(/<= 1/);
+    // Sum == 1 is allowed (intentionally empty test split).
+    expect(() => compile(rows, { splits: { train: 0.7, validation: 0.3 } })).not.toThrow();
+  });
+});

--- a/src/lib/evals/trainingDataset.ts
+++ b/src/lib/evals/trainingDataset.ts
@@ -1,0 +1,409 @@
+/**
+ * Local, deterministic Fireworks training-dataset compiler (issue #228).
+ *
+ * Turns explicitly training-approved review candidates into a Fireworks-compatible
+ * chat/SFT JSONL dataset with deterministic train/validation/test splits and a
+ * manifest. Pure and local: no network, no Convex, no Fireworks API, no real
+ * customer data. The caller supplies `generated_at` so output is byte-stable.
+ *
+ * DATA-BOUNDARY CONTRACT (mirrors docs/tenancy-consent-data-isolation.md):
+ *  - Only candidates produced by `approveForTraining` enter (TS enforces this).
+ *  - `prod_sensitive` / `redacted_prod` candidates are blocked by construction.
+ *  - Non-synthetic `training_approved` rows export ONLY when the caller passes
+ *    `allow_training_approved_export` (default-deny explicit policy approval).
+ *  - Rows marked `eval_only` (held-out) never reach train/validation; they reach
+ *    the test split only when `allow_in_test` is set, else they are excluded.
+ * Excluded rows are reported with a reason in the manifest, never dropped silently.
+ */
+import { createHash } from "node:crypto";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+import { EvalCase, type PrivacyClass, type ScenarioSource } from "./evalCase";
+import { stableStringify } from "./cloudflareAiGateway";
+import {
+  customerPilotSmokeCases,
+  customerPilotSmokeFixturesAllPass,
+} from "./packs/customerPilot";
+import {
+  PromotionPolicy,
+  ReviewDecision,
+  approveForTraining,
+  type DataClassification,
+  type TrainingExportCandidate,
+} from "./reviewWorkflow";
+
+export type SplitName = "train" | "validation" | "test";
+export const SPLITS: SplitName[] = ["train", "validation", "test"];
+
+// --- Inputs ------------------------------------------------------------------
+
+/** A training-approved candidate plus the metadata the compiler filters/splits on. */
+export interface TrainingDatasetSourceRow {
+  /** Produced by `approveForTraining` — the approval gate by construction. */
+  candidate: TrainingExportCandidate;
+  /** Provenance of the underlying case; gates raw-text export of real prod data. */
+  source: ScenarioSource;
+  /** Safe assistant completion for SFT (synthetic or approved-redacted text). */
+  assistant_output: string;
+  /** Held-out / eval-only: must never appear in train or validation. */
+  eval_only?: boolean;
+  /** Explicit allowance for an eval_only row to appear in the test split. */
+  allow_in_test?: boolean;
+  /** Force a split; otherwise a deterministic hash of the case id decides. */
+  split_hint?: SplitName;
+  variant?: string;
+  customer_scope?: string;
+  /** Optional reviewer score / rating used by min_score / min_rating filters. */
+  metrics?: { score?: number; rating?: number };
+}
+
+export interface TrainingDatasetFilters {
+  products?: string[];
+  variants?: string[];
+  privacy_classes?: PrivacyClass[];
+  classifications?: DataClassification[];
+  customer_scopes?: string[];
+  approvers?: string[];
+  min_score?: number;
+  min_rating?: number;
+}
+
+export interface CompileOptions {
+  /** ISO-8601 timestamp stamped into the manifest (caller-supplied, deterministic). */
+  generated_at: string;
+  dataset_name?: string;
+  filters?: TrainingDatasetFilters;
+  /** Required to export non-synthetic `training_approved` rows (default-deny). */
+  allow_training_approved_export?: boolean;
+  /** Split ratios; test is the remainder. Defaults to 0.8 / 0.1 / 0.1. */
+  splits?: { train: number; validation: number };
+  /**
+   * Safety gate: any row whose input messages OR completion contain one of these
+   * substrings is excluded (reason `forbidden_substring_blocked`) and never written
+   * to JSONL. Use for known forbidden sentinels (cross-tenant ids, PII markers).
+   */
+  blocked_substrings?: string[];
+}
+
+// --- Outputs -----------------------------------------------------------------
+
+/**
+ * Safe sidecar metadata for a kept row. Lives in the MANIFEST (per-row entries),
+ * never in the training JSONL — see `toJsonl`. Optional fields may be absent;
+ * `JSON.stringify` (manifest) omits undefined keys so the manifest stays valid JSON.
+ */
+export interface RowMetadata {
+  case_id: string;
+  product: string;
+  source: ScenarioSource;
+  classification: DataClassification;
+  privacy_class: PrivacyClass;
+  split: SplitName;
+  approver: string;
+  approved_at?: string;
+  variant?: string;
+  customer_scope?: string;
+}
+
+/**
+ * A compiled row held in memory. Only `messages` is written to JSONL (Fireworks
+ * chat/SFT shape: `{ "messages": [...] }`); `metadata` is emitted in the manifest.
+ */
+export interface CompiledRow {
+  messages: { role: string; content: string }[];
+  metadata: RowMetadata;
+}
+
+/** Manifest per-row entry: the safe sidecar metadata plus the JSONL row hash. */
+export type RowEntry = RowMetadata & { hash: string };
+
+export interface ExcludedRow {
+  case_id: string;
+  reason: string;
+}
+
+export interface TrainingDatasetManifest {
+  dataset_name: string;
+  generated_at: string;
+  filters: TrainingDatasetFilters;
+  allow_training_approved_export: boolean;
+  split_ratios: { train: number; validation: number; test: number };
+  products: string[];
+  privacy_classes: string[];
+  classifications: string[];
+  split_counts: Record<SplitName, number>;
+  /** Per-row sidecar metadata + hash of the messages-only JSONL row, by split. */
+  row_entries: Record<SplitName, RowEntry[]>;
+  dataset_hash: string;
+  excluded: ExcludedRow[];
+}
+
+export interface CompiledTrainingDataset {
+  splits: Record<SplitName, CompiledRow[]>;
+  manifest: TrainingDatasetManifest;
+}
+
+// --- Helpers -----------------------------------------------------------------
+
+const sha256hex = (s: string) => createHash("sha256").update(s).digest("hex");
+
+/** Stable 0–99 bucket from the case id — deterministic split assignment. */
+function hashBucket(caseId: string): number {
+  return createHash("sha256").update(caseId).digest().readUInt32BE(0) % 100;
+}
+
+/** Build the SFT message list: prior transcript, then case messages, then the completion. */
+function buildMessages(row: TrainingDatasetSourceRow): { role: string; content: string }[] {
+  const input = row.candidate.snapshot.input;
+  return [
+    ...(input.transcript ?? []),
+    ...(input.messages ?? []),
+    { role: "assistant", content: row.assistant_output },
+  ];
+}
+
+/**
+ * Why a row is excluded, or null if it should be kept. Default-deny: the first
+ * failing gate wins, in classification → policy → filter order.
+ */
+function exclusionReason(row: TrainingDatasetSourceRow, opts: CompileOptions): string | null {
+  const c = row.candidate;
+  if (c.kind !== "training_export") return "not a training_export candidate";
+
+  // Classification gate (defensive — approveForTraining only emits training_approved).
+  if (c.classification === "prod_sensitive") return "prod_sensitive_blocked";
+  if (c.classification === "redacted_prod") return "redacted_prod_not_exportable";
+  if (c.classification !== "training_approved") return "classification_not_exportable";
+
+  // Real (non-synthetic) data needs explicit policy approval to export raw text.
+  if (row.source !== "synthetic" && !opts.allow_training_approved_export)
+    return "training_approved_export_not_policy_approved";
+
+  if (!row.assistant_output) return "no_assistant_output";
+  const messages = buildMessages(row);
+  if (messages.length <= 1) return "no_input_messages";
+
+  // Safety gate: drop rows carrying a known forbidden sentinel in input or completion.
+  // Reason is generic on purpose — never echo the matched value into the manifest.
+  if (opts.blocked_substrings?.some((s) => messages.some((m) => m.content.includes(s))))
+    return "forbidden_substring_blocked";
+
+  // Filters.
+  const f = opts.filters ?? {};
+  const privacy = c.snapshot.expected.privacy_class;
+  if (f.products && !f.products.includes(c.product)) return "filtered_out:product";
+  if (f.classifications && !f.classifications.includes(c.classification))
+    return "filtered_out:classification";
+  if (f.privacy_classes && !f.privacy_classes.includes(privacy)) return "filtered_out:privacy_class";
+  if (f.variants && !f.variants.includes(row.variant ?? "")) return "filtered_out:variant";
+  if (f.customer_scopes && !f.customer_scopes.includes(row.customer_scope ?? ""))
+    return "filtered_out:customer_scope";
+  if (f.approvers && !f.approvers.includes(c.approver)) return "filtered_out:approver";
+  if (f.min_score !== undefined && !(typeof row.metrics?.score === "number" && row.metrics.score >= f.min_score))
+    return "filtered_out:min_score";
+  if (f.min_rating !== undefined && !(typeof row.metrics?.rating === "number" && row.metrics.rating >= f.min_rating))
+    return "filtered_out:min_rating";
+
+  // Contamination prevention: held-out rows never train/validate; test only if allowed.
+  if (row.eval_only && !row.allow_in_test) return "held_out_eval_only_excluded";
+
+  return null;
+}
+
+/** Reject non-finite, negative, or >1 split ratios before compiling. */
+function validateRatios(ratios: { train: number; validation: number }): void {
+  const { train, validation } = ratios;
+  for (const [name, v] of [["train", train], ["validation", validation]] as const) {
+    if (!Number.isFinite(v) || v < 0)
+      throw new Error(`Invalid split ratio: ${name}=${v} must be finite and non-negative`);
+  }
+  // test is the remainder (1 - train - validation); allow == 1 (empty test) but not over.
+  if (train + validation > 1)
+    throw new Error(
+      `Invalid split ratios: train(${train}) + validation(${validation}) = ${train + validation} must be <= 1`,
+    );
+}
+
+/** Resolve the split for a KEPT row. Held-out rows are forced to test. */
+function assignSplit(
+  row: TrainingDatasetSourceRow,
+  ratios: { train: number; validation: number },
+): SplitName {
+  if (row.eval_only) return "test"; // exclusionReason already required allow_in_test
+  if (row.split_hint) return row.split_hint;
+  const bucket = hashBucket(row.candidate.source_case_id);
+  const t = Math.round(ratios.train * 100);
+  const v = Math.round(ratios.validation * 100);
+  if (bucket < t) return "train";
+  if (bucket < t + v) return "validation";
+  return "test";
+}
+
+// --- Compile -----------------------------------------------------------------
+
+export function compileTrainingDataset(
+  rows: TrainingDatasetSourceRow[],
+  opts: CompileOptions,
+): CompiledTrainingDataset {
+  const ratios = opts.splits ?? { train: 0.8, validation: 0.1 };
+  validateRatios(ratios);
+  const splits: Record<SplitName, CompiledRow[]> = { train: [], validation: [], test: [] };
+  const excluded: ExcludedRow[] = [];
+  const products = new Set<string>();
+  const privacyClasses = new Set<string>();
+  const classifications = new Set<string>();
+
+  for (const row of rows) {
+    const reason = exclusionReason(row, opts);
+    if (reason) {
+      excluded.push({ case_id: row.candidate.source_case_id, reason });
+      continue;
+    }
+    const split = assignSplit(row, ratios);
+    const c = row.candidate;
+    products.add(c.product);
+    privacyClasses.add(c.snapshot.expected.privacy_class);
+    classifications.add(c.classification);
+    const metadata: RowMetadata = {
+      case_id: c.source_case_id,
+      product: c.product,
+      source: row.source,
+      classification: c.classification,
+      privacy_class: c.snapshot.expected.privacy_class,
+      split,
+      approver: c.approver,
+    };
+    if (c.approved_at !== undefined) metadata.approved_at = c.approved_at;
+    if (row.variant !== undefined) metadata.variant = row.variant;
+    if (row.customer_scope !== undefined) metadata.customer_scope = row.customer_scope;
+    splits[split].push({
+      messages: buildMessages(row),
+      metadata,
+    });
+  }
+
+  // Sort every split by case id for deterministic ordering, then hash.
+  const row_entries = {} as Record<SplitName, RowEntry[]>;
+  const split_counts = {} as Record<SplitName, number>;
+  for (const s of SPLITS) {
+    splits[s].sort((a, b) => a.metadata.case_id.localeCompare(b.metadata.case_id));
+    split_counts[s] = splits[s].length;
+    // Hash the messages-only JSONL row so the manifest verifies what's actually written.
+    row_entries[s] = splits[s].map((r) => ({
+      ...r.metadata,
+      hash: sha256hex(jsonlLine(r)),
+    }));
+  }
+  excluded.sort((a, b) => a.case_id.localeCompare(b.case_id) || a.reason.localeCompare(b.reason));
+
+  const dataset_hash = sha256hex(stableStringify(row_entries));
+
+  return {
+    splits,
+    manifest: {
+      dataset_name: opts.dataset_name ?? "training-dataset",
+      generated_at: opts.generated_at,
+      filters: opts.filters ?? {},
+      allow_training_approved_export: opts.allow_training_approved_export ?? false,
+      split_ratios: { train: ratios.train, validation: ratios.validation, test: Number((1 - ratios.train - ratios.validation).toFixed(4)) },
+      products: [...products].sort(),
+      privacy_classes: [...privacyClasses].sort(),
+      classifications: [...classifications].sort(),
+      split_counts,
+      row_entries,
+      dataset_hash,
+      excluded,
+    },
+  };
+}
+
+/**
+ * One messages-only JSONL line for a row: `{"messages":[...]}`. Fireworks chat/SFT
+ * shape. Always valid JSON — no optional/undefined sidecar keys (those live in the
+ * manifest). stableStringify gives deterministic key order; message contents are strings.
+ */
+function jsonlLine(row: CompiledRow): string {
+  return stableStringify({ messages: row.messages });
+}
+
+/** Serialize one split to deterministic, strictly-valid JSONL (trailing newline). */
+export function toJsonl(rows: CompiledRow[]): string {
+  return rows.map(jsonlLine).join("\n") + (rows.length ? "\n" : "");
+}
+
+export function formatManifest(manifest: TrainingDatasetManifest): string {
+  return JSON.stringify(manifest, null, 2) + "\n";
+}
+
+// --- Synthetic customer-pilot fixture source ---------------------------------
+
+const PILOT_REVIEWED_AT = "2026-01-01T00:00:00Z";
+const PILOT_APPROVED_AT = "2026-01-01T00:00:00Z";
+
+/**
+ * Build training source rows from the SYNTHETIC customer-pilot smoke pack by
+ * approving each case with an explicit `training_approved` policy and pairing it
+ * with the clean (all-pass) synthetic completion. Every 5th case is marked
+ * held-out (eval_only, allow_in_test) to exercise contamination prevention.
+ */
+export function customerPilotTrainingSourceRows(): TrainingDatasetSourceRow[] {
+  const policy = PromotionPolicy.parse({
+    classification: "training_approved",
+    review_allowed: true,
+    training_allowed: true,
+  });
+  return customerPilotSmokeCases.map((raw, i) => {
+    const c = EvalCase.parse(raw);
+    const review = ReviewDecision.parse({
+      case_id: c.id,
+      reviewer_id: "reviewer-TEST-1",
+      outcome: "pass",
+      reason_tag: "approved_for_training",
+      reviewed_at: PILOT_REVIEWED_AT,
+    });
+    const candidate = approveForTraining(c, review, policy, PILOT_APPROVED_AT);
+    const eval_only = i % 5 === 0;
+    return {
+      candidate,
+      source: c.source,
+      assistant_output: customerPilotSmokeFixturesAllPass[c.id]?.text ?? "",
+      eval_only,
+      allow_in_test: eval_only,
+      variant: c.product === "eavesly" ? "voice-v1" : "sms-v1",
+      customer_scope: (c.metadata?.customer_scope as string | undefined) ?? "customer-pilot",
+      metrics: { score: 1, rating: 5 },
+    };
+  });
+}
+
+// --- CLI entrypoint ----------------------------------------------------------
+
+const OUT_DIR = "artifacts";
+const BASENAME = "customer-pilot-training-dataset";
+// Fixed default so `npm run dataset:customer-pilot` is byte-stable; override via argv[0].
+const DEFAULT_GENERATED_AT = "2026-01-01T00:00:00Z";
+
+export async function main(argv: string[]): Promise<number> {
+  const generated_at = argv[0] ?? DEFAULT_GENERATED_AT;
+  const { splits, manifest } = compileTrainingDataset(customerPilotTrainingSourceRows(), {
+    generated_at,
+    dataset_name: BASENAME,
+  });
+
+  mkdirSync(OUT_DIR, { recursive: true });
+  for (const s of SPLITS) writeFileSync(`${OUT_DIR}/${BASENAME}.${s}.jsonl`, toJsonl(splits[s]));
+  writeFileSync(`${OUT_DIR}/${BASENAME}.manifest.json`, formatManifest(manifest));
+
+  process.stdout.write(
+    `Wrote ${OUT_DIR}/${BASENAME}.{train,validation,test}.jsonl + .manifest.json\n` +
+      `  splits: train=${manifest.split_counts.train} validation=${manifest.split_counts.validation} test=${manifest.split_counts.test}\n` +
+      `  excluded: ${manifest.excluded.length}  dataset_hash: ${manifest.dataset_hash.slice(0, 16)}…\n`,
+  );
+  return 0;
+}
+
+const invokedDirectly =
+  process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (invokedDirectly) {
+  main(process.argv.slice(2)).then((code) => process.exit(code));
+}


### PR DESCRIPTION
## Summary

Implements the next M30 milestone: a local Fireworks training dataset compiler from explicitly training-approved Blind Bench review candidates.

Closes #228

- Adds `src/lib/evals/trainingDataset.ts` for deterministic train/validation/test JSONL splits plus a manifest.
- Adds `npm run dataset:customer-pilot`, which writes gitignored `artifacts/customer-pilot-training-dataset.{train,validation,test}.jsonl` and `.manifest.json`.
- Emits Fireworks-compatible messages-only chat/SFT JSONL (`{"messages":[...]}`); per-row metadata and hashes live in `manifest.row_entries`.
- Enforces default-deny training export gates: `prod_sensitive` and `redacted_prod` are blocked, non-synthetic `training_approved` rows require explicit `allow_training_approved_export`, and held-out/eval-only rows can never enter train/validation.
- Adds blocked-substring protection for known forbidden sentinels and reports exclusions without echoing matched sensitive values.
- Documents the compiler, Cloudflare AI Gateway trace handoff path, filters, split-ratio rules, and data-boundary contract.

## Verification

- ✅ `env -u NODE_ENV npm run test:evals` — 9 files / 80 tests passed
- ✅ `env -u NODE_ENV npm run dataset:customer-pilot` — wrote dataset artifacts; train=29, validation=6, test=15, excluded=0
- ✅ messages-only JSONL smoke: parsed all generated JSONL rows and verified each row only has `messages`, with assistant final turn
- ✅ `env -u NODE_ENV npx tsc --ignoreConfig --noEmit --module ESNext --moduleResolution bundler --target ES2022 --types node --strict --skipLibCheck src/lib/evals/trainingDataset.ts src/lib/evals/trainingDataset.test.ts` — passed
- ✅ `git diff --check` — clean
- ⚠️ `env -u NODE_ENV npm run build` still fails locally on the known repo-wide Convex generated-bindings blocker (`convex/_generated/*` missing). `npx convex codegen --typecheck disable` reports `No CONVEX_DEPLOYMENT set`.

## Data boundary

Compiler + fixtures + tests only: no network calls, no Convex writes, no Fireworks API calls, no real customer data. The included customer-pilot source rows are synthetic fake data only; generated artifacts remain gitignored and regenerated on demand.