### PR TITLE
Add Cloudflare Gateway live log import

### DIFF
--- a/convex/gatewayImport.ts
+++ b/convex/gatewayImport.ts
@@ -1,0 +1,149 @@
+import { v } from "convex/values";
+import { action, internalMutation } from "./_generated/server";
+import { internal } from "./_generated/api";
+import type { Id } from "./_generated/dataModel";
+import { requireProjectRole } from "./lib/auth";
+import {
+  DEFAULT_LIMITS,
+  MAX_REPORTED_INVALID_LINES,
+  parseGatewayJsonl,
+  summarizeTraces,
+} from "./traceAdapters/cloudflareAiGateway";
+
+const SOURCE = "cloudflare_ai_gateway" as const;
+
+/**
+ * Auth + dedup + identity insert for a batch of parsed traces. Runs as one
+ * mutation so within-batch duplicates are caught by read-your-writes, not just
+ * across prior imports. Returns the index (into the parsed list) of each newly
+ * inserted row so the action can attach raw-payload storage to exactly those.
+ */
+export const insertImportRows = internalMutation({
+  args: {
+    projectId: v.id("projects"),
+    sourceTraceIds: v.array(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const { userId } = await requireProjectRole(ctx, args.projectId, [
+      "owner",
+      "editor",
+    ]);
+
+    let imported = 0;
+    let deduped = 0;
+    const newRows: { importId: Id<"traceImports">; index: number }[] = [];
+    for (let i = 0; i < args.sourceTraceIds.length; i++) {
+      const sourceTraceId = args.sourceTraceIds[i];
+      const existing = await ctx.db
+        .query("traceImports")
+        .withIndex("by_source_trace", (q) =>
+          q.eq("source", SOURCE).eq("sourceTraceId", sourceTraceId),
+        )
+        .filter((q) => q.eq(q.field("projectId"), args.projectId))
+        .first();
+      if (existing) {
+        deduped++;
+        continue;
+      }
+      const importId = await ctx.db.insert("traceImports", {
+        projectId: args.projectId,
+        source: SOURCE,
+        sourceTraceId,
+        importedById: userId,
+      });
+      newRows.push({ importId, index: i });
+      imported++;
+    }
+    return { imported, deduped, newRows };
+  },
+});
+
+/** Attach raw-payload storage ids to rows inserted by `insertImportRows`. */
+export const attachRawPayloads = internalMutation({
+  args: {
+    updates: v.array(
+      v.object({
+        importId: v.id("traceImports"),
+        storageId: v.id("_storage"),
+      }),
+    ),
+  },
+  handler: async (ctx, args) => {
+    for (const { importId, storageId } of args.updates) {
+      await ctx.db.patch(importId, { rawPayloadStorageId: storageId });
+    }
+  },
+});
+
+/**
+ * Import exported Cloudflare AI Gateway logs (Logpush/API JSONL) into a
+ * project as deduplicated trace-import rows.
+ *
+ * No external Cloudflare calls — the customer pastes/uploads JSONL they
+ * exported from their own gateway. For each newly imported (non-duplicate)
+ * trace we persist import identity (projectId, source, sourceTraceId) plus the
+ * raw source record to access-controlled Convex storage (rawPayloadStorageId),
+ * so adapter improvements / materialization into prompt versions can re-parse
+ * without re-export. Raw content is never rendered back in the UI.
+ *
+ * An action (not a mutation) because `ctx.storage.store` is action-only;
+ * auth/dedup/insert run inside `insertImportRows` so dedup stays transactional.
+ *
+ * Returns a management-safe summary: counts + model/provider names + time
+ * bounds. Never echoes customer trace content or invalid line text.
+ */
+export const importGatewayLogs = action({
+  args: {
+    projectId: v.id("projects"),
+    jsonl: v.string(),
+  },
+  handler: async (ctx, args) => {
+    // UTF-16 char length, not exact bytes — a cheap upper-bound guard before
+    // we do any work.
+    if (args.jsonl.length > DEFAULT_LIMITS.maxBytes) {
+      throw new Error(
+        `Payload too large (${args.jsonl.length} chars, limit ${DEFAULT_LIMITS.maxBytes}). Split the export into smaller batches.`,
+      );
+    }
+
+    const { traces, invalidLines, truncated } = parseGatewayJsonl(
+      args.jsonl,
+      DEFAULT_LIMITS,
+    );
+
+    const { imported, deduped, newRows } = await ctx.runMutation(
+      internal.gatewayImport.insertImportRows,
+      {
+        projectId: args.projectId,
+        sourceTraceIds: traces.map((t) => t.sourceTraceId),
+      },
+    );
+
+    // Store the raw record for exactly the new (non-duplicate) rows — never
+    // for dedup hits. Sequential keeps it simple and bounded by maxLines.
+    const updates: { importId: Id<"traceImports">; storageId: Id<"_storage"> }[] =
+      [];
+    for (const { importId, index } of newRows) {
+      const storageId = await ctx.storage.store(
+        new Blob([traces[index].rawPayloadJson], { type: "application/json" }),
+      );
+      updates.push({ importId, storageId });
+    }
+    if (updates.length > 0) {
+      await ctx.runMutation(internal.gatewayImport.attachRawPayloads, {
+        updates,
+      });
+    }
+
+    const agg = summarizeTraces(traces);
+    return {
+      imported,
+      deduped,
+      parsed: traces.length,
+      invalid: invalidLines.length,
+      invalidLines: invalidLines.slice(0, MAX_REPORTED_INVALID_LINES),
+      truncated,
+      ...agg,
+    };
+  },
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -621,6 +621,7 @@ const schema = defineSchema({
       v.literal("posthog"),
       v.literal("promptlayer"),
       v.literal("manual_paste"),
+      v.literal("cloudflare_ai_gateway"),
     ),
     // Provider's stable trace identifier when available — manual_paste imports
     // don't have one. Combined with `source` it forms the dedup key.

--- a/convex/traceAdapters/cloudflareAiGateway.test.ts
+++ b/convex/traceAdapters/cloudflareAiGateway.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import {
+  normalizeGatewayLog,
+  parseGatewayJsonl,
+  summarizeTraces,
+} from "./cloudflareAiGateway";
+
+// Pure parser tests — no `_generated` files, no convex runtime needed.
+
+const chat = {
+  log_id: "log_TEST_001",
+  timestamp: "2026-06-23T12:00:00Z",
+  provider: "anthropic",
+  model: "claude-sonnet-4-0",
+  request: {
+    messages: [
+      { role: "system", content: "You are a synthetic assistant." },
+      { role: "user", content: "What is my synthetic payoff?" },
+    ],
+  },
+  response: { choices: [{ message: { content: "Your payoff is $123.45." } }] },
+  usage: { input_tokens: 42, output_tokens: 12, total_tokens: 54 },
+  cost_usd: 0.0021,
+  duration_ms: 1180,
+};
+
+const redacted = {
+  log_id: "log_TEST_002",
+  timestamp: "2026-06-23T12:01:00Z",
+  provider: "openai",
+  model: "gpt-4.1-mini",
+  request: { redacted: true },
+};
+
+describe("convex cloudflare gateway parser", () => {
+  it("normalizes a chat log and uses the gateway log id as dedup key", () => {
+    const t = normalizeGatewayLog(chat);
+    expect(t.sourceTraceId).toBe("log_TEST_001");
+    expect(t.messages).toHaveLength(2);
+    expect(t.outputText).toBe("Your payoff is $123.45.");
+    expect(t.model).toBe("claude-sonnet-4-0");
+    expect(t.usage.inputTokens).toBe(42);
+    expect(t.costUsd).toBe(0.0021);
+    expect(t.requestMissing).toBe(false);
+    expect(t.responseMissing).toBe(false);
+  });
+
+  it("retains a deterministic raw payload string for storage", () => {
+    const t = normalizeGatewayLog(chat);
+    // The parser hands the importer the raw record verbatim (for access-
+    // controlled storage), so this DOES contain content — unlike the summary.
+    expect(typeof t.rawPayloadJson).toBe("string");
+    expect(JSON.parse(t.rawPayloadJson)).toMatchObject({
+      log_id: "log_TEST_001",
+      response: { choices: [{ message: { content: "Your payoff is $123.45." } }] },
+    });
+    // Deterministic: same input -> identical string (safe as a dedup/store key).
+    expect(t.rawPayloadJson).toBe(normalizeGatewayLog(chat).rawPayloadJson);
+  });
+
+  it("flags redacted/missing request and response", () => {
+    const t = normalizeGatewayLog(redacted);
+    expect(t.messages).toEqual([]);
+    expect(t.outputText).toBeUndefined();
+    expect(t.requestMissing).toBe(true);
+    expect(t.responseMissing).toBe(true);
+  });
+
+  it("falls back to a stable content hash when no id is present", () => {
+    const noId = { ...chat, log_id: undefined, id: undefined };
+    const a = normalizeGatewayLog(noId).sourceTraceId;
+    const b = normalizeGatewayLog(noId).sourceTraceId;
+    expect(a).toMatch(/^cf-aigw-/);
+    expect(a).toBe(b);
+  });
+
+  it("reports invalid lines by number, not content, and skips blanks", () => {
+    const input = [
+      JSON.stringify(chat),
+      "{ this is not json",
+      "",
+      "[1,2,3]", // valid json but not an object -> invalid
+      JSON.stringify(redacted),
+    ].join("\n");
+    const { traces, invalidLines } = parseGatewayJsonl(input);
+    expect(traces).toHaveLength(2);
+    expect(invalidLines).toEqual([2, 4]);
+  });
+
+  it("truncates at maxLines and flags it", () => {
+    const lines = Array.from({ length: 5 }, (_, i) =>
+      JSON.stringify({ ...chat, log_id: `log_${i}` }),
+    ).join("\n");
+    const { traces, truncated } = parseGatewayJsonl(lines, {
+      maxLines: 3,
+      maxBytes: 1e9,
+    });
+    expect(traces).toHaveLength(3);
+    expect(truncated).toBe(true);
+  });
+
+  it("summarizes to counts, models, providers, and time bounds only", () => {
+    const { traces } = parseGatewayJsonl(
+      [JSON.stringify(chat), JSON.stringify(redacted)].join("\n"),
+    );
+    const s = summarizeTraces(traces);
+    expect(s.models).toEqual(["claude-sonnet-4-0", "gpt-4.1-mini"]);
+    expect(s.providers).toEqual(["anthropic", "openai"]);
+    expect(s.redactedRequest).toBe(1);
+    expect(s.redactedResponse).toBe(1);
+    expect(s.earliest).toBe("2026-06-23T12:00:00Z");
+    expect(s.latest).toBe("2026-06-23T12:01:00Z");
+    // summary carries no message/output text
+    expect(JSON.stringify(s)).not.toContain("payoff");
+  });
+});

--- a/convex/traceAdapters/cloudflareAiGateway.ts
+++ b/convex/traceAdapters/cloudflareAiGateway.ts
@@ -1,0 +1,291 @@
+/**
+ * Convex-safe Cloudflare AI Gateway JSONL parser.
+ *
+ * Mirrors the field-mapping logic in `src/lib/evals/cloudflareAiGateway.ts`,
+ * but with NO `node:crypto` and NO `zod` so it runs inside the Convex query/
+ * mutation runtime — and in plain vitest without any `_generated` files. Pure
+ * functions only; the importer in `convex/gatewayImport.ts` handles auth,
+ * dedup persistence, and limits.
+ *
+ * Safety posture: parse errors are reported as line numbers, never raw
+ * content. Each trace carries `rawPayloadJson` (a deterministic stringify of
+ * the source record) so the importer can persist it to access-controlled
+ * Convex storage for later re-parse/materialization — but message/output
+ * fields and the summary never surface that content back to the UI.
+ */
+
+export interface GatewayLimits {
+  /** Maximum non-blank lines parsed per import; extras are dropped + flagged. */
+  maxLines: number;
+  /** Maximum payload size guard, applied by the importer before parsing. */
+  maxBytes: number;
+}
+
+export const DEFAULT_LIMITS: GatewayLimits = {
+  maxLines: 5000,
+  maxBytes: 8 * 1024 * 1024,
+};
+
+/** Number of invalid line numbers surfaced in a summary (the rest are counted). */
+export const MAX_REPORTED_INVALID_LINES = 50;
+
+export interface NormalizedGatewayTrace {
+  /** Stable dedup key: the gateway's own log/event id, or a content hash. */
+  sourceTraceId: string;
+  messages: { role: string; content: string }[];
+  outputText?: string;
+  model?: string;
+  provider?: string;
+  timestamp?: string;
+  usage: { inputTokens?: number; outputTokens?: number; totalTokens?: number };
+  costUsd?: number;
+  durationMs?: number;
+  /** Request was redacted/missing/empty (no usable input messages). */
+  requestMissing: boolean;
+  /** Response was redacted/missing/empty (no usable output text). */
+  responseMissing: boolean;
+  /**
+   * Deterministic stringify of the source record. The importer persists this
+   * to access-controlled Convex storage (`rawPayloadStorageId`) so adapter
+   * improvements can re-parse without re-export. Never rendered in the UI nor
+   * returned in summaries.
+   */
+  rawPayloadJson: string;
+}
+
+export interface ParseResult {
+  traces: NormalizedGatewayTrace[];
+  /** 1-based line numbers that failed JSON parse or normalization. */
+  invalidLines: number[];
+  /** True when the import hit `maxLines` and stopped early. */
+  truncated: boolean;
+}
+
+// ---- tiny readers (ported, zod-free) -----------------------------------
+
+const asRecord = (v: unknown): Record<string, unknown> | undefined =>
+  v && typeof v === "object" && !Array.isArray(v)
+    ? (v as Record<string, unknown>)
+    : undefined;
+const asArray = (v: unknown): unknown[] => (Array.isArray(v) ? v : []);
+const str = (v: unknown): string | undefined =>
+  typeof v === "string" && v.length ? v : undefined;
+const num = (v: unknown): number | undefined =>
+  typeof v === "number" && Number.isFinite(v) ? v : undefined;
+
+const get = (obj: unknown, paths: string[]): unknown => {
+  for (const path of paths) {
+    let cur: unknown = obj;
+    for (const key of path.split(".")) cur = asRecord(cur)?.[key];
+    if (cur !== undefined && cur !== null) return cur;
+  }
+  return undefined;
+};
+const getRecord = (obj: unknown, paths: string[]) => asRecord(get(obj, paths));
+const getStr = (obj: unknown, paths: string[]) => str(get(obj, paths));
+const getNum = (obj: unknown, paths: string[]) => num(get(obj, paths));
+
+// FNV-1a is enough for a dedup fallback id — not a security hash.
+function fnv1a(s: string): string {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = (h + ((h << 1) + (h << 4) + (h << 7) + (h << 8) + (h << 24))) >>> 0;
+  }
+  return h.toString(16).padStart(8, "0");
+}
+
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(",")}]`;
+  const obj = value as Record<string, unknown>;
+  return `{${Object.keys(obj)
+    .sort()
+    .map((k) => `${JSON.stringify(k)}:${stableStringify(obj[k])}`)
+    .join(",")}}`;
+}
+
+function extractMessages(request: unknown): { role: string; content: string }[] {
+  const req = asRecord(request);
+  if (!req) return [];
+  const input = asRecord(req.input);
+  const rawMessages = asArray(req.messages ?? input?.messages);
+  const messages = rawMessages.flatMap((m) => {
+    const rec = asRecord(m);
+    const role = str(rec?.role);
+    const content = str(rec?.content);
+    return role && content ? [{ role, content }] : [];
+  });
+  if (messages.length === 0) {
+    const prompt = str(req.prompt ?? req.input);
+    if (prompt) messages.push({ role: "user", content: prompt });
+  }
+  return messages;
+}
+
+function extractOutput(response: unknown): string | undefined {
+  const res = asRecord(response);
+  if (!res) return undefined;
+  const direct = str(res.output_text ?? res.text ?? res.content);
+  if (direct) return direct;
+  const choice0 = asRecord(asArray(res.choices)[0]);
+  const msg = asRecord(choice0?.message);
+  return str(msg?.content ?? choice0?.text);
+}
+
+/**
+ * Normalize one parsed Gateway log object. Throws only on a non-object input
+ * (caller already guards), so it is safe to call per line.
+ */
+export function normalizeGatewayLog(record: unknown): NormalizedGatewayTrace {
+  const rec = asRecord(record);
+  if (!rec) throw new Error("not an object");
+
+  const request = get(rec, [
+    "request",
+    "request_body",
+    "payload.request",
+    "event.request",
+  ]);
+  const response = get(rec, [
+    "response",
+    "response_body",
+    "payload.response",
+    "event.response",
+  ]);
+
+  const messages = extractMessages(request);
+  const outputText = extractOutput(response);
+  const timestamp = getStr(rec, ["timestamp", "created_at", "datetime"]);
+  const model = getStr(rec, ["model", "request.model", "response.model"]);
+  const provider = getStr(rec, [
+    "provider",
+    "request.provider",
+    "response.provider",
+  ]);
+
+  const explicitId = getStr(rec, [
+    "log_id",
+    "id",
+    "log.id",
+    "event_id",
+    "event.id",
+    "cf.ray_id",
+    "ray_id",
+  ]);
+  const seed = {
+    account: getStr(rec, ["account_id", "account.id"]),
+    gateway: getStr(rec, ["gateway_id", "gateway.id"]),
+    ts: timestamp,
+    model,
+    request_hash: fnv1a(stableStringify(request ?? "missing")),
+  };
+  const sourceTraceId = explicitId ?? `cf-aigw-${fnv1a(stableStringify(seed))}`;
+
+  return {
+    sourceTraceId,
+    messages,
+    outputText,
+    model,
+    provider,
+    timestamp,
+    usage: {
+      inputTokens: getNum(rec, [
+        "tokens_in",
+        "usage.input_tokens",
+        "usage.prompt_tokens",
+      ]),
+      outputTokens: getNum(rec, [
+        "tokens_out",
+        "usage.output_tokens",
+        "usage.completion_tokens",
+      ]),
+      totalTokens: getNum(rec, ["tokens_total", "usage.total_tokens"]),
+    },
+    costUsd: getNum(rec, ["cost", "cost_usd", "usage.cost_usd"]),
+    durationMs: getNum(rec, ["duration", "duration_ms", "latency_ms"]),
+    requestMissing: messages.length === 0,
+    responseMissing: outputText === undefined,
+    rawPayloadJson: stableStringify(rec),
+  };
+}
+
+/**
+ * Parse exported Gateway JSONL. Blank lines are skipped; malformed lines are
+ * counted by line number, never by content. Stops at `maxLines`.
+ */
+export function parseGatewayJsonl(
+  text: string,
+  limits: GatewayLimits = DEFAULT_LIMITS,
+): ParseResult {
+  const traces: NormalizedGatewayTrace[] = [];
+  const invalidLines: number[] = [];
+  const lines = text.split(/\r?\n/);
+  let processed = 0;
+  let truncated = false;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i].trim();
+    if (!line) continue;
+    if (processed >= limits.maxLines) {
+      truncated = true;
+      break;
+    }
+    processed++;
+    let obj: unknown;
+    try {
+      obj = JSON.parse(line);
+    } catch {
+      invalidLines.push(i + 1);
+      continue;
+    }
+    try {
+      traces.push(normalizeGatewayLog(obj));
+    } catch {
+      invalidLines.push(i + 1);
+    }
+  }
+
+  return { traces, invalidLines, truncated };
+}
+
+export interface TraceAggregate {
+  redactedRequest: number;
+  redactedResponse: number;
+  models: string[];
+  providers: string[];
+  earliest?: string;
+  latest?: string;
+}
+
+/** Management-safe rollup — counts, model/provider names, time bounds only. */
+export function summarizeTraces(
+  traces: NormalizedGatewayTrace[],
+): TraceAggregate {
+  const models = new Set<string>();
+  const providers = new Set<string>();
+  let earliest: string | undefined;
+  let latest: string | undefined;
+  let redactedRequest = 0;
+  let redactedResponse = 0;
+
+  for (const t of traces) {
+    if (t.model) models.add(t.model);
+    if (t.provider) providers.add(t.provider);
+    if (t.requestMissing) redactedRequest++;
+    if (t.responseMissing) redactedResponse++;
+    if (t.timestamp) {
+      if (earliest === undefined || t.timestamp < earliest) earliest = t.timestamp;
+      if (latest === undefined || t.timestamp > latest) latest = t.timestamp;
+    }
+  }
+
+  return {
+    redactedRequest,
+    redactedResponse,
+    models: [...models].sort(),
+    providers: [...providers].sort(),
+    earliest,
+    latest,
+  };
+}

--- a/convex/traceAdapters/types.ts
+++ b/convex/traceAdapters/types.ts
@@ -64,7 +64,8 @@ export type TraceSource =
   | "langfuse"
   | "posthog"
   | "promptlayer"
-  | "manual_paste";
+  | "manual_paste"
+  | "cloudflare_ai_gateway";
 
 export interface ParsedTrace {
   source: TraceSource;

--- a/convex/traceImports.ts
+++ b/convex/traceImports.ts
@@ -7,6 +7,7 @@ const SOURCE_VALIDATOR = v.union(
   v.literal("posthog"),
   v.literal("promptlayer"),
   v.literal("manual_paste"),
+  v.literal("cloudflare_ai_gateway"),
 );
 
 /**

--- a/docs/cloudflare-gateway-live-import.md
+++ b/docs/cloudflare-gateway-live-import.md
@@ -1,0 +1,107 @@
+# Cloudflare AI Gateway — live log import
+
+Import production prompt traffic from a customer-owned Cloudflare AI Gateway
+into Blind Bench as deduplicated trace imports, so it can become a measurable
+eval set.
+
+**Blind Bench makes no calls to Cloudflare.** The customer exports logs from
+their own gateway and pastes/uploads them. This keeps the data boundary
+one-directional and avoids holding any Cloudflare credentials.
+
+## 1. Export from Cloudflare
+
+Pull request logs from the customer's gateway — either path produces JSONL
+(one JSON object per line):
+
+- **Dashboard:** AI Gateway → select gateway → Logs → filter by time/product →
+  export.
+- **API / Logpush:**
+  ```
+  GET https://api.cloudflare.com/client/v4/accounts/<account>/ai-gateway/gateways/<gateway>/logs
+  ```
+  or a Logpush job writing the gateway dataset to object storage.
+
+Required token scope: **AI Gateway — Read**, scoped to the specific account and
+gateway (not a global key). See the in-app *Gateway onboarding* page for the
+metadata conventions (`product`, `module`, `prompt_version`, …) that make
+imported logs groupable.
+
+The parser reads common field shapes opportunistically:
+
+| Field | Source paths tried |
+| --- | --- |
+| dedup id | `log_id`, `id`, `event_id`, `cf.ray_id` (else a content hash) |
+| messages | `request.messages`, `request.input.messages`, `request.prompt` |
+| output | `response.output_text` / `.text` / `.content`, `response.choices[0].message.content` |
+| model / provider | `model`, `request.model`, `response.model` / `provider`, … |
+| usage | `usage.*_tokens`, `tokens_in` / `tokens_out` |
+| cost / duration | `cost` / `cost_usd`, `duration` / `duration_ms` / `latency_ms` |
+| timestamp | `timestamp`, `created_at`, `datetime` |
+
+## 2. Import
+
+1. Org sidebar → **Import Gateway logs** (or *Gateway onboarding → Import
+   Gateway logs*).
+2. Select the destination project (you must be **owner** or **editor**).
+3. Paste the JSONL and click **Import Gateway logs**.
+
+The importer returns a management-safe summary: imported / deduped / parsed
+counts, invalid line numbers, missing-request / missing-response counts, the
+set of models and providers seen, and the earliest/latest timestamp.
+
+## 3. Data boundary
+
+- **Import identity** is persisted: `(projectId, source, sourceTraceId)` rows
+  in the `traceImports` table.
+- For each new (non-duplicate) trace, the **raw source record** is persisted to
+  **access-controlled Convex storage** (`rawPayloadStorageId`) so imports can
+  be re-parsed/materialized into eval sets without re-export. Duplicates are
+  never stored again.
+- The UI **never renders trace content back** — counts, model/provider names,
+  and timestamps only. The stored raw payload is reachable only through
+  access-controlled server code, never in a query response or summary.
+- Invalid lines are reported by **line number**, never by content, so a
+  malformed line can't leak into an error message.
+
+## 4. Limits
+
+| Limit | Value | Behavior on exceed |
+| --- | --- | --- |
+| Lines per import | 5,000 | Stops early, `truncated: true` in summary |
+| Payload size | 8 MB | Importer rejects with a "split into batches" error |
+| Invalid lines reported | 50 | Remainder counted but line numbers omitted |
+
+Defaults live in `convex/traceAdapters/cloudflareAiGateway.ts`
+(`DEFAULT_LIMITS`).
+
+## 5. Verification
+
+- Pure parser unit tests: `npm run test:convex` (covers
+  `convex/traceAdapters/cloudflareAiGateway.test.ts` — no Convex backend
+  needed).
+- Local exported-JSONL adapter tests: `env -u NODE_ENV npm run test:evals`.
+- Manual: paste a small synthetic JSONL sample, confirm the summary counts;
+  re-paste the same sample and confirm everything reports as **deduped**.
+
+## 6. Rollback
+
+The change is additive — a new source literal, a parser module, one import
+action (plus its internal mutations), one route. To disable:
+
+- **Hide the entry point:** remove the *Import Gateway logs* links in
+  `src/components/SideNavContent.tsx` and `GatewayOnboarding.tsx`, and the
+  `gateway-import` route in `src/App.tsx`.
+- **Disable the importer:** remove/guard `importGatewayLogs` in
+  `convex/gatewayImport.ts`.
+- The `cloudflare_ai_gateway` source literal in the schema can stay; removing
+  it requires there be no rows using it.
+
+No external state is created, so rollback needs no Cloudflare-side action.
+
+## Follow-up (not in this slice)
+
+- **Materialization:** turn imported traces into prompt versions / completed
+  run outputs (`setMaterialized` already exists) to drive baseline evals.
+- **Sidecar metadata merge:** the local adapter supports a `trace_id`-keyed
+  sidecar for fields too large for Gateway custom metadata; the Convex importer
+  does not yet accept one.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ const WelcomeFirstRun = lazy(() => import("./routes/welcome/WelcomeFirstRun").th
 const OrgHome = lazy(() => import("./routes/orgs/OrgHome").then(m => ({ default: m.OrgHome })));
 const GatewayOnboarding = lazy(() => import("./routes/orgs/GatewayOnboarding").then(m => ({ default: m.GatewayOnboarding })));
 const PilotScorecard = lazy(() => import("./routes/orgs/PilotScorecard").then(m => ({ default: m.PilotScorecard })));
+const GatewayImport = lazy(() => import("./routes/orgs/GatewayImport").then(m => ({ default: m.GatewayImport })));
 const OrgSettings = lazy(() => import("./routes/orgs/settings/OrgSettings").then(m => ({ default: m.OrgSettings })));
 const OrgMembers = lazy(() => import("./routes/orgs/settings/OrgMembers").then(m => ({ default: m.OrgMembers })));
 const OpenRouterKey = lazy(() => import("./routes/orgs/settings/OpenRouterKey").then(m => ({ default: m.OpenRouterKey })));
@@ -76,6 +77,7 @@ export function App() {
           <Route path="/orgs/:orgSlug" element={<OrgLayout />}>
             <Route index element={<OrgHome />} />
             <Route path="gateway-onboarding" element={<GatewayOnboarding />} />
+            <Route path="gateway-import" element={<GatewayImport />} />
             <Route path="pilot-scorecard" element={<PilotScorecard />} />
             <Route path="settings" element={<OrgSettings />} />
             <Route path="settings/members" element={<OrgMembers />} />

--- a/src/components/SideNavContent.tsx
+++ b/src/components/SideNavContent.tsx
@@ -5,6 +5,7 @@ import { useOrg } from "@/contexts/OrgContext";
 import { cn } from "@/lib/utils";
 import {
   ClipboardCheck,
+  CloudDownload,
   CreditCard,
   FolderOpen,
   Key,
@@ -99,6 +100,14 @@ export function SideNavContent({
       >
         <Plug aria-hidden="true" className="h-4 w-4 shrink-0" />
         Gateway onboarding
+      </NavLink>
+      <NavLink
+        to={`/orgs/${org.slug}/gateway-import`}
+        className={linkClass}
+        onClick={onNavigate}
+      >
+        <CloudDownload aria-hidden="true" className="h-4 w-4 shrink-0" />
+        Import Gateway logs
       </NavLink>
       <NavLink
         to={`/orgs/${org.slug}/pilot-scorecard`}

--- a/src/routes/orgs/GatewayImport.tsx
+++ b/src/routes/orgs/GatewayImport.tsx
@@ -1,0 +1,222 @@
+import { useState } from "react";
+import { useAction, useQuery } from "convex/react";
+import type { FunctionReturnType } from "convex/server";
+import { Link } from "react-router-dom";
+import { api } from "../../../convex/_generated/api";
+import type { Id } from "../../../convex/_generated/dataModel";
+import { useOrg } from "@/contexts/OrgContext";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { friendlyError } from "@/lib/errors";
+import { CloudDownload, ShieldAlert, ArrowLeft } from "lucide-react";
+
+type ImportSummary = FunctionReturnType<
+  typeof api.gatewayImport.importGatewayLogs
+>;
+
+export function GatewayImport() {
+  const { org, orgId } = useOrg();
+  const base = `/orgs/${org.slug}`;
+  const projects = useQuery(api.projects.list, { orgId });
+  const importLogs = useAction(api.gatewayImport.importGatewayLogs);
+
+  const [projectId, setProjectId] = useState<string>("");
+  const [jsonl, setJsonl] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState("");
+  const [summary, setSummary] = useState<ImportSummary | null>(null);
+
+  async function handleImport(e: React.FormEvent) {
+    e.preventDefault();
+    if (!projectId) return;
+    setBusy(true);
+    setError("");
+    setSummary(null);
+    try {
+      const result = await importLogs({
+        projectId: projectId as Id<"projects">,
+        jsonl,
+      });
+      setSummary(result);
+    } catch (err) {
+      setError(friendlyError(err, "Import failed. Check the JSONL and try again."));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="mx-auto max-w-3xl p-6">
+      <Link
+        to={`${base}/gateway-onboarding`}
+        className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+      >
+        <ArrowLeft className="h-3 w-3" aria-hidden="true" />
+        Gateway onboarding
+      </Link>
+
+      <header className="mt-3">
+        <div className="flex items-center gap-2">
+          <CloudDownload aria-hidden="true" className="h-5 w-5 text-primary" />
+          <h1 className="text-2xl font-bold">Import Gateway logs</h1>
+        </div>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Paste exported Cloudflare AI Gateway logs (Logpush or API JSONL, one
+          record per line) to register them as deduplicated trace imports.
+        </p>
+      </header>
+
+      <Card className="mt-6 border-amber-500/40 bg-amber-500/5">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-base">
+            <ShieldAlert aria-hidden="true" className="h-4 w-4 text-amber-600" />
+            Data boundary
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2 text-sm text-muted-foreground">
+          <p>
+            Blind Bench makes <strong className="text-foreground">no calls to
+            Cloudflare</strong> — you export from your own gateway and paste it
+            here. Import identity (a per-record dedup id) and the raw record are
+            stored access-controlled, so imports can be re-parsed for eval sets.
+          </p>
+          <p>
+            This page never renders your trace content back — only counts,
+            model/provider names, and timestamps.
+          </p>
+        </CardContent>
+      </Card>
+
+      <form onSubmit={handleImport} className="mt-6 space-y-4">
+        <div className="space-y-1.5">
+          <Label htmlFor="gw-project">Project</Label>
+          {/* native select dodges the base-ui Select callback gotchas */}
+          <select
+            id="gw-project"
+            value={projectId}
+            onChange={(e) => setProjectId(e.target.value)}
+            required
+            className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+          >
+            <option value="" disabled>
+              {projects === undefined
+                ? "Loading projects…"
+                : projects.length === 0
+                  ? "No projects — create one first"
+                  : "Select a project"}
+            </option>
+            {projects?.map((p) => (
+              <option key={p._id} value={p._id}>
+                {p.name}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="gw-jsonl">Gateway logs (JSONL)</Label>
+          <Textarea
+            id="gw-jsonl"
+            value={jsonl}
+            onChange={(e) => setJsonl(e.target.value)}
+            placeholder={'{"log_id":"...","model":"...","request":{...},"response":{...}}'}
+            rows={12}
+            required
+            spellCheck={false}
+            className="font-mono text-xs"
+          />
+          <p className="text-xs text-muted-foreground">
+            One JSON object per line. Up to 5,000 lines / 8&nbsp;MB per import —
+            split larger exports into batches.
+          </p>
+        </div>
+
+        {error && (
+          <p className="text-sm text-destructive" role="alert">
+            {error}
+          </p>
+        )}
+
+        <Button type="submit" disabled={busy || !projectId || !jsonl.trim()}>
+          {busy ? "Importing…" : "Import Gateway logs"}
+        </Button>
+      </form>
+
+      {summary && <ImportSummaryCard summary={summary} />}
+
+      {projectId && (
+        <p className="mt-6 text-sm">
+          <Link
+            to={`${base}/projects/${projectId}/history`}
+            className="text-primary hover:underline"
+          >
+            View project import history →
+          </Link>
+        </p>
+      )}
+    </div>
+  );
+}
+
+function ImportSummaryCard({ summary }: { summary: ImportSummary }) {
+  const stats: { label: string; value: string }[] = [
+    { label: "Imported", value: String(summary.imported) },
+    { label: "Deduped", value: String(summary.deduped) },
+    { label: "Parsed", value: String(summary.parsed) },
+    { label: "Invalid lines", value: String(summary.invalid) },
+    { label: "Missing request", value: String(summary.redactedRequest) },
+    { label: "Missing response", value: String(summary.redactedResponse) },
+  ];
+  return (
+    <Card className="mt-6">
+      <CardHeader>
+        <CardTitle className="text-base">Import summary</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3 text-sm">
+        <dl className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+          {stats.map((s) => (
+            <div key={s.label}>
+              <dt className="text-xs text-muted-foreground">{s.label}</dt>
+              <dd className="text-lg font-semibold tabular-nums">{s.value}</dd>
+            </div>
+          ))}
+        </dl>
+
+        {summary.truncated && (
+          <p className="text-xs text-amber-600">
+            Import hit the per-batch line limit and stopped early — split the
+            export and re-import the remainder.
+          </p>
+        )}
+        {summary.invalidLines.length > 0 && (
+          <p className="text-xs text-muted-foreground">
+            Invalid line numbers (first {summary.invalidLines.length}):{" "}
+            {summary.invalidLines.join(", ")}
+          </p>
+        )}
+
+        <div className="grid gap-3 sm:grid-cols-2">
+          <Meta label="Models" values={summary.models} />
+          <Meta label="Providers" values={summary.providers} />
+        </div>
+
+        {(summary.earliest || summary.latest) && (
+          <p className="text-xs text-muted-foreground">
+            Window: {summary.earliest ?? "?"} → {summary.latest ?? "?"}
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function Meta({ label, values }: { label: string; values: string[] }) {
+  return (
+    <div>
+      <p className="text-xs text-muted-foreground">{label}</p>
+      <p className="text-sm">{values.length ? values.join(", ") : "—"}</p>
+    </div>
+  );
+}

--- a/src/routes/orgs/GatewayOnboarding.tsx
+++ b/src/routes/orgs/GatewayOnboarding.tsx
@@ -313,6 +313,12 @@ export function GatewayOnboarding() {
       {/* Footer links */}
       <div className="mt-8 flex flex-wrap gap-4 border-t pt-4 text-sm">
         <Link
+          to={`${base}/gateway-import`}
+          className="inline-flex items-center gap-1 font-medium text-primary hover:underline"
+        >
+          Import Gateway logs →
+        </Link>
+        <Link
           to={`${base}/settings/openrouter-key`}
           className="inline-flex items-center gap-1 text-primary hover:underline"
         >


### PR DESCRIPTION
## Summary

Adds a customer-owned Cloudflare AI Gateway log import path so live Gateway exports can be registered in Blind Bench for pilot evaluation workflows.

- Adds `cloudflare_ai_gateway` as a trace import source.
- Adds a Convex-safe Gateway JSONL parser with pure tests.
- Adds `gatewayImport.importGatewayLogs` action:
  - owner/editor gated
  - 5,000 line / 8 MB guardrails
  - dedupes by `(projectId, source, sourceTraceId)`
  - stores raw exported records in Convex storage for newly imported traces
  - returns only management-safe summaries; no prompt/output content in UI responses
- Adds `/orgs/:orgSlug/gateway-import` app route with project picker, JSONL paste box, and safe summary card.
- Adds sidebar/onboarding links and docs.

## Data boundary

Blind Bench makes no calls to Cloudflare and stores no Cloudflare credentials. Customers export JSONL from their own Gateway and paste it into the app.

The importer stores raw exported records in access-controlled Convex storage via `traceImports.rawPayloadStorageId` so adapter improvements/materialization can re-parse later, but the UI and action response never render prompt or response content back. Invalid lines are reported by line number only.

## Verification

- ✅ `env -u NODE_ENV npx vitest run convex/traceAdapters/cloudflareAiGateway.test.ts --config convex/vitest.config.ts` — 7 tests passed
- ✅ `env -u NODE_ENV npm run test:evals` — 11 files / 104 tests passed
- ✅ focused route bundle:
  `env -u NODE_ENV npx esbuild src/routes/orgs/GatewayImport.tsx --bundle --platform=browser --format=esm --jsx=automatic --external:react --external:react/jsx-runtime --external:react-router-dom --external:convex/react --external:../../../convex/_generated/api --external:../../../convex/_generated/dataModel --external:@/* --external:lucide-react --outfile=/tmp/gateway-import.js`
- ✅ focused Convex syntax bundle:
  `env -u NODE_ENV npx esbuild convex/gatewayImport.ts convex/traceAdapters/cloudflareAiGateway.ts --bundle --platform=node --format=esm --external:./_generated/* --external:convex/* --external:@convex-dev/* --outdir=/tmp/gateway-import-convex`
- ✅ `git diff --check`

## Known implementation note

`ctx.storage.store` is action-only, so import is two-phase:

1. internal mutation authorizes/dedupes/inserts trace import rows;
2. action stores raw payload blobs;
3. internal mutation patches `rawPayloadStorageId`.

If the action dies between steps, a row could exist without a storage id. That is acceptable for the paste-import MVP and can be repaired by re-importing or tightened later with an upload-url flow.

## Remaining follow-up

- Materialize imported raw payloads into prompt versions / completed run outputs for direct scorecard generation.
- Add optional sidecar metadata import for fields too large for Gateway metadata.
- Add browser visual QA screenshot once the preview is accessible with auth/seed data.
