### PR TITLE
Add Polar self-serve billing foundation

### DIFF
--- a/convex/billing.ts
+++ b/convex/billing.ts
@@ -1,0 +1,427 @@
+import { ConvexError, v } from "convex/values";
+import {
+  action,
+  query,
+  internalQuery,
+  internalMutation,
+} from "./_generated/server";
+import { internal } from "./_generated/api";
+import { Id } from "./_generated/dataModel";
+import { QueryCtx, MutationCtx } from "./_generated/server";
+import { requireOrgRole } from "./lib/auth";
+import {
+  BILLING_PACKAGES,
+  TRIAL,
+  getPackage,
+  resolveProductId,
+  publicPackageCatalog,
+} from "./lib/billingPlans";
+
+// Webhook event types we act on. Anything else is acknowledged and ignored.
+const GRANT_EVENTS = new Set(["order.paid"]);
+const REFUND_EVENTS = new Set(["order.refunded", "order.refund.created"]);
+const REVOKE_EVENTS = new Set([
+  "subscription.revoked",
+  "subscription.canceled",
+  "subscription.cancelled",
+]);
+
+/** Sum of all ledger deltas for an org = remaining eval credits. */
+async function sumCredits(
+  ctx: QueryCtx,
+  orgId: Id<"organizations">,
+): Promise<number> {
+  const rows = await ctx.db
+    .query("billingLedger")
+    .withIndex("by_org", (q) => q.eq("organizationId", orgId))
+    .collect();
+  return rows.reduce((acc, r) => acc + r.creditDelta, 0);
+}
+
+async function activeEntitlement(ctx: QueryCtx, orgId: Id<"organizations">) {
+  return ctx.db
+    .query("billingEntitlements")
+    .withIndex("by_org_and_status", (q) =>
+      q.eq("organizationId", orgId).eq("status", "active"),
+    )
+    .first();
+}
+
+// ---------------------------------------------------------------------------
+// Owner-facing read
+// ---------------------------------------------------------------------------
+
+/**
+ * Owner-only billing overview: catalog config, the active entitlement,
+ * remaining credits, recent ledger, and portal availability. The UI consumes
+ * the catalog from here rather than hard-coding product IDs or credit counts.
+ */
+export const getBillingOverview = query({
+  args: { orgId: v.id("organizations") },
+  handler: async (ctx, args) => {
+    await requireOrgRole(ctx, args.orgId, ["owner"]);
+
+    const entitlement = await activeEntitlement(ctx, args.orgId);
+    const customer = await ctx.db
+      .query("billingCustomers")
+      .withIndex("by_org", (q) => q.eq("organizationId", args.orgId))
+      .unique();
+
+    const ledger = await ctx.db
+      .query("billingLedger")
+      .withIndex("by_org", (q) => q.eq("organizationId", args.orgId))
+      .order("desc")
+      .take(20);
+
+    return {
+      packages: publicPackageCatalog(),
+      trial: TRIAL,
+      entitlement: entitlement
+        ? { packageKey: entitlement.packageKey, status: entitlement.status }
+        : null,
+      remainingCredits: await sumCredits(ctx, args.orgId),
+      ledger: ledger.map((r) => ({
+        creditDelta: r.creditDelta,
+        reason: r.reason,
+        packageKey: r.packageKey ?? null,
+        createdAt: r.createdAt,
+      })),
+      // Portal needs an established Polar customer; self-serve checkout needs
+      // the Polar access token to be configured server-side.
+      portalAvailable: !!customer,
+      checkoutConfigured: !!process.env.POLAR_ACCESS_TOKEN,
+    };
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Internal helpers for actions (actions can't touch ctx.db directly)
+// ---------------------------------------------------------------------------
+
+export const loadBillingContext = internalQuery({
+  args: { orgId: v.id("organizations") },
+  handler: async (ctx, args) => {
+    const { userId } = await requireOrgRole(ctx, args.orgId, ["owner"]);
+    const org = await ctx.db.get(args.orgId);
+    const customer = await ctx.db
+      .query("billingCustomers")
+      .withIndex("by_org", (q) => q.eq("organizationId", args.orgId))
+      .unique();
+    return {
+      userId,
+      orgSlug: org?.slug ?? "",
+      polarCustomerId: customer?.polarCustomerId ?? null,
+      externalCustomerId: customer?.externalCustomerId ?? null,
+    };
+  },
+});
+
+/** Create-or-resume the org's billing customer row. Idempotent. */
+export const ensureBillingCustomer = internalMutation({
+  args: { orgId: v.id("organizations") },
+  handler: async (ctx, args) => {
+    const externalCustomerId = args.orgId as string;
+    const existing = await ctx.db
+      .query("billingCustomers")
+      .withIndex("by_org", (q) => q.eq("organizationId", args.orgId))
+      .unique();
+    if (existing) return existing.externalCustomerId;
+    const now = Date.now();
+    await ctx.db.insert("billingCustomers", {
+      organizationId: args.orgId,
+      externalCustomerId,
+      createdAt: now,
+      updatedAt: now,
+    });
+    return externalCustomerId;
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Checkout + portal actions
+// ---------------------------------------------------------------------------
+
+function polarBaseUrl(): string {
+  return process.env.POLAR_API_URL ?? "https://api.polar.sh";
+}
+
+function appBaseUrl(): string {
+  return process.env.APP_BASE_URL ?? "http://localhost:5173";
+}
+
+/**
+ * Begin a self-serve checkout. Resolves the package's product ID from env and
+ * sends only org id / package key / environment as metadata — never any trace
+ * or eval data. Fails closed (ConvexError) when billing isn't configured.
+ */
+export const createCheckout = action({
+  args: { orgId: v.id("organizations"), packageKey: v.string() },
+  handler: async (ctx, args) => {
+    const pkg = getPackage(args.packageKey);
+    if (!pkg) throw new ConvexError("Unknown package.");
+    if (pkg.manualEnterprise) {
+      throw new ConvexError(
+        "Enterprise is sales-assisted. Contact us to get set up.",
+      );
+    }
+
+    const ctxData: { userId: Id<"users">; orgSlug: string } =
+      await ctx.runQuery(internal.billing.loadBillingContext, {
+        orgId: args.orgId,
+      });
+
+    const productId = resolveProductId(pkg);
+    const accessToken = process.env.POLAR_ACCESS_TOKEN;
+    if (!productId || !accessToken) {
+      throw new ConvexError("Billing is not configured. Contact support.");
+    }
+
+    // Create-or-resume the local customer so the same external id is reused.
+    const externalCustomerId: string = await ctx.runMutation(
+      internal.billing.ensureBillingCustomer,
+      { orgId: args.orgId },
+    );
+
+    const environment = process.env.POLAR_ENV ?? "production";
+    const successUrl = `${appBaseUrl()}/orgs/${ctxData.orgSlug}/settings/billing?checkout=success`;
+
+    const res = await fetch(`${polarBaseUrl()}/v1/checkouts/`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        products: [productId],
+        external_customer_id: externalCustomerId,
+        success_url: successUrl,
+        metadata: {
+          orgId: args.orgId as string,
+          packageKey: pkg.key,
+          environment,
+        },
+      }),
+    });
+
+    if (!res.ok) {
+      throw new ConvexError("Could not start checkout. Please try again.");
+    }
+    const data = (await res.json()) as { id: string; url: string };
+    return { checkoutId: data.id, url: data.url };
+  },
+});
+
+/**
+ * Open the Polar customer portal for managing/cancelling a subscription.
+ * Requires an established Polar customer; fails gracefully otherwise.
+ */
+export const createCustomerPortal = action({
+  args: { orgId: v.id("organizations") },
+  handler: async (ctx, args) => {
+    const ctxData: { polarCustomerId: string | null; externalCustomerId: string | null } =
+      await ctx.runQuery(internal.billing.loadBillingContext, { orgId: args.orgId });
+
+    const accessToken = process.env.POLAR_ACCESS_TOKEN;
+    if (!accessToken) {
+      throw new ConvexError("Billing is not configured. Contact support.");
+    }
+    const customerRef = ctxData.polarCustomerId
+      ? { customer_id: ctxData.polarCustomerId }
+      : { external_customer_id: ctxData.externalCustomerId ?? (args.orgId as string) };
+
+    const res = await fetch(`${polarBaseUrl()}/v1/customer-sessions/`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(customerRef),
+    });
+    if (!res.ok) {
+      throw new ConvexError("Could not open billing portal. Please try again.");
+    }
+    const data = (await res.json()) as { customer_portal_url: string };
+    return { url: data.customer_portal_url };
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Webhook application (idempotent)
+// ---------------------------------------------------------------------------
+
+async function upsertActiveEntitlement(
+  ctx: MutationCtx,
+  orgId: Id<"organizations">,
+  packageKey: string,
+  polarSubscriptionId: string | undefined,
+) {
+  const now = Date.now();
+  const existing = await activeEntitlement(ctx, orgId);
+  if (existing) {
+    await ctx.db.patch(existing._id, {
+      packageKey,
+      polarSubscriptionId,
+      updatedAt: now,
+    });
+    return existing._id;
+  }
+  return ctx.db.insert("billingEntitlements", {
+    organizationId: orgId,
+    packageKey,
+    status: "active",
+    polarSubscriptionId,
+    grantedAt: now,
+    updatedAt: now,
+  });
+}
+
+/**
+ * Apply a verified, sanitized Polar webhook event. Idempotent by `eventId`
+ * (re-delivery is a no-op) AND by `polarOrderId` (a duplicate order never
+ * double-credits). Only payment/entitlement bookkeeping happens here — no
+ * trace or test-case data is touched. Returns a result object for tests.
+ */
+export const applyPolarEvent = internalMutation({
+  args: {
+    eventId: v.string(),
+    eventType: v.string(),
+    externalCustomerId: v.string(),
+    packageKey: v.optional(v.string()),
+    polarCustomerId: v.optional(v.string()),
+    polarOrderId: v.optional(v.string()),
+    polarSubscriptionId: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    // 1. Event-level idempotency.
+    const seen = await ctx.db
+      .query("polarWebhookEvents")
+      .withIndex("by_event_id", (q) => q.eq("eventId", args.eventId))
+      .unique();
+    if (seen) return { duplicate: true, action: "duplicate" as const };
+
+    const finish = async (result: string, extra: Record<string, unknown>) => {
+      await ctx.db.insert("polarWebhookEvents", {
+        eventId: args.eventId,
+        eventType: args.eventType,
+        processedAt: Date.now(),
+        result,
+      });
+      return { duplicate: false, action: result, ...extra };
+    };
+
+    // 2. Resolve org safely from the external customer id (= org id).
+    const orgId = ctx.db.normalizeId("organizations", args.externalCustomerId);
+    if (!orgId || !(await ctx.db.get(orgId))) {
+      return finish("ignored_unknown_org", {});
+    }
+
+    // 3. Create-or-resume the customer row; record the Polar customer id.
+    const now = Date.now();
+    const customer = await ctx.db
+      .query("billingCustomers")
+      .withIndex("by_org", (q) => q.eq("organizationId", orgId))
+      .unique();
+    if (!customer) {
+      await ctx.db.insert("billingCustomers", {
+        organizationId: orgId,
+        externalCustomerId: args.externalCustomerId,
+        polarCustomerId: args.polarCustomerId,
+        createdAt: now,
+        updatedAt: now,
+      });
+    } else if (args.polarCustomerId && !customer.polarCustomerId) {
+      await ctx.db.patch(customer._id, {
+        polarCustomerId: args.polarCustomerId,
+        updatedAt: now,
+      });
+    }
+
+    // 4. Branch on event type.
+    if (GRANT_EVENTS.has(args.eventType)) {
+      const pkg = args.packageKey ? getPackage(args.packageKey) : undefined;
+      if (!pkg) return finish("ignored_unknown_package", {});
+
+      // Order-level idempotency: never double-credit the same order.
+      if (args.polarOrderId) {
+        const prior = await ctx.db
+          .query("billingLedger")
+          .withIndex("by_order", (q) =>
+            q.eq("polarOrderId", args.polarOrderId),
+          )
+          .first();
+        if (prior) {
+          return finish("duplicate_order", {
+            creditDelta: 0,
+            entitlementStatus: "active",
+          });
+        }
+      }
+
+      await upsertActiveEntitlement(
+        ctx,
+        orgId,
+        pkg.key,
+        args.polarSubscriptionId,
+      );
+      await ctx.db.insert("billingLedger", {
+        organizationId: orgId,
+        creditDelta: pkg.monthlyEvalCredits,
+        reason: "package_purchase",
+        packageKey: pkg.key,
+        polarOrderId: args.polarOrderId,
+        polarSubscriptionId: args.polarSubscriptionId,
+        polarEventId: args.eventId,
+        createdAt: now,
+      });
+      return finish("granted", {
+        creditDelta: pkg.monthlyEvalCredits,
+        entitlementStatus: "active",
+        packageKey: pkg.key,
+      });
+    }
+
+    if (REFUND_EVENTS.has(args.eventType)) {
+      // Reverse the exact grant for this order, once.
+      if (!args.polarOrderId) return finish("ignored_no_order", {});
+      const entries = await ctx.db
+        .query("billingLedger")
+        .withIndex("by_order", (q) => q.eq("polarOrderId", args.polarOrderId))
+        .collect();
+      const grant = entries.find((e) => e.creditDelta > 0);
+      const alreadyRefunded = entries.some((e) => e.creditDelta < 0);
+      if (!grant || alreadyRefunded) {
+        return finish("ignored_no_grant", {});
+      }
+      await ctx.db.insert("billingLedger", {
+        organizationId: orgId,
+        creditDelta: -grant.creditDelta,
+        reason: "refund",
+        packageKey: grant.packageKey,
+        polarOrderId: args.polarOrderId,
+        polarSubscriptionId: args.polarSubscriptionId,
+        polarEventId: args.eventId,
+        createdAt: now,
+      });
+      const ent = await activeEntitlement(ctx, orgId);
+      if (ent) await ctx.db.patch(ent._id, { status: "revoked", updatedAt: now });
+      return finish("refunded", {
+        creditDelta: -grant.creditDelta,
+        entitlementStatus: "revoked",
+      });
+    }
+
+    if (REVOKE_EVENTS.has(args.eventType)) {
+      const ent = await activeEntitlement(ctx, orgId);
+      if (ent) await ctx.db.patch(ent._id, { status: "revoked", updatedAt: now });
+      return finish("revoked", {
+        creditDelta: 0,
+        entitlementStatus: "revoked",
+      });
+    }
+
+    return finish("ignored_unsupported", {});
+  },
+});
+
+// Re-export so callers/tests can reference the catalog symbol from this module.
+export { BILLING_PACKAGES };

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -2,10 +2,103 @@ import { httpRouter } from "convex/server";
 import { httpAction } from "./_generated/server";
 import { internal } from "./_generated/api";
 import { auth } from "./auth";
+import { verifyWebhook } from "./lib/polarSignature";
 
 const http = httpRouter();
 
 auth.addHttpRoutes(http);
+
+// --- Polar billing webhook ---
+
+/**
+ * Pull ONLY the scalar billing fields we need out of a Polar event. Never
+ * forwards arbitrary payload (no trace/test-case content can leak this way).
+ * `orgId`/`packageKey` come from the metadata we set at checkout, falling back
+ * to the customer's external id (which is the org id).
+ */
+function sanitizePolarEvent(eventId: string, event: unknown) {
+  if (!event || typeof event !== "object") return null;
+  const e = event as Record<string, unknown>;
+  const eventType = typeof e.type === "string" ? e.type : "";
+  if (!eventType) return null;
+  const data = (e.data ?? {}) as Record<string, unknown>;
+  const meta = (data.metadata ?? {}) as Record<string, unknown>;
+  const customer = (data.customer ?? {}) as Record<string, unknown>;
+  const subscription = (data.subscription ?? {}) as Record<string, unknown>;
+
+  const str = (x: unknown): string | undefined =>
+    typeof x === "string" && x.length > 0 ? x : undefined;
+
+  const externalCustomerId =
+    str(meta.orgId) ??
+    str(data.external_customer_id) ??
+    str(customer.external_id) ??
+    str(data.customer_external_id);
+  if (!externalCustomerId) return null;
+
+  return {
+    eventId,
+    eventType,
+    externalCustomerId,
+    packageKey: str(meta.packageKey),
+    polarCustomerId: str(data.customer_id) ?? str(customer.id),
+    polarOrderId:
+      eventType.startsWith("order") ? str(data.id) ?? str(data.order_id) : str(data.order_id),
+    polarSubscriptionId:
+      str(data.subscription_id) ?? str(subscription.id) ??
+      (eventType.startsWith("subscription") ? str(data.id) : undefined),
+  };
+}
+
+http.route({
+  path: "/polar/webhook",
+  method: "POST",
+  handler: httpAction(async (ctx, req) => {
+    const secret = process.env.POLAR_WEBHOOK_SECRET;
+    if (!secret) {
+      return new Response("Billing webhook not configured", { status: 503 });
+    }
+
+    const id = req.headers.get("webhook-id");
+    const timestamp = req.headers.get("webhook-timestamp");
+    const signature = req.headers.get("webhook-signature");
+    const body = await req.text();
+
+    if (!id || !timestamp || !signature) {
+      return new Response("Missing signature headers", { status: 400 });
+    }
+
+    const ok = await verifyWebhook({ id, timestamp, signature, body, secret });
+    if (!ok) {
+      return new Response("Invalid signature", { status: 401 });
+    }
+
+    let event: unknown;
+    try {
+      event = JSON.parse(body);
+    } catch {
+      return new Response("Invalid JSON", { status: 400 });
+    }
+
+    const sanitized = sanitizePolarEvent(id, event);
+    if (!sanitized) {
+      // Acknowledge so Polar doesn't retry an event we can't route.
+      return new Response(JSON.stringify({ ok: true, ignored: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    const result = await ctx.runMutation(
+      internal.billing.applyPolarEvent,
+      sanitized,
+    );
+    return new Response(JSON.stringify({ ok: true, result }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }),
+});
 
 // --- Landing page demo vote endpoints ---
 

--- a/convex/lib/__tests__/polarSignature.test.ts
+++ b/convex/lib/__tests__/polarSignature.test.ts
@@ -1,0 +1,82 @@
+import { describe, test, expect } from "vitest";
+import { signWebhook, verifyWebhook } from "../polarSignature";
+
+const secret = "whsec_" + btoa("super-secret-key-for-testing-only");
+const id = "msg_2KWPBgLlAfxdpx2AI54pPJ85f4W";
+const body = JSON.stringify({ type: "order.paid", data: { id: "ord_1" } });
+const now = 1_700_000_000_000;
+const timestamp = String(Math.floor(now / 1000));
+
+describe("polar webhook signature", () => {
+  test("verifies a signature it produced", async () => {
+    const signature = await signWebhook(id, timestamp, body, secret);
+    expect(
+      await verifyWebhook({ id, timestamp, signature, body, secret, nowMs: now }),
+    ).toBe(true);
+  });
+
+  test("rejects a tampered body", async () => {
+    const signature = await signWebhook(id, timestamp, body, secret);
+    expect(
+      await verifyWebhook({
+        id,
+        timestamp,
+        signature,
+        body: body + " ",
+        secret,
+        nowMs: now,
+      }),
+    ).toBe(false);
+  });
+
+  test("rejects a wrong secret", async () => {
+    const signature = await signWebhook(id, timestamp, body, secret);
+    expect(
+      await verifyWebhook({
+        id,
+        timestamp,
+        signature,
+        body,
+        secret: "whsec_" + btoa("different-key"),
+        nowMs: now,
+      }),
+    ).toBe(false);
+  });
+
+  test("rejects a stale timestamp outside tolerance", async () => {
+    const signature = await signWebhook(id, timestamp, body, secret);
+    expect(
+      await verifyWebhook({
+        id,
+        timestamp,
+        signature,
+        body,
+        secret,
+        nowMs: now + 10 * 60 * 1000, // 10 min later, tolerance is 5 min
+      }),
+    ).toBe(false);
+  });
+
+  test("accepts a plain (non-whsec) secret as utf-8", async () => {
+    const plain = "plain-secret";
+    const signature = await signWebhook(id, timestamp, body, plain);
+    expect(
+      await verifyWebhook({
+        id,
+        timestamp,
+        signature,
+        body,
+        secret: plain,
+        nowMs: now,
+      }),
+    ).toBe(true);
+  });
+
+  test("accepts any matching entry among rotated signatures", async () => {
+    const valid = await signWebhook(id, timestamp, body, secret);
+    const signature = `v1,bogussignaturevalue ${valid}`;
+    expect(
+      await verifyWebhook({ id, timestamp, signature, body, secret, nowMs: now }),
+    ).toBe(true);
+  });
+});

--- a/convex/lib/billingPlans.ts
+++ b/convex/lib/billingPlans.ts
@@ -1,0 +1,150 @@
+/**
+ * Self-serve billing package configuration (Polar payments foundation).
+ *
+ * Single source of truth for what each package grants. Product IDs are NEVER
+ * hard-coded here — they are resolved at runtime from environment variables
+ * (one per package) so the same code runs against Polar sandbox and
+ * production without edits. The frontend consumes this metadata via
+ * `api.billing.getBillingOverview` rather than hard-coding product IDs or
+ * credit counts in UI copy.
+ *
+ * Billing model (see docs/polar-self-serve-billing.md):
+ *   - Packages: a monthly subscription that grants a fixed bundle of eval
+ *     credits + reviewer seats + trace-import headroom + a support level.
+ *   - Credits: a fungible per-eval unit tracked in `billingLedger`. A package
+ *     purchase adds a positive ledger entry; a refund/revoke adds a negative
+ *     one. Remaining credits = sum of all ledger deltas for the org.
+ *   - Trial: every workspace starts with a small free credit grant (no card).
+ *   - Manual enterprise: the largest tier is sales-assisted, not self-serve;
+ *     `manualEnterprise: true` hides the self-serve checkout button.
+ */
+
+export type PackageKey = "starter" | "team" | "scale" | "enterprise";
+
+export type SupportLevel = "community" | "standard" | "priority";
+
+export interface BillingPackage {
+  key: PackageKey;
+  name: string;
+  /** One-line value prop shown in the UI. */
+  blurb: string;
+  /**
+   * Environment variable holding the Polar product ID for this package.
+   * Resolved at runtime; absent => self-serve checkout fails closed.
+   */
+  productEnvVar: string;
+  /** Eval credits granted per paid billing period. */
+  monthlyEvalCredits: number;
+  /** Reviewer seats included. */
+  reviewerSeats: number;
+  /** Max trace imports per billing period. */
+  traceImportLimit: number;
+  supportLevel: SupportLevel;
+  /** True => sales-assisted only; no self-serve checkout. */
+  manualEnterprise: boolean;
+}
+
+/**
+ * Trial grant applied to a fresh workspace before any purchase. Represented in
+ * config (not UI copy) so the same number drives the ledger seed and the UI.
+ */
+export const TRIAL = {
+  evalCredits: 50,
+  reviewerSeats: 2,
+  traceImportLimit: 10,
+} as const;
+
+export const BILLING_PACKAGES: Record<PackageKey, BillingPackage> = {
+  starter: {
+    key: "starter",
+    name: "Starter",
+    blurb: "For individuals validating a single prompt.",
+    productEnvVar: "POLAR_PRODUCT_STARTER",
+    monthlyEvalCredits: 500,
+    reviewerSeats: 3,
+    traceImportLimit: 100,
+    supportLevel: "community",
+    manualEnterprise: false,
+  },
+  team: {
+    key: "team",
+    name: "Team",
+    blurb: "For teams running regular blind evals.",
+    productEnvVar: "POLAR_PRODUCT_TEAM",
+    monthlyEvalCredits: 2500,
+    reviewerSeats: 10,
+    traceImportLimit: 1000,
+    supportLevel: "standard",
+    manualEnterprise: false,
+  },
+  scale: {
+    key: "scale",
+    name: "Scale",
+    blurb: "For orgs with high eval volume.",
+    productEnvVar: "POLAR_PRODUCT_SCALE",
+    monthlyEvalCredits: 10000,
+    reviewerSeats: 25,
+    traceImportLimit: 5000,
+    supportLevel: "priority",
+    manualEnterprise: false,
+  },
+  enterprise: {
+    key: "enterprise",
+    name: "Enterprise",
+    blurb: "Custom volume, SSO, and a dedicated contact. Talk to us.",
+    // No self-serve product; provisioned manually after a contract.
+    productEnvVar: "POLAR_PRODUCT_ENTERPRISE",
+    monthlyEvalCredits: 0,
+    reviewerSeats: 0,
+    traceImportLimit: 0,
+    supportLevel: "priority",
+    manualEnterprise: true,
+  },
+};
+
+export const PACKAGE_ORDER: PackageKey[] = [
+  "starter",
+  "team",
+  "scale",
+  "enterprise",
+];
+
+export function isPackageKey(key: string): key is PackageKey {
+  return key in BILLING_PACKAGES;
+}
+
+/** Lookup a package or return undefined. Callers throw their own user error. */
+export function getPackage(key: string): BillingPackage | undefined {
+  return isPackageKey(key) ? BILLING_PACKAGES[key] : undefined;
+}
+
+/**
+ * Resolve the Polar product ID for a package from the environment. Returns
+ * undefined when unset so callers can fail closed with a user-facing error.
+ */
+export function resolveProductId(
+  pkg: BillingPackage,
+  env: Record<string, string | undefined> = process.env,
+): string | undefined {
+  return env[pkg.productEnvVar];
+}
+
+/**
+ * Public, secret-free view of the catalog for the UI. Never includes resolved
+ * product IDs — those stay server-side.
+ */
+export function publicPackageCatalog() {
+  return PACKAGE_ORDER.map((key) => {
+    const p = BILLING_PACKAGES[key];
+    return {
+      key: p.key,
+      name: p.name,
+      blurb: p.blurb,
+      monthlyEvalCredits: p.monthlyEvalCredits,
+      reviewerSeats: p.reviewerSeats,
+      traceImportLimit: p.traceImportLimit,
+      supportLevel: p.supportLevel,
+      manualEnterprise: p.manualEnterprise,
+    };
+  });
+}

--- a/convex/lib/polarSignature.ts
+++ b/convex/lib/polarSignature.ts
@@ -1,0 +1,115 @@
+/**
+ * Standard Webhooks signature verification for Polar webhooks.
+ * https://www.standardwebhooks.com/ — Polar signs with this scheme.
+ *
+ * Signed content is `${webhook-id}.${webhook-timestamp}.${rawBody}`. The
+ * `webhook-signature` header is a space-delimited list of `v1,<base64sig>`
+ * entries (key rotation can send several); the message is authentic if ANY
+ * entry matches our HMAC-SHA256 over the signed content.
+ *
+ * The secret is the Standard Webhooks form `whsec_<base64>`; the HMAC key is
+ * the base64-decoded portion after the prefix. A raw (non-prefixed) secret is
+ * accepted as UTF-8 bytes so local testing can use a plain string.
+ *
+ * Pure (Web Crypto only) so it runs under the Convex V8 runtime and the
+ * vitest edge-runtime without `_generated`.
+ */
+
+const DEFAULT_TOLERANCE_SECONDS = 300; // 5 min replay window
+
+function toBase64(bytes: Uint8Array): string {
+  let binary = "";
+  for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i]!);
+  return btoa(binary);
+}
+
+function fromBase64(b64: string): Uint8Array {
+  const binary = atob(b64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}
+
+function secretToKeyBytes(secret: string): Uint8Array {
+  if (secret.startsWith("whsec_")) return fromBase64(secret.slice("whsec_".length));
+  return new TextEncoder().encode(secret);
+}
+
+async function hmacBase64(keyBytes: Uint8Array, message: string): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    keyBytes,
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const sig = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    new TextEncoder().encode(message),
+  );
+  return toBase64(new Uint8Array(sig));
+}
+
+/** Length-independent constant-time string compare. */
+function timingSafeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  return diff === 0;
+}
+
+export interface VerifyArgs {
+  id: string;
+  timestamp: string; // unix seconds, as sent in `webhook-timestamp`
+  signature: string; // raw `webhook-signature` header value
+  body: string; // raw request body, exactly as received
+  secret: string;
+  toleranceSeconds?: number;
+  /** Injectable clock for tests. Defaults to Date.now(). */
+  nowMs?: number;
+}
+
+/**
+ * Returns true iff the signature is valid AND the timestamp is within the
+ * replay tolerance. Never throws on bad input — returns false.
+ */
+export async function verifyWebhook(args: VerifyArgs): Promise<boolean> {
+  const tolerance = args.toleranceSeconds ?? DEFAULT_TOLERANCE_SECONDS;
+  const now = args.nowMs ?? Date.now();
+
+  const ts = Number(args.timestamp);
+  if (!Number.isFinite(ts)) return false;
+  if (Math.abs(now / 1000 - ts) > tolerance) return false;
+
+  let expected: string;
+  try {
+    const signedContent = `${args.id}.${args.timestamp}.${args.body}`;
+    expected = await hmacBase64(secretToKeyBytes(args.secret), signedContent);
+  } catch {
+    return false;
+  }
+
+  for (const part of args.signature.split(" ")) {
+    const comma = part.indexOf(",");
+    if (comma === -1) continue;
+    const value = part.slice(comma + 1);
+    if (timingSafeEqual(value, expected)) return true;
+  }
+  return false;
+}
+
+/**
+ * Produce a valid `webhook-signature` header value for the given content.
+ * Used by tests (and any local sender) to exercise verification end-to-end.
+ */
+export async function signWebhook(
+  id: string,
+  timestamp: string,
+  body: string,
+  secret: string,
+): Promise<string> {
+  const signedContent = `${id}.${timestamp}.${body}`;
+  const sig = await hmacBase64(secretToKeyBytes(secret), signedContent);
+  return `v1,${sig}`;
+}

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -988,6 +988,72 @@ const schema = defineSchema({
     .index("by_scope", ["scope", "scopeId"])
     .index("by_email_scope", ["email", "scope", "scopeId"])
     .index("by_org_status", ["orgId", "status"]),
+
+  // =========================================================================
+  // Polar self-serve billing. Payment state lives ONLY in these four tables
+  // and is never joined to trace/eval/test-case data. Nothing here stores
+  // customer trace content — only money/entitlement bookkeeping and Polar IDs.
+  // =========================================================================
+
+  // One row per org once it touches billing. `externalCustomerId` is the
+  // stable handle we send to Polar (derived from the org id) so checkout can
+  // create-or-resume the same Polar customer; `polarCustomerId` is filled in
+  // once Polar assigns one.
+  billingCustomers: defineTable({
+    organizationId: v.id("organizations"),
+    externalCustomerId: v.string(),
+    polarCustomerId: v.optional(v.string()),
+    createdAt: v.number(),
+    updatedAt: v.number(),
+  })
+    .index("by_org", ["organizationId"])
+    .index("by_polar_customer", ["polarCustomerId"])
+    .index("by_external_customer", ["externalCustomerId"]),
+
+  // Current package grant for an org. One active row per org at a time; older
+  // grants are flipped to "revoked" rather than deleted for audit.
+  billingEntitlements: defineTable({
+    organizationId: v.id("organizations"),
+    packageKey: v.string(),
+    status: v.union(
+      v.literal("trialing"),
+      v.literal("active"),
+      v.literal("revoked"),
+    ),
+    polarSubscriptionId: v.optional(v.string()),
+    grantedAt: v.number(),
+    updatedAt: v.number(),
+  })
+    .index("by_org", ["organizationId"])
+    .index("by_org_and_status", ["organizationId", "status"])
+    .index("by_subscription", ["polarSubscriptionId"]),
+
+  // Append-only credit ledger. Remaining credits = sum of `creditDelta` for an
+  // org. Purchases add positive deltas; refunds/revocations add negative ones.
+  // Carries Polar IDs for idempotency and audit — never trace/test-case data.
+  billingLedger: defineTable({
+    organizationId: v.id("organizations"),
+    creditDelta: v.number(),
+    reason: v.string(),
+    packageKey: v.optional(v.string()),
+    polarOrderId: v.optional(v.string()),
+    polarSubscriptionId: v.optional(v.string()),
+    polarEventId: v.optional(v.string()),
+    createdAt: v.number(),
+  })
+    .index("by_org", ["organizationId"])
+    .index("by_order", ["polarOrderId"])
+    .index("by_subscription", ["polarSubscriptionId"])
+    .index("by_event", ["polarEventId"]),
+
+  // Idempotency + audit log of every webhook delivery we accepted. Keyed by the
+  // Standard Webhooks `webhook-id`; a repeat delivery is a no-op.
+  polarWebhookEvents: defineTable({
+    eventId: v.string(),
+    eventType: v.string(),
+    processedAt: v.number(),
+    result: v.string(),
+  }).index("by_event_id", ["eventId"]),
 });
 
 export default schema;

--- a/convex/tests/billing.test.ts
+++ b/convex/tests/billing.test.ts
@@ -1,0 +1,228 @@
+import { convexTest } from "convex-test";
+import { expect, test, describe } from "vitest";
+import { api, internal } from "../_generated/api";
+import schema from "../schema";
+
+async function seedBillingEnv() {
+  const t = convexTest(schema);
+  const ids = await t.run(async (ctx) => {
+    const ownerUserId = await ctx.db.insert("users", {
+      name: "Owner",
+      email: "owner@test.com",
+    });
+    const orgId = await ctx.db.insert("organizations", {
+      name: "Acme",
+      slug: "acme",
+      createdById: ownerUserId,
+    });
+    await ctx.db.insert("organizationMembers", {
+      organizationId: orgId,
+      userId: ownerUserId,
+      role: "owner",
+    });
+    return { ownerUserId, orgId };
+  });
+
+  const asOwner = t.withIdentity({
+    subject: `${ids.ownerUserId}|s`,
+    tokenIdentifier: `test|${ids.ownerUserId}`,
+  });
+  return { t, ids, asOwner };
+}
+
+function orderPaid(orgId: string, eventId: string, orderId: string) {
+  return {
+    eventId,
+    eventType: "order.paid",
+    externalCustomerId: orgId,
+    packageKey: "team",
+    polarCustomerId: "cus_123",
+    polarOrderId: orderId,
+    polarSubscriptionId: "sub_123",
+  };
+}
+
+describe("applyPolarEvent", () => {
+  test("order.paid grants entitlement + credits", async () => {
+    const { t, ids } = await seedBillingEnv();
+    const res = await t.mutation(
+      internal.billing.applyPolarEvent,
+      orderPaid(ids.orgId, "evt_1", "ord_1"),
+    );
+    expect(res).toMatchObject({
+      duplicate: false,
+      action: "granted",
+      creditDelta: 2500,
+      entitlementStatus: "active",
+      packageKey: "team",
+    });
+
+    await t.run(async (ctx) => {
+      const ledger = await ctx.db
+        .query("billingLedger")
+        .withIndex("by_org", (q) => q.eq("organizationId", ids.orgId))
+        .collect();
+      expect(ledger).toHaveLength(1);
+      expect(ledger[0].creditDelta).toBe(2500);
+
+      const ent = await ctx.db
+        .query("billingEntitlements")
+        .withIndex("by_org", (q) => q.eq("organizationId", ids.orgId))
+        .collect();
+      expect(ent).toHaveLength(1);
+      expect(ent[0].status).toBe("active");
+      expect(ent[0].packageKey).toBe("team");
+
+      const cust = await ctx.db
+        .query("billingCustomers")
+        .withIndex("by_org", (q) => q.eq("organizationId", ids.orgId))
+        .unique();
+      expect(cust?.polarCustomerId).toBe("cus_123");
+    });
+  });
+
+  test("redelivery of same event id is a no-op", async () => {
+    const { t, ids } = await seedBillingEnv();
+    await t.mutation(internal.billing.applyPolarEvent, orderPaid(ids.orgId, "evt_1", "ord_1"));
+    const dup = await t.mutation(
+      internal.billing.applyPolarEvent,
+      orderPaid(ids.orgId, "evt_1", "ord_1"),
+    );
+    expect(dup).toMatchObject({ duplicate: true });
+
+    await t.run(async (ctx) => {
+      const ledger = await ctx.db
+        .query("billingLedger")
+        .withIndex("by_org", (q) => q.eq("organizationId", ids.orgId))
+        .collect();
+      expect(ledger).toHaveLength(1); // not doubled
+    });
+  });
+
+  test("same order via a new event id never double-credits", async () => {
+    const { t, ids } = await seedBillingEnv();
+    await t.mutation(internal.billing.applyPolarEvent, orderPaid(ids.orgId, "evt_1", "ord_1"));
+    const second = await t.mutation(
+      internal.billing.applyPolarEvent,
+      orderPaid(ids.orgId, "evt_2", "ord_1"),
+    );
+    expect(second).toMatchObject({ action: "duplicate_order", creditDelta: 0 });
+
+    const credits = await t.run(async (ctx) => {
+      const ledger = await ctx.db
+        .query("billingLedger")
+        .withIndex("by_org", (q) => q.eq("organizationId", ids.orgId))
+        .collect();
+      return ledger.reduce((a, r) => a + r.creditDelta, 0);
+    });
+    expect(credits).toBe(2500);
+  });
+
+  test("refund reverses the grant and revokes entitlement", async () => {
+    const { t, ids } = await seedBillingEnv();
+    await t.mutation(internal.billing.applyPolarEvent, orderPaid(ids.orgId, "evt_1", "ord_1"));
+    const refund = await t.mutation(internal.billing.applyPolarEvent, {
+      eventId: "evt_refund",
+      eventType: "order.refunded",
+      externalCustomerId: ids.orgId,
+      polarOrderId: "ord_1",
+    });
+    expect(refund).toMatchObject({
+      action: "refunded",
+      creditDelta: -2500,
+      entitlementStatus: "revoked",
+    });
+
+    const credits = await t.run(async (ctx) => {
+      const ledger = await ctx.db
+        .query("billingLedger")
+        .withIndex("by_org", (q) => q.eq("organizationId", ids.orgId))
+        .collect();
+      const ent = await ctx.db
+        .query("billingEntitlements")
+        .withIndex("by_org", (q) => q.eq("organizationId", ids.orgId))
+        .collect();
+      expect(ent[0].status).toBe("revoked");
+      return ledger.reduce((a, r) => a + r.creditDelta, 0);
+    });
+    expect(credits).toBe(0);
+  });
+
+  test("subscription.revoked revokes without ledger change", async () => {
+    const { t, ids } = await seedBillingEnv();
+    await t.mutation(internal.billing.applyPolarEvent, orderPaid(ids.orgId, "evt_1", "ord_1"));
+    const revoke = await t.mutation(internal.billing.applyPolarEvent, {
+      eventId: "evt_revoke",
+      eventType: "subscription.revoked",
+      externalCustomerId: ids.orgId,
+      polarSubscriptionId: "sub_123",
+    });
+    expect(revoke).toMatchObject({ action: "revoked", creditDelta: 0 });
+
+    const credits = await t.run(async (ctx) => {
+      const ledger = await ctx.db
+        .query("billingLedger")
+        .withIndex("by_org", (q) => q.eq("organizationId", ids.orgId))
+        .collect();
+      return ledger.reduce((a, r) => a + r.creditDelta, 0);
+    });
+    expect(credits).toBe(2500); // credits untouched on cancel
+  });
+
+  test("unknown org is ignored, not an error", async () => {
+    const { t, ids } = await seedBillingEnv();
+    const res = await t.mutation(internal.billing.applyPolarEvent, {
+      eventId: "evt_x",
+      eventType: "order.paid",
+      externalCustomerId: "not-a-real-id",
+      packageKey: "team",
+      polarOrderId: "ord_9",
+    });
+    expect(res).toMatchObject({ action: "ignored_unknown_org" });
+    void ids;
+  });
+
+  test("unsupported event type is acknowledged and ignored", async () => {
+    const { t, ids } = await seedBillingEnv();
+    const res = await t.mutation(internal.billing.applyPolarEvent, {
+      eventId: "evt_unsup",
+      eventType: "customer.updated",
+      externalCustomerId: ids.orgId,
+    });
+    expect(res).toMatchObject({ action: "ignored_unsupported" });
+  });
+});
+
+describe("getBillingOverview", () => {
+  test("owner sees catalog + remaining credits", async () => {
+    const { t, ids, asOwner } = await seedBillingEnv();
+    await t.mutation(internal.billing.applyPolarEvent, orderPaid(ids.orgId, "evt_1", "ord_1"));
+    const overview = await asOwner.query(api.billing.getBillingOverview, {
+      orgId: ids.orgId,
+    });
+    expect(overview.remainingCredits).toBe(2500);
+    expect(overview.entitlement).toMatchObject({ packageKey: "team", status: "active" });
+    expect(overview.packages.length).toBeGreaterThan(0);
+    expect(overview.packages.some((p) => p.manualEnterprise)).toBe(true);
+  });
+
+  test("non-owner is denied", async () => {
+    const { t, ids } = await seedBillingEnv();
+    const memberId = await t.run(async (ctx) => {
+      const u = await ctx.db.insert("users", { name: "M", email: "m@test.com" });
+      await ctx.db.insert("organizationMembers", {
+        organizationId: ids.orgId,
+        userId: u,
+        role: "member",
+      });
+      return u;
+    });
+    const asMember = t.withIdentity({
+      subject: `${memberId}|s`,
+      tokenIdentifier: `test|${memberId}`,
+    });
+    await expect(
+      asMember.query(api.billing.getBillingOverview, { orgId: ids.orgId }),
+    ).rejects.toThrow("Permission denied");
+  });
+});

--- a/docs/polar-self-serve-billing.md
+++ b/docs/polar-self-serve-billing.md
@@ -1,0 +1,111 @@
+# Polar self-serve billing
+
+Foundation for self-serve packages on Blind Bench, paid through
+[Polar](https://polar.sh). Owner-scoped, per-organization (workspace)
+entitlements — not per-user credits.
+
+## Billing model
+
+- **Packages** — a monthly subscription that grants a fixed bundle: eval
+  credits, reviewer seats, trace-import headroom, and a support level. The
+  catalog lives in `convex/lib/billingPlans.ts` (`BILLING_PACKAGES`), not in UI
+  copy. Stable package keys: `starter`, `team`, `scale`, `enterprise`.
+- **Credits** — a fungible per-eval unit tracked in the append-only
+  `billingLedger`. **Remaining credits = sum of `creditDelta` for the org.** A
+  package purchase adds a positive entry; a refund/revoke adds a negative one.
+- **Trial** — every workspace starts with a small free grant (`TRIAL` in
+  `billingPlans.ts`): 50 eval credits, 2 reviewer seats, 10 trace imports. No
+  card required. (Trial credits are represented in config; seed them into the
+  ledger when you wire trial provisioning — the foundation does not auto-seed.)
+- **Manual enterprise** — the `enterprise` package has `manualEnterprise: true`:
+  no self-serve product, the checkout button is replaced by "Contact sales".
+  Provision it by inserting an `active` `billingEntitlements` row + a ledger
+  grant by hand (or a small admin mutation) after the contract is signed.
+- **Refund rules** — a `order.refunded` webhook reverses the *exact* credits
+  granted for that order (one reversal per order, idempotent) and flips the
+  active entitlement to `revoked`. A `subscription.revoked`/`canceled` event
+  revokes the entitlement but leaves already-granted credits intact (the
+  customer keeps what they paid for through the period).
+
+## Data boundary (payment state vs. trace data)
+
+Payment state lives **only** in four tables: `billingCustomers`,
+`billingEntitlements`, `billingLedger`, `polarWebhookEvents`. None of them
+reference or store trace / test-case / eval content. The webhook handler
+(`convex/http.ts`) extracts **only** scalar billing fields (event id/type,
+external customer id, package key, Polar order/subscription/customer ids) via
+`sanitizePolarEvent` before anything is persisted — the raw payload is never
+logged or stored, so no customer trace data can leak through billing events.
+Metadata we send to Polar at checkout is limited to `orgId`, `packageKey`, and
+`environment`.
+
+## Configuration (Convex dashboard env vars)
+
+| Var | Purpose |
+|-----|---------|
+| `POLAR_ACCESS_TOKEN` | Polar organization access token (server-side only). |
+| `POLAR_WEBHOOK_SECRET` | Standard Webhooks secret (`whsec_…`) for signature verification. |
+| `POLAR_PRODUCT_STARTER` | Polar product id for the Starter package. |
+| `POLAR_PRODUCT_TEAM` | Polar product id for the Team package. |
+| `POLAR_PRODUCT_SCALE` | Polar product id for the Scale package. |
+| `POLAR_PRODUCT_ENTERPRISE` | Optional; enterprise is manual. |
+| `POLAR_API_URL` | Override base URL. Default `https://api.polar.sh`; use `https://sandbox-api.polar.sh` for sandbox. |
+| `POLAR_ENV` | Free-form tag echoed into checkout metadata (`sandbox`/`production`). |
+| `APP_BASE_URL` | App origin for the checkout `success_url`. Default `http://localhost:5173`. |
+
+Checkout and portal **fail closed** with a `ConvexError` when the token or a
+product id is missing — nothing half-works.
+
+## Webhook setup
+
+1. In Polar, add a webhook endpoint pointing at
+   `https://<your-convex-deployment>.convex.site/polar/webhook`.
+2. Select the Standard Webhooks format. Subscribe to at least: `order.paid`,
+   `order.refunded`, `subscription.revoked`, `subscription.canceled`.
+3. Copy the signing secret into `POLAR_WEBHOOK_SECRET`.
+
+The handler verifies `webhook-id` / `webhook-timestamp` / `webhook-signature`
+(HMAC-SHA256, 5-minute replay window) and is **idempotent**: by `webhook-id`
+(re-delivery is a no-op) and by Polar order id (a duplicate order never
+double-credits).
+
+## Local testing
+
+- Unit tests, no live Polar:
+  - `env -u NODE_ENV npx vitest run --config convex/vitest.config.ts convex/lib/__tests__/polarSignature.test.ts` — signature sign/verify/replay.
+  - `env -u NODE_ENV npm run test:convex` — webhook idempotency + ledger/entitlement (`convex/tests/billing.test.ts`). Requires `_generated` (run `npx convex dev` once to codegen).
+- Drive a webhook by hand: use `signWebhook(id, timestamp, body, secret)` from
+  `convex/lib/polarSignature.ts` to build a valid `webhook-signature`, then
+  `curl` your local `/polar/webhook` with the three headers and a JSON body
+  shaped like `{ "type": "order.paid", "data": { "id": "ord_x", "metadata": { "orgId": "<org id>", "packageKey": "team" }, "customer_id": "cus_x" } }`.
+- Or use the Polar sandbox + the Polar CLI to forward real sandbox webhooks.
+
+## Cutover / rollback
+
+**Cutover (sandbox → production):**
+
+1. Create the production products in Polar; copy their ids into the
+   `POLAR_PRODUCT_*` env vars on the production Convex deployment.
+2. Set `POLAR_ACCESS_TOKEN` (production token), `POLAR_API_URL`
+   (`https://api.polar.sh`), `POLAR_ENV=production`, and `APP_BASE_URL`.
+3. Register the production webhook endpoint and set `POLAR_WEBHOOK_SECRET`.
+4. `npx convex deploy` to ship the schema + functions.
+5. Smoke test: run a real low-value checkout, confirm an `order.paid` lands a
+   ledger row and an `active` entitlement, then refund it and confirm the
+   reversal.
+
+**Rollback:** unset `POLAR_ACCESS_TOKEN` (and/or the `POLAR_PRODUCT_*` vars) —
+checkout and portal immediately fail closed and the Billing page shows the
+trial state; the app keeps working. Optionally remove the Polar webhook
+endpoint. The billing tables are additive and isolated, so leaving them in
+place is harmless; no eval/trace data is affected. To fully revert, redeploy
+the prior commit (the four billing tables are unused by the rest of the app).
+
+## Manual enterprise path
+
+1. Sign the contract out of band.
+2. Insert an `active` `billingEntitlements` row (`packageKey: "enterprise"`)
+   and a positive `billingLedger` grant for the negotiated credits, scoped to
+   the org. A tiny owner/admin-gated internal mutation is the cleanest home for
+   this; the foundation intentionally ships none so credits can't be minted by
+   accident.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ const PilotScorecard = lazy(() => import("./routes/orgs/PilotScorecard").then(m 
 const OrgSettings = lazy(() => import("./routes/orgs/settings/OrgSettings").then(m => ({ default: m.OrgSettings })));
 const OrgMembers = lazy(() => import("./routes/orgs/settings/OrgMembers").then(m => ({ default: m.OrgMembers })));
 const OpenRouterKey = lazy(() => import("./routes/orgs/settings/OpenRouterKey").then(m => ({ default: m.OpenRouterKey })));
+const Billing = lazy(() => import("./routes/orgs/settings/Billing").then(m => ({ default: m.Billing })));
 const ProjectSettings = lazy(() => import("./routes/orgs/projects/settings/ProjectSettings").then(m => ({ default: m.ProjectSettings })));
 const ProjectCollaborators = lazy(() => import("./routes/orgs/projects/settings/ProjectCollaborators").then(m => ({ default: m.ProjectCollaborators })));
 const Variables = lazy(() => import("./routes/orgs/projects/Variables").then(m => ({ default: m.Variables })));
@@ -79,6 +80,7 @@ export function App() {
             <Route path="settings" element={<OrgSettings />} />
             <Route path="settings/members" element={<OrgMembers />} />
             <Route path="settings/openrouter-key" element={<OpenRouterKey />} />
+            <Route path="settings/billing" element={<Billing />} />
             <Route path="projects/:projectId" element={<ProjectLayout />}>
               <Route index element={<Navigate to="versions" replace />} />
               <Route path="variables" element={<Variables />} />

--- a/src/components/SideNavContent.tsx
+++ b/src/components/SideNavContent.tsx
@@ -5,6 +5,7 @@ import { useOrg } from "@/contexts/OrgContext";
 import { cn } from "@/lib/utils";
 import {
   ClipboardCheck,
+  CreditCard,
   FolderOpen,
   Key,
   Plug,
@@ -139,6 +140,14 @@ export function SideNavContent({
           >
             <Key className="h-4 w-4 shrink-0" />
             OpenRouter Key
+          </NavLink>
+          <NavLink
+            to={`/orgs/${org.slug}/settings/billing`}
+            className={linkClass}
+            onClick={onNavigate}
+          >
+            <CreditCard aria-hidden="true" className="h-4 w-4 shrink-0" />
+            Billing
           </NavLink>
         </>
       )}

--- a/src/routes/orgs/settings/Billing.tsx
+++ b/src/routes/orgs/settings/Billing.tsx
@@ -1,0 +1,203 @@
+import { useState } from "react";
+import { useQuery, useAction } from "convex/react";
+import { Navigate } from "react-router-dom";
+import { api } from "../../../../convex/_generated/api";
+import { useOrg } from "@/contexts/OrgContext";
+import { Button, buttonVariants } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { friendlyError } from "@/lib/errors";
+import { CreditCard, ExternalLink, Check } from "lucide-react";
+
+export function Billing() {
+  const { role } = useOrg();
+  if (role !== "owner") {
+    return <Navigate to="/denied" replace />;
+  }
+  return <BillingPanel />;
+}
+
+function BillingPanel() {
+  const { orgId } = useOrg();
+  const overview = useQuery(api.billing.getBillingOverview, { orgId });
+  const createCheckout = useAction(api.billing.createCheckout);
+  const createPortal = useAction(api.billing.createCustomerPortal);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [error, setError] = useState("");
+
+  if (overview === undefined) {
+    return (
+      <div className="p-6 max-w-3xl">
+        <Skeleton className="h-8 w-48 mb-4" />
+        <Skeleton className="h-64 w-full" />
+      </div>
+    );
+  }
+
+  async function startCheckout(packageKey: string) {
+    setBusy(packageKey);
+    setError("");
+    try {
+      const { url } = await createCheckout({ orgId, packageKey });
+      window.location.href = url;
+    } catch (err) {
+      setError(friendlyError(err, "Could not start checkout. Please try again."));
+      setBusy(null);
+    }
+  }
+
+  async function openPortal() {
+    setBusy("portal");
+    setError("");
+    try {
+      const { url } = await createPortal({ orgId });
+      window.location.href = url;
+    } catch (err) {
+      setError(friendlyError(err, "Could not open the billing portal."));
+      setBusy(null);
+    }
+  }
+
+  const { entitlement, remainingCredits, packages, ledger, trial, portalAvailable } =
+    overview;
+
+  return (
+    <div className="p-6 max-w-3xl">
+      <h1 className="text-2xl font-bold">Billing</h1>
+      <p className="mt-1 text-sm text-muted-foreground">
+        Pick a package to add monthly eval credits and reviewer seats. New
+        workspaces start with {trial.evalCredits} free trial credits — no card
+        required.
+      </p>
+
+      {error && <p className="mt-4 text-sm text-destructive">{error}</p>}
+
+      {/* Current plan summary */}
+      <Card className="mt-6">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-base">
+            <CreditCard aria-hidden="true" className="h-4 w-4" />
+            Current plan
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          <p className="text-sm">
+            {entitlement && entitlement.status === "active" ? (
+              <span className="text-sky-700 dark:text-sky-300">
+                {packages.find((p) => p.key === entitlement.packageKey)?.name ??
+                  entitlement.packageKey}{" "}
+                · active
+              </span>
+            ) : (
+              <span className="text-muted-foreground">
+                Trial — no active package
+              </span>
+            )}
+          </p>
+          <p className="text-sm text-muted-foreground">
+            {remainingCredits.toLocaleString()} eval credits remaining
+          </p>
+          {portalAvailable && (
+            <Button
+              variant="outline"
+              size="sm"
+              className="mt-2"
+              disabled={busy === "portal"}
+              onClick={openPortal}
+            >
+              {busy === "portal" ? "Opening…" : "Manage billing"}
+              <ExternalLink aria-hidden="true" className="ml-1 h-3 w-3" />
+            </Button>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Packages */}
+      <div className="mt-6 grid gap-4 sm:grid-cols-2">
+        {packages.map((p) => (
+          <Card key={p.key}>
+            <CardHeader>
+              <CardTitle className="text-base">{p.name}</CardTitle>
+              <p className="text-xs text-muted-foreground">{p.blurb}</p>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              <ul className="space-y-1 text-sm">
+                {p.manualEnterprise ? (
+                  <li className="text-muted-foreground">Custom volume & seats</li>
+                ) : (
+                  <>
+                    <Feature>
+                      {p.monthlyEvalCredits.toLocaleString()} eval credits / mo
+                    </Feature>
+                    <Feature>{p.reviewerSeats} reviewer seats</Feature>
+                    <Feature>
+                      {p.traceImportLimit.toLocaleString()} trace imports / mo
+                    </Feature>
+                    <Feature>{p.supportLevel} support</Feature>
+                  </>
+                )}
+              </ul>
+              {p.manualEnterprise ? (
+                <a
+                  href="mailto:sales@blindbench.dev"
+                  className={cn(buttonVariants({ variant: "outline" }), "w-full")}
+                >
+                  Contact sales
+                </a>
+              ) : (
+                <Button
+                  className="w-full"
+                  disabled={busy === p.key}
+                  onClick={() => startCheckout(p.key)}
+                >
+                  {busy === p.key ? "Starting…" : `Choose ${p.name}`}
+                </Button>
+              )}
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      {/* Ledger */}
+      {ledger.length > 0 && (
+        <Card className="mt-6">
+          <CardHeader>
+            <CardTitle className="text-base">Credit history</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <ul className="divide-y text-sm">
+              {ledger.map((row, i) => (
+                <li key={i} className="flex items-center justify-between py-2">
+                  <span className="text-muted-foreground">
+                    {row.reason.replace(/_/g, " ")}
+                    {row.packageKey ? ` · ${row.packageKey}` : ""}
+                  </span>
+                  <span
+                    className={
+                      row.creditDelta < 0
+                        ? "text-violet-700 dark:text-violet-300"
+                        : "text-sky-700 dark:text-sky-300"
+                    }
+                  >
+                    {row.creditDelta > 0 ? "+" : ""}
+                    {row.creditDelta.toLocaleString()}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}
+
+function Feature({ children }: { children: React.ReactNode }) {
+  return (
+    <li className="flex items-start gap-2">
+      <Check aria-hidden="true" className="mt-0.5 h-3.5 w-3.5 shrink-0 text-sky-600" />
+      <span>{children}</span>
+    </li>
+  );
+}


### PR DESCRIPTION
## Summary

Implements #236: Polar self-serve billing foundation for Blind Bench packages.

- Adds server-side billing package config in `convex/lib/billingPlans.ts` so product IDs/credit limits are represented in metadata/config, not just UI copy.
- Adds isolated billing schema tables for customers, entitlements, ledger, and webhook idempotency/audit.
- Adds owner-gated billing APIs in `convex/billing.ts`:
  - `getBillingOverview`
  - `createCheckout`
  - `createCustomerPortal`
  - internal `applyPolarEvent`
- Adds signed Polar webhook endpoint at `/polar/webhook` using Standard Webhooks HMAC verification.
- Adds app Billing page at `/orgs/:orgSlug/settings/billing` and owner-only sidebar link.
- Adds docs for billing model, env vars, webhook setup, local testing, cutover/rollback, manual enterprise path, and data boundary.

## Safety / data boundary

Payment state is separated into dedicated billing tables only. Billing events persist scalar billing identifiers and ledger deltas; no trace, eval, test-case, prompt, or output content is stored or sent through Polar metadata.

Checkout metadata is limited to:

- org id
- package key
- environment

## Verification

- ✅ `env -u NODE_ENV npm run test:evals` — 10 files / 94 tests passed
- ✅ `env -u NODE_ENV npx vitest run --config convex/vitest.config.ts convex/lib/__tests__/polarSignature.test.ts` — 6 tests passed
- ✅ focused Billing route bundle:
  `env -u NODE_ENV npx esbuild src/routes/orgs/settings/Billing.tsx --bundle --platform=browser --format=esm --jsx=automatic --external:react --external:react/jsx-runtime --external:react-router-dom --external:convex/react --external:../../../../convex/_generated/api --external:@/* --external:lucide-react --outfile=/tmp/billing.js`
- ✅ focused Convex syntax bundle:
  `env -u NODE_ENV npx esbuild convex/billing.ts convex/http.ts --bundle --platform=node --format=esm --external:./_generated/* --external:./auth --external:convex/* --external:@convex-dev/* --outdir=/tmp/billing-convex`
- ✅ `git diff --check`

## Known local verification blocker

`env -u NODE_ENV npm run test:convex -- convex/tests/billing.test.ts convex/lib/__tests__/polarSignature.test.ts` cannot run the new Convex DB tests in this local checkout because `convex/_generated/api` is absent. This is the same local generated-bindings blocker already present for full builds; docs note that `npx convex dev` / deploy codegen is required before running the Convex DB tests.

The pure signature tests run and pass without generated bindings. The billing DB tests are included for CI/codegen-capable environments and cover:

- event-id idempotency
- order-id idempotency
- entitlement grants
- refund reversal
- subscription revoke behavior
- unknown org ignored safely
- non-owner denied on overview

## Operator setup after merge

Set these on the Convex deployment before live checkout:

- `POLAR_ACCESS_TOKEN`
- `POLAR_WEBHOOK_SECRET`
- `POLAR_PRODUCT_STARTER`
- `POLAR_PRODUCT_TEAM`
- `POLAR_PRODUCT_SCALE`
- `POLAR_API_URL` if using sandbox
- `POLAR_ENV`
- `APP_BASE_URL`

Then register the Polar webhook endpoint:

`https://<convex-deployment>.convex.site/polar/webhook`

## Merge-order note

This branch does not depend on #250. If #250 merges first, expected overlap is only routing/sidebar/package-adjacent files; keep both the Fireworks Gateway prototype and Billing surfaces.