### PR TITLE
ci: run typecheck gates on preview builds (no Convex deploy key needed)

### DIFF
--- a/docs/preview-typecheck-builds.md
+++ b/docs/preview-typecheck-builds.md
@@ -1,0 +1,63 @@
+# Preview typecheck builds (no Convex deploy key)
+
+## The problem
+
+Vercel runs `npm run build:deploy` for **both** production and preview
+(PR) environments. That script used to start with `npx convex deploy`, but
+`CONVEX_DEPLOY_KEY` is scoped to Production only. So every preview build died
+in ~5s at `convex deploy` ("no Convex deployment configuration found") —
+**before either TypeScript gate ran**. PRs therefore carried no type signal:
+the June 26–July 2, 2026 production outage (25 type errors — 18 from the
+convex-side typecheck, 7 from `tsc -b`) was mergeable behind green-looking
+checks and went a week undetected.
+
+## What the stub build does
+
+`scripts/vercel-build.mjs` is the build entrypoint (`build:deploy`):
+
+- **Deploy key present** (production, or preview if a Convex Pro preview key
+  is added later): behaves exactly as before — `npx convex deploy && tsc -b &&
+  vite build`.
+- **No deploy key** (preview today): prints a note, runs
+  `scripts/generate-convex-stubs.mjs` to reconstruct `convex/_generated`, then
+  runs **both** type gates (`tsc -p convex` — what `convex deploy` would have
+  typechecked — and `tsc -b`) plus `vite build`.
+
+The generated stubs are deterministic (module list walked from `convex/`,
+sorted) and reproduced Vercel's `convex deploy` typecheck output byte-for-byte
+on 2026-07-02.
+
+## Skip-if-exists guarantee
+
+`generate-convex-stubs.mjs` exits immediately without writing anything if
+`convex/_generated/api.d.ts` already exists. Real codegen — locally, or after
+a genuine `convex deploy` — is never clobbered. Production behavior is
+unchanged.
+
+## Local use
+
+On a machine with no Convex deployment, run:
+
+```bash
+node scripts/generate-convex-stubs.mjs
+```
+
+to unblock `tsc -b`, `npm run test:convex`, and `npm run test:evals` without
+needing a live backend. (`convex/_generated` is gitignored; the stubs are
+never committed.)
+
+## Upgrade path: real isolated preview deployments
+
+Previews auto-upgrade to real Convex preview deployments — no code change — as
+soon as a preview deploy key exists:
+
+1. Mint a Convex **preview** deploy key: Convex dashboard → project Settings →
+   URL & Deploy Keys (requires Convex Pro).
+2. `vercel env add CONVEX_DEPLOY_KEY preview`.
+
+`scripts/vercel-build.mjs` then takes the deploy branch for previews too.
+
+Until then, note that a preview URL is a **CI artifact, not a usable app**:
+the bundle is built against the stub `api` at runtime and previews have no
+`VITE_CONVEX_URL`. The value of the preview build is the type signal, not a
+clickable deployment.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
-    "build:deploy": "npx convex deploy && tsc -b && vite build",
+    "build:deploy": "node scripts/vercel-build.mjs",
     "preview": "vite preview",
     "test:evals": "vitest run src/lib/evals/",
     "test:convex": "vitest run --config convex/vitest.config.ts",

