### PR TITLE
fix: unblock Convex deploy typecheck (all prod deploys failing since #251)

### DIFF
--- a/convex/billing.ts
+++ b/convex/billing.ts
@@ -58,7 +58,23 @@ async function activeEntitlement(ctx: QueryCtx, orgId: Id<"organizations">) {
  */
 export const getBillingOverview = query({
   args: { orgId: v.id("organizations") },
-  handler: async (ctx, args) => {
+  handler: async (
+    ctx,
+    args,
+  ): Promise<{
+    packages: ReturnType<typeof publicPackageCatalog>;
+    trial: typeof TRIAL;
+    entitlement: { packageKey: string; status: string } | null;
+    remainingCredits: number;
+    ledger: Array<{
+      creditDelta: number;
+      reason: string;
+      packageKey: string | null;
+      createdAt: number;
+    }>;
+    portalAvailable: boolean;
+    checkoutConfigured: boolean;
+  }> => {
     await requireOrgRole(ctx, args.orgId, ["owner"]);
 
     const entitlement = await activeEntitlement(ctx, args.orgId);

--- a/convex/feedback.ts
+++ b/convex/feedback.ts
@@ -1,5 +1,6 @@
 import { v } from "convex/values";
 import { mutation, query } from "./_generated/server";
+import type { Doc } from "./_generated/dataModel";
 import { requireAuth, requireProjectRole } from "./lib/auth";
 import { legacyTargetFieldForMessage, readMessages } from "./lib/messages";
 
@@ -73,7 +74,12 @@ export const addOutputFeedback = mutation({
 
 export const listOutputFeedback = query({
   args: { outputId: v.id("runOutputs") },
-  handler: async (ctx, args) => {
+  handler: async (
+    ctx,
+    args,
+  ): Promise<
+    Array<Doc<"outputFeedback"> & { authorName: string | null; isOwn: boolean }>
+  > => {
     const output = await ctx.db.get(args.outputId);
     if (!output) return [];
 

--- a/convex/gatewayImport.ts
+++ b/convex/gatewayImport.ts
@@ -9,8 +9,24 @@ import {
   parseGatewayJsonl,
   summarizeTraces,
 } from "./traceAdapters/cloudflareAiGateway";
+import type { TraceAggregate } from "./traceAdapters/cloudflareAiGateway";
 
 const SOURCE = "cloudflare_ai_gateway" as const;
+
+interface InsertImportRowsResult {
+  imported: number;
+  deduped: number;
+  newRows: { importId: Id<"traceImports">; index: number }[];
+}
+
+type ImportGatewayLogsResult = {
+  imported: number;
+  deduped: number;
+  parsed: number;
+  invalid: number;
+  invalidLines: number[];
+  truncated: boolean;
+} & TraceAggregate;
 
 /**
  * Auth + dedup + identity insert for a batch of parsed traces. Runs as one
@@ -23,7 +39,7 @@ export const insertImportRows = internalMutation({
     projectId: v.id("projects"),
     sourceTraceIds: v.array(v.string()),
   },
-  handler: async (ctx, args) => {
+  handler: async (ctx, args): Promise<InsertImportRowsResult> => {
     const { userId } = await requireProjectRole(ctx, args.projectId, [
       "owner",
       "editor",
@@ -97,7 +113,7 @@ export const importGatewayLogs = action({
     projectId: v.id("projects"),
     jsonl: v.string(),
   },
-  handler: async (ctx, args) => {
+  handler: async (ctx, args): Promise<ImportGatewayLogsResult> => {
     // UTF-16 char length, not exact bytes — a cheap upper-bound guard before
     // we do any work.
     if (args.jsonl.length > DEFAULT_LIMITS.maxBytes) {
@@ -111,9 +127,8 @@ export const importGatewayLogs = action({
       DEFAULT_LIMITS,
     );
 
-    const { imported, deduped, newRows } = await ctx.runMutation(
-      internal.gatewayImport.insertImportRows,
-      {
+    const { imported, deduped, newRows }: InsertImportRowsResult =
+      await ctx.runMutation(internal.gatewayImport.insertImportRows, {
         projectId: args.projectId,
         sourceTraceIds: traces.map((t) => t.sourceTraceId),
       },
@@ -125,7 +140,7 @@ export const importGatewayLogs = action({
       [];
     for (const { importId, index } of newRows) {
       const storageId = await ctx.storage.store(
-        new Blob([traces[index].rawPayloadJson], { type: "application/json" }),
+        new Blob([traces[index]!.rawPayloadJson], { type: "application/json" }),
       );
       updates.push({ importId, storageId });
     }

--- a/convex/lib/polarSignature.ts
+++ b/convex/lib/polarSignature.ts
@@ -23,19 +23,19 @@ function toBase64(bytes: Uint8Array): string {
   return btoa(binary);
 }
 
-function fromBase64(b64: string): Uint8Array {
+function fromBase64(b64: string): Uint8Array<ArrayBuffer> {
   const binary = atob(b64);
   const bytes = new Uint8Array(binary.length);
   for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
   return bytes;
 }
 
-function secretToKeyBytes(secret: string): Uint8Array {
+function secretToKeyBytes(secret: string): Uint8Array<ArrayBuffer> {
   if (secret.startsWith("whsec_")) return fromBase64(secret.slice("whsec_".length));
   return new TextEncoder().encode(secret);
 }
 
-async function hmacBase64(keyBytes: Uint8Array, message: string): Promise<string> {
+async function hmacBase64(keyBytes: Uint8Array<ArrayBuffer>, message: string): Promise<string> {
   const key = await crypto.subtle.importKey(
     "raw",
     keyBytes,

--- a/convex/optimize.ts
+++ b/convex/optimize.ts
@@ -265,7 +265,7 @@ export const cancelOptimization = mutation({
 
 export const acceptOptimization = mutation({
   args: { requestId: v.id("optimizationRequests") },
-  handler: async (ctx, args) => {
+  handler: async (ctx, args): Promise<Id<"promptVersions">> => {
     const request = await ctx.db.get(args.requestId);
     if (!request) throw new Error("Optimization request not found");
 

--- a/convex/runComments.ts
+++ b/convex/runComments.ts
@@ -1,5 +1,6 @@
 import { v } from "convex/values";
 import { mutation, query } from "./_generated/server";
+import type { Id } from "./_generated/dataModel";
 import { isBlindReviewer, requireProjectRole } from "./lib/auth";
 
 // ---------------------------------------------------------------------------
@@ -76,7 +77,18 @@ export const getMyComment = query({
 
 export const listForRun = query({
   args: { runId: v.id("promptRuns") },
-  handler: async (ctx, args) => {
+  handler: async (
+    ctx,
+    args,
+  ): Promise<
+    Array<{
+      _id: Id<"runComments">;
+      comment: string;
+      createdAt: number;
+      authorName: string | null;
+      isOwn: boolean;
+    }>
+  > => {
     const run = await ctx.db.get(args.runId);
     if (!run) return [];
 

--- a/convex/runsActions.ts
+++ b/convex/runsActions.ts
@@ -161,9 +161,10 @@ export const executeRunAction = internalAction({
       version,
       testCase,
       variables,
-      promptAttachments,
       organizationId,
     } = context;
+    const promptAttachments: Doc<"promptAttachments">[] =
+      context.promptAttachments;
 
     // 2. Decrypt org's OpenRouter key
     let apiKey: string;

--- a/convex/tests/billing.test.ts
+++ b/convex/tests/billing.test.ts
@@ -63,15 +63,15 @@ describe("applyPolarEvent", () => {
         .withIndex("by_org", (q) => q.eq("organizationId", ids.orgId))
         .collect();
       expect(ledger).toHaveLength(1);
-      expect(ledger[0].creditDelta).toBe(2500);
+      expect(ledger[0]!.creditDelta).toBe(2500);
 
       const ent = await ctx.db
         .query("billingEntitlements")
         .withIndex("by_org", (q) => q.eq("organizationId", ids.orgId))
         .collect();
       expect(ent).toHaveLength(1);
-      expect(ent[0].status).toBe("active");
-      expect(ent[0].packageKey).toBe("team");
+      expect(ent[0]!.status).toBe("active");
+      expect(ent[0]!.packageKey).toBe("team");
 
       const cust = await ctx.db
         .query("billingCustomers")
@@ -142,7 +142,7 @@ describe("applyPolarEvent", () => {
         .query("billingEntitlements")
         .withIndex("by_org", (q) => q.eq("organizationId", ids.orgId))
         .collect();
-      expect(ent[0].status).toBe("revoked");
+      expect(ent[0]!.status).toBe("revoked");
       return ledger.reduce((a, r) => a + r.creditDelta, 0);
     });
     expect(credits).toBe(0);

--- a/convex/traceAdapters/cloudflareAiGateway.ts
+++ b/convex/traceAdapters/cloudflareAiGateway.ts
@@ -81,7 +81,6 @@ const get = (obj: unknown, paths: string[]): unknown => {
   }
   return undefined;
 };
-const getRecord = (obj: unknown, paths: string[]) => asRecord(get(obj, paths));
 const getStr = (obj: unknown, paths: string[]) => str(get(obj, paths));
 const getNum = (obj: unknown, paths: string[]) => num(get(obj, paths));
 
@@ -225,7 +224,7 @@ export function parseGatewayJsonl(
   let truncated = false;
 
   for (let i = 0; i < lines.length; i++) {
-    const line = lines[i].trim();
+    const line = lines[i]!.trim();
     if (!line) continue;
     if (processed >= limits.maxLines) {
       truncated = true;


### PR DESCRIPTION
## What broke

**Every Vercel production deploy has failed since June 26** (last green: 58e3e04, PR #250's merge). Not caused by PR #253 — it touched no `convex/` code; the identical 18 errors appear in the June 26 deploy log for 8ad356d.

**Root cause:** the modules added by PRs #251 (Polar billing) and #252 (gateway import) pushed TypeScript's type-inference budget over a complexity cliff in the generated Convex `api` type. Inference then degraded *codebase-wide*, which is why untouched April-era files (`runsActions.ts`, `optimize/feedback/evalSecurity` tests) suddenly error. Verified empirically: the full pre-#251 tree typechecks clean under the identical toolchain (TS 6.0.2, same lockfile); the current tree fails with exactly the deploy's 18 errors.

A second layer: `tsc -b` (the deploy step *after* `convex deploy`) compiles `convex/` under stricter flags (`noUncheckedIndexedAccess`, `noUnusedLocals`) and had 7 more errors in the same PRs' files — masked until now because deploys died at the convex step first.

## The fix (type-level only, zero behavior change)

- Explicit handler return-type annotations at the source — restores narrowing for every caller and permanently cuts the inference chains: `billing.getBillingOverview`, `feedback.listOutputFeedback`, `runComments.listForRun`, `optimize.acceptOptimization`, `gatewayImport` (breaks the same-file `internal.*` circularity), `runsActions` attachments.
- `Uint8Array` → `Uint8Array<ArrayBuffer>` in `polarSignature.ts` (TS 6 dom lib narrowed `BufferSource`; the bare annotations were widening).
- `!` assertions on provably-in-range indices + one dead function (`getRecord`) deleted in `traceAdapters/cloudflareAiGateway.ts` (grep-verified unreferenced).

No `any`, no ts-ignore, no runtime changes.

## Verification (all local, against reconstructed `_generated` bindings that reproduce the deploy's typecheck exactly)

- `npx tsc -p convex`: 18 → **0 errors**
- `npx tsc -b`: 7 → **0 errors** (exit 0; also proves the widened billing types don't break `src/` consumers)
- `npm run test:convex`: **141/141** (runnable locally for the first time via runtime stubs)
- `npm run test:evals`: **121/121**
- Reviewed: every annotation verified against the actual return shape; every `!` verified in range.

Merging this should produce the first green production deploy since June 26 — it will take #251, #252, and #253 live together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)