--- a/scripts/generate-convex-stubs.mjs
+++ b/scripts/generate-convex-stubs.mjs
@@ -1,0 +1,155 @@
+/* Generate deterministic convex/_generated stubs for preview-CI typecheck.
+ *
+ * Vercel preview builds have no CONVEX_DEPLOY_KEY, so `convex deploy` (which
+ * normally writes convex/_generated) never runs and the type gates can't see
+ * the generated `api`/`server`/`dataModel` modules. This script reconstructs
+ * those files just well enough to typecheck against — it reproduced Vercel's
+ * `convex deploy` typecheck output byte-for-byte on 2026-07-02.
+ *
+ * Real codegen ALWAYS wins: if convex/_generated/api.d.ts already exists
+ * (locally, or after a real `convex deploy`), this script exits 0 and touches
+ * nothing. See docs/preview-typecheck-builds.md.
+ *
+ * ESM, Node 20+, only node: builtins. No dependencies.
+ */
+import { readdirSync, existsSync, writeFileSync, mkdirSync } from "node:fs";
+import { join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const convexDir = fileURLToPath(new URL("../convex/", import.meta.url));
+const generatedDir = join(convexDir, "_generated");
+
+// Real codegen wins — never clobber it.
+if (existsSync(join(generatedDir, "api.d.ts"))) {
+  console.log(
+    "convex/_generated/api.d.ts already exists — leaving real codegen in place (no stubs written).",
+  );
+  process.exit(0);
+}
+
+const EXCLUDED_DIRS = new Set(["_generated", "tests", "fixtures"]);
+
+/** Walk convex/ and collect module paths (relative to convex/, no extension). */
+function collectModules(dir) {
+  const modules = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (EXCLUDED_DIRS.has(entry.name)) continue;
+      modules.push(...collectModules(full));
+      continue;
+    }
+    if (!entry.name.endsWith(".ts")) continue;
+    if (entry.name.endsWith(".test.ts")) continue;
+    if (entry.name.endsWith(".config.ts")) continue;
+    if (entry.name === "schema.ts") continue;
+    // module path relative to convex/, forward slashes, no extension
+    const rel = relative(convexDir, full).replace(/\\/g, "/").replace(/\.ts$/, "");
+    modules.push(rel);
+  }
+  return modules;
+}
+
+const modules = collectModules(convexDir).sort();
+
+// alias = module path with /, ., - replaced by _
+const alias = (m) => m.replace(/[/.\-]/g, "_");
+
+const imports = modules
+  .map((m) => `import type * as ${alias(m)} from "../${m}.js";`)
+  .join("\n");
+
+const fullApiEntries = modules
+  .map((m) => `  "${m}": typeof ${alias(m)};`)
+  .join("\n");
+
+const apiDts = `/* eslint-disable */
+import type { ApiFromModules, FilterApi, FunctionReference } from "convex/server";
+${imports}
+declare const fullApi: ApiFromModules<{
+${fullApiEntries}
+}>;
+export declare const api: FilterApi<typeof fullApi, FunctionReference<any, "public">>;
+export declare const internal: FilterApi<typeof fullApi, FunctionReference<any, "internal">>;
+`;
+
+const dataModelDts = `/* eslint-disable */
+import type {
+  DataModelFromSchemaDefinition,
+  DocumentByName,
+  TableNamesInDataModel,
+  SystemTableNames,
+} from "convex/server";
+import type { GenericId } from "convex/values";
+import schema from "../schema.js";
+
+export type TableNames = TableNamesInDataModel<DataModel>;
+export type Doc<TableName extends TableNames> = DocumentByName<DataModel, TableName>;
+export type Id<TableName extends TableNames | SystemTableNames> = GenericId<TableName>;
+export type DataModel = DataModelFromSchemaDefinition<typeof schema>;
+`;
+
+const serverDts = `/* eslint-disable */
+import {
+  ActionBuilder,
+  HttpActionBuilder,
+  MutationBuilder,
+  QueryBuilder,
+  GenericActionCtx,
+  GenericMutationCtx,
+  GenericQueryCtx,
+  GenericDatabaseReader,
+  GenericDatabaseWriter,
+} from "convex/server";
+import type { DataModel } from "./dataModel.js";
+
+export declare const query: QueryBuilder<DataModel, "public">;
+export declare const internalQuery: QueryBuilder<DataModel, "internal">;
+export declare const mutation: MutationBuilder<DataModel, "public">;
+export declare const internalMutation: MutationBuilder<DataModel, "internal">;
+export declare const action: ActionBuilder<DataModel, "public">;
+export declare const internalAction: ActionBuilder<DataModel, "internal">;
+export declare const httpAction: HttpActionBuilder;
+
+export type QueryCtx = GenericQueryCtx<DataModel>;
+export type MutationCtx = GenericMutationCtx<DataModel>;
+export type ActionCtx = GenericActionCtx<DataModel>;
+export type DatabaseReader = GenericDatabaseReader<DataModel>;
+export type DatabaseWriter = GenericDatabaseWriter<DataModel>;
+`;
+
+const apiJs = `/* eslint-disable */
+import { anyApi } from "convex/server";
+export const api = anyApi;
+export const internal = anyApi;
+`;
+
+const serverJs = `/* eslint-disable */
+import {
+  actionGeneric,
+  httpActionGeneric,
+  mutationGeneric,
+  queryGeneric,
+  internalActionGeneric,
+  internalMutationGeneric,
+  internalQueryGeneric,
+} from "convex/server";
+export const action = actionGeneric;
+export const httpAction = httpActionGeneric;
+export const mutation = mutationGeneric;
+export const query = queryGeneric;
+export const internalAction = internalActionGeneric;
+export const internalMutation = internalMutationGeneric;
+export const internalQuery = internalQueryGeneric;
+`;
+
+mkdirSync(generatedDir, { recursive: true });
+writeFileSync(join(generatedDir, "api.d.ts"), apiDts);
+writeFileSync(join(generatedDir, "dataModel.d.ts"), dataModelDts);
+writeFileSync(join(generatedDir, "server.d.ts"), serverDts);
+writeFileSync(join(generatedDir, "api.js"), apiJs);
+writeFileSync(join(generatedDir, "server.js"), serverJs);
+
+console.log(
+  `Wrote convex/_generated stubs for ${modules.length} modules (preview typecheck only).`,
+);

--- a/scripts/vercel-build.mjs
+++ b/scripts/vercel-build.mjs
@@ -1,0 +1,26 @@
+/* Vercel build entrypoint: real Convex deploy when a deploy key exists
+ * (production — or preview, if a Convex Pro preview key is added later);
+ * otherwise typecheck-only against generated stubs so PR builds still run
+ * both type gates. See docs/preview-typecheck-builds.md. */
+import { execSync } from "node:child_process";
+
+const run = (cmd) => {
+  try {
+    execSync(cmd, { stdio: "inherit" });
+  } catch {
+    console.error(`\nBuild step failed: ${cmd}`);
+    process.exit(1);
+  }
+};
+
+if (process.env.CONVEX_DEPLOY_KEY || process.env.CONVEX_SELF_HOSTED_URL) {
+  run("npx convex deploy");
+} else {
+  console.log("No CONVEX_DEPLOY_KEY — preview typecheck build (no backend push).");
+  run("node scripts/generate-convex-stubs.mjs");
+  // Gate 1: what `convex deploy` would have typechecked.
+  run("npx tsc -p convex --pretty false");
+}
+// Gate 2 + bundle: same for both paths.
+run("npx tsc -b");
+run("npx vite build");


### PR DESCRIPTION
## Why

`CONVEX_DEPLOY_KEY` is Production-scoped only, so every Vercel **preview** build has been failing in ~5s at `convex deploy` ("no Convex deployment configuration found") — before any typecheck runs. PRs therefore carried zero type signal, which is how the June 26 – July 2 production outage (25 type errors across both gates, fixed in #254) was mergeable without a red check.

## What

`npm run build:deploy` now runs `scripts/vercel-build.mjs`:

- **Deploy key present** (production today; previews too if a key is ever added): `npx convex deploy && tsc -b && vite build` — behavior unchanged.
- **No key** (previews today): generate deterministic `convex/_generated` stubs (`scripts/generate-convex-stubs.mjs`) → **gate 1** `tsc -p convex` (what `convex deploy` would typecheck) → **gate 2** `tsc -b` → `vite build`. Any failure exits non-zero → red PR check.

The stub generator is skip-if-exists (real codegen always wins), dependency-free, and reproduces the deploy's typecheck exactly — it's the same reconstruction that pinpointed the #254 errors byte-for-byte. It also doubles as the local bootstrap: on a machine with no Convex deployment, `node scripts/generate-convex-stubs.mjs` unblocks `tsc -b` and `npm run test:convex`.

Docs: `docs/preview-typecheck-builds.md`, including the upgrade path — mint a Convex **preview** deploy key (Convex Pro) and `vercel env add CONVEX_DEPLOY_KEY preview`, and previews switch to real isolated deployments with zero code change. Until then, preview URLs are CI artifacts, not usable apps (same as today).

## Verification

- Simulated preview build (`env -u CONVEX_DEPLOY_KEY npm run build:deploy`): exit 0 — 71-module stubs, both gates, vite build.
- Deliberate type error injected: exit 1 at gate 1 with the error printed (failure propagation proven).
- Skip-if-exists guard: no-op on second run; regenerated `api.d.ts` byte-identical to the reference that reproduced #254's errors.
- `npm run test:convex` 141/141, `npm run test:evals` 121/121 with generated stubs.
- Reviewed: every error path in the build script verified unable to exit 0 or skip a gate; module-list exclusions independently checked against the tree (71/71, edge cases incl. `lib/__tests__`, `*.config.ts`).

After merging: the next PR's preview check should go red iff the typecheck fails — you can test it by pushing any branch with a deliberate type error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)