### PR TITLE
M30 batch: live Fireworks gateway smoke, run input snapshots, onboarding + product docs (#230, #188, #232, #227)

### DIFF
--- a/convex/imageVariableAttachments.ts
+++ b/convex/imageVariableAttachments.ts
@@ -1,6 +1,7 @@
 import { v } from "convex/values";
 import { mutation, query } from "./_generated/server";
 import { requireProjectRole } from "./lib/auth";
+import { safeDeleteTestCaseBlob } from "./lib/storageCleanup";
 
 // Mime allowlist matching OpenRouter's OpenAI-compatible image input format.
 // Anything outside this set is rejected at finalize() — never trust the client.
@@ -101,6 +102,8 @@ export const deleteAttachment = mutation({
   },
   handler: async (ctx, args) => {
     await requireProjectRole(ctx, args.projectId, ["owner", "editor"]);
-    await ctx.storage.delete(args.storageId);
+    // #188: don't delete a blob still referenced by a past run's inputSnapshot;
+    // its "what we sent" history depends on the blob staying alive.
+    await safeDeleteTestCaseBlob(ctx, args.projectId, args.storageId);
   },
 });

--- a/convex/lib/inputSnapshot.ts
+++ b/convex/lib/inputSnapshot.ts
@@ -1,0 +1,61 @@
+import type { Id } from "../_generated/dataModel";
+
+/**
+ * #188: The frozen inputs dispatched with a run. `text` holds the resolved
+ * text-variable values; `images` maps image-variable name → the _storage blob
+ * that was sent. Mirrors the `promptRuns.inputSnapshot` schema shape.
+ */
+export type InputSnapshot = {
+  text: Record<string, string>;
+  images?: Record<string, Id<"_storage">>;
+};
+
+/**
+ * Build the snapshot to freeze onto a run at dispatch time.
+ *
+ * - Quick runs (no test case) snapshot the inline variables as `text`.
+ * - Test-case runs snapshot `variableValues` as `text` and any
+ *   `variableAttachments` (image variables) as `images`.
+ *
+ * The returned object is a shallow copy so later edits to the source test case
+ * can never mutate the frozen snapshot.
+ */
+export function buildInputSnapshot(args: {
+  inlineVariables?: Record<string, string>;
+  testCase?: {
+    variableValues: Record<string, string>;
+    variableAttachments?: Record<string, Id<"_storage">>;
+  } | null;
+}): InputSnapshot {
+  if (args.inlineVariables) {
+    return { text: { ...args.inlineVariables } };
+  }
+  const tc = args.testCase;
+  const text = { ...(tc?.variableValues ?? {}) };
+  const images = tc?.variableAttachments;
+  if (images && Object.keys(images).length > 0) {
+    return { text, images: { ...images } };
+  }
+  return { text };
+}
+
+/**
+ * Pure blob-retention predicate: is `storageId` referenced by the
+ * `inputSnapshot.images` of any of the given runs? Used to decide whether a
+ * test-case blob is safe to delete when the test case is edited or removed —
+ * blobs still referenced by a past run's snapshot must survive so the run's
+ * "what we sent" history stays intact.
+ */
+export function isStorageIdReferencedBySnapshots(
+  runs: ReadonlyArray<{ inputSnapshot?: InputSnapshot | null }>,
+  storageId: Id<"_storage">,
+): boolean {
+  for (const run of runs) {
+    const images = run.inputSnapshot?.images;
+    if (!images) continue;
+    for (const id of Object.values(images)) {
+      if (id === storageId) return true;
+    }
+  }
+  return false;
+}

--- a/convex/lib/inputSnapshot.ts
+++ b/convex/lib/inputSnapshot.ts
@@ -40,6 +40,37 @@ export function buildInputSnapshot(args: {
 }
 
 /**
+ * Resolve the variable inputs to dispatch for a run. When a snapshot exists it
+ * is authoritative for BOTH text and images — a snapshot without `images`
+ * means "no image variables were bound at dispatch", so we must not fall back
+ * to the live test case's attachments (that would dispatch images added after
+ * run creation). Live fallback applies only to pre-#188 runs with no snapshot.
+ */
+export function resolveDispatchInputs(args: {
+  snapshot?: InputSnapshot | null;
+  testCase?: {
+    variableValues: Record<string, string>;
+    variableAttachments?: Record<string, Id<"_storage">>;
+  } | null;
+  inlineVariables?: Record<string, string>;
+}): {
+  variableValues: Record<string, string>;
+  variableAttachments: Record<string, Id<"_storage">>;
+} {
+  if (args.snapshot) {
+    return {
+      variableValues: args.snapshot.text,
+      variableAttachments: args.snapshot.images ?? {},
+    };
+  }
+  return {
+    variableValues:
+      args.testCase?.variableValues ?? args.inlineVariables ?? {},
+    variableAttachments: args.testCase?.variableAttachments ?? {},
+  };
+}
+
+/**
  * Pure blob-retention predicate: is `storageId` referenced by the
  * `inputSnapshot.images` of any of the given runs? Used to decide whether a
  * test-case blob is safe to delete when the test case is edited or removed —

--- a/convex/lib/storageCleanup.ts
+++ b/convex/lib/storageCleanup.ts
@@ -1,5 +1,6 @@
 import type { MutationCtx } from "../_generated/server";
 import type { Id } from "../_generated/dataModel";
+import { isStorageIdReferencedBySnapshots } from "./inputSnapshot";
 
 /**
  * Idempotent ctx.storage.delete — swallows "not found" errors so cascade
@@ -17,4 +18,29 @@ export async function safeDeleteStorage(
     if (/not found|does not exist|no such/i.test(msg)) return;
     throw err;
   }
+}
+
+/**
+ * #188: Delete a test-case image blob unless a past run's `inputSnapshot`
+ * still references it. Snapshots freeze "what we sent", so editing or deleting
+ * a test case must not garbage-collect a blob that a completed run's history
+ * depends on. When still referenced, we keep the blob (it is retained for the
+ * life of the referencing run(s)).
+ *
+ * ponytail: scans every promptRuns row in the project per blob delete, scoped
+ * via the `by_project_and_status` index prefix (projectId only). Fine at
+ * current volumes; if run counts per project grow large, add a dedicated
+ * reverse index (storageId → runs) or a snapshot-blob table to avoid the scan.
+ */
+export async function safeDeleteTestCaseBlob(
+  ctx: MutationCtx,
+  projectId: Id<"projects">,
+  storageId: Id<"_storage">,
+): Promise<void> {
+  const runs = await ctx.db
+    .query("promptRuns")
+    .withIndex("by_project_and_status", (q) => q.eq("projectId", projectId))
+    .collect();
+  if (isStorageIdReferencedBySnapshots(runs, storageId)) return;
+  await safeDeleteStorage(ctx, storageId);
 }

--- a/convex/projects.ts
+++ b/convex/projects.ts
@@ -6,7 +6,7 @@ import {
   requireOrgRole,
   requireProjectRole,
 } from "./lib/auth";
-import { safeDeleteStorage } from "./lib/storageCleanup";
+import { safeDeleteTestCaseBlob } from "./lib/storageCleanup";
 import { genMessageId } from "./lib/messages";
 import {
   createPersonalOrg,
@@ -474,13 +474,16 @@ export const deleteProject = mutation({
     // project is removed. Only image attachments are cleaned up here — other
     // entity rows (testCases, runs, versions, etc.) are intentionally left
     // for the broader cleanup story.
+    // #188: because promptRuns rows survive this cascade, their inputSnapshot
+    // history can still reference these blobs — route through the retention
+    // check so a lingering run's "what we sent" stays intact.
     const testCases = await ctx.db
       .query("testCases")
       .withIndex("by_project", (q) => q.eq("projectId", args.projectId))
       .take(500);
     for (const tc of testCases) {
       for (const storageId of Object.values(tc.variableAttachments ?? {})) {
-        await safeDeleteStorage(ctx, storageId);
+        await safeDeleteTestCaseBlob(ctx, args.projectId, storageId);
       }
     }
 

--- a/convex/runs.ts
+++ b/convex/runs.ts
@@ -12,7 +12,10 @@ import { getBlindLabels, validateSlotConfigs } from "./lib/slotConfig";
 import { collectReferencedVariables } from "./lib/templateValidation";
 import { readMessages } from "./lib/messages";
 import { modelSupportsImages } from "./lib/modelCapabilities";
-import { buildInputSnapshot } from "./lib/inputSnapshot";
+import {
+  buildInputSnapshot,
+  resolveDispatchInputs,
+} from "./lib/inputSnapshot";
 
 const CONCURRENT_CAP = 10;
 
@@ -49,6 +52,11 @@ export const execute = mutation({
     // Require exactly one of testCaseId or inlineVariables
     if (!args.testCaseId && !args.inlineVariables) {
       throw new Error("Provide a test case or inline variable values.");
+    }
+    if (args.testCaseId && args.inlineVariables) {
+      throw new Error(
+        "Provide either a test case or inline variable values, not both.",
+      );
     }
 
     // Verify test case belongs to same project (when using test case)
@@ -495,26 +503,22 @@ export const getRunContext = internalQuery({
 
     // #188: Dispatch from the frozen input snapshot, not the live test case.
     // The action runs asynchronously after the run row is created, so a test
-    // case edited in that window would otherwise change "what we sent".
-    // `attachmentIds` (legacy prompt/test-case attachments, not keyed by
-    // variable) are outside the snapshot's scope, so those still ride on the
-    // live test case. Pre-#188 runs have no snapshot and fall back to live.
-    const snapshot = run.inputSnapshot;
+    // case edited in that window would otherwise change "what we sent". A
+    // snapshot is authoritative for BOTH text and images (no live fallback for
+    // either — see resolveDispatchInputs). `attachmentIds` (legacy prompt/
+    // test-case attachments, not keyed by variable) are outside the snapshot's
+    // scope, so those still ride on the live test case.
+    const dispatchInputs = resolveDispatchInputs({
+      snapshot: run.inputSnapshot,
+      testCase,
+      inlineVariables: run.inlineVariables,
+    });
     const effectiveTestCase = {
-      variableValues:
-        snapshot?.text ??
-        testCase?.variableValues ??
-        ((run.inlineVariables ?? {}) as Record<string, string>),
+      variableValues: dispatchInputs.variableValues,
       attachmentIds: (testCase?.attachmentIds ?? []) as Array<
         import("./_generated/dataModel").Id<"_storage">
       >,
-      variableAttachments:
-        snapshot?.images ??
-        testCase?.variableAttachments ??
-        ({} as Record<
-          string,
-          import("./_generated/dataModel").Id<"_storage">
-        >),
+      variableAttachments: dispatchInputs.variableAttachments,
     };
 
     const project = await ctx.db.get(version.projectId);

--- a/convex/runs.ts
+++ b/convex/runs.ts
@@ -12,6 +12,7 @@ import { getBlindLabels, validateSlotConfigs } from "./lib/slotConfig";
 import { collectReferencedVariables } from "./lib/templateValidation";
 import { readMessages } from "./lib/messages";
 import { modelSupportsImages } from "./lib/modelCapabilities";
+import { buildInputSnapshot } from "./lib/inputSnapshot";
 
 const CONCURRENT_CAP = 10;
 
@@ -52,6 +53,7 @@ export const execute = mutation({
 
     // Verify test case belongs to same project (when using test case)
     let testCaseVarValues: Record<string, string> | undefined;
+    let testCaseAttachments: Record<string, Id<"_storage">> | undefined;
     let testCaseHasImages = false;
     if (args.testCaseId) {
       const testCase = await ctx.db.get(args.testCaseId);
@@ -59,6 +61,7 @@ export const execute = mutation({
         throw new Error("Test case not found");
       }
       testCaseVarValues = testCase.variableValues;
+      testCaseAttachments = testCase.variableAttachments;
       testCaseHasImages =
         Object.keys(testCase.variableAttachments ?? {}).length > 0;
     }
@@ -141,12 +144,25 @@ export const execute = mutation({
       }
     }
 
+    // #188: Freeze the inputs we're about to dispatch onto the run row so the
+    // run's "what we sent" history survives later edits to the test case.
+    const inputSnapshot = buildInputSnapshot({
+      inlineVariables: args.inlineVariables,
+      testCase: args.testCaseId
+        ? {
+            variableValues: testCaseVarValues ?? {},
+            variableAttachments: testCaseAttachments,
+          }
+        : null,
+    });
+
     // Create run
     const runId = await ctx.db.insert("promptRuns", {
       projectId: version.projectId,
       promptVersionId: args.versionId,
       testCaseId: args.testCaseId,
       inlineVariables: args.inlineVariables,
+      inputSnapshot,
       model: args.model,
       temperature: args.temperature,
       maxTokens: args.maxTokens,
@@ -307,6 +323,19 @@ export const get = query({
       : null;
     const trigger = await ctx.db.get(run.triggeredById);
 
+    // #188: The inputs shown in the run's "what we sent" view. Prefer the
+    // frozen snapshot; then inline variables (immutable, so accurate for both
+    // old and new quick runs); finally, for pre-#188 test-case runs with no
+    // snapshot, fall back to the *live* test case values and flag it so the UI
+    // can warn the reader instead of silently presenting current state as
+    // history.
+    const inputVariables =
+      run.inputSnapshot?.text ??
+      run.inlineVariables ??
+      testCase?.variableValues ??
+      null;
+    const inputSnapshotMissing = run.testCaseId != null && !run.inputSnapshot;
+
     return {
       ...run,
       outputs: outputs.sort((a, b) => a.blindLabel.localeCompare(b.blindLabel)),
@@ -315,6 +344,8 @@ export const get = query({
       testCaseName: testCase?.name ?? null,
       isQuickRun: !run.testCaseId,
       inlineVariables: run.inlineVariables ?? null,
+      inputVariables,
+      inputSnapshotMissing,
       triggeredByName: trigger?.name ?? null,
     };
   },
@@ -462,14 +493,28 @@ export const getRunContext = internalQuery({
       : null;
     if (run.testCaseId && !testCase) throw new Error("Test case not found");
 
-    // Construct a synthetic test case shape for quick runs
-    const effectiveTestCase = testCase ?? {
-      variableValues: (run.inlineVariables ?? {}) as Record<string, string>,
-      attachmentIds: [] as Array<import("./_generated/dataModel").Id<"_storage">>,
-      variableAttachments: {} as Record<
-        string,
+    // #188: Dispatch from the frozen input snapshot, not the live test case.
+    // The action runs asynchronously after the run row is created, so a test
+    // case edited in that window would otherwise change "what we sent".
+    // `attachmentIds` (legacy prompt/test-case attachments, not keyed by
+    // variable) are outside the snapshot's scope, so those still ride on the
+    // live test case. Pre-#188 runs have no snapshot and fall back to live.
+    const snapshot = run.inputSnapshot;
+    const effectiveTestCase = {
+      variableValues:
+        snapshot?.text ??
+        testCase?.variableValues ??
+        ((run.inlineVariables ?? {}) as Record<string, string>),
+      attachmentIds: (testCase?.attachmentIds ?? []) as Array<
         import("./_generated/dataModel").Id<"_storage">
       >,
+      variableAttachments:
+        snapshot?.images ??
+        testCase?.variableAttachments ??
+        ({} as Record<
+          string,
+          import("./_generated/dataModel").Id<"_storage">
+        >),
     };
 
     const project = await ctx.db.get(version.projectId);

--- a/convex/sampleSeed.ts
+++ b/convex/sampleSeed.ts
@@ -283,6 +283,11 @@ export async function materializeSampleProject(
     projectId,
     promptVersionId: versionId,
     testCaseId,
+    // #188: seeded runs carry an input snapshot like real dispatches, so the
+    // sample run's "what we sent" view doesn't show the legacy fallback note.
+    inputSnapshot: {
+      text: { [SAMPLE_VARIABLE_NAME]: SAMPLE_TEST_CASE_DRAFT },
+    },
     model: SAMPLE_OUTPUTS[0]!.model,
     temperature: 0.7,
     mode: "mix",

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -192,6 +192,20 @@ const schema = defineSchema({
     testCaseId: v.optional(v.id("testCases")),
     // M12: Quick run — inline variables when no test case
     inlineVariables: v.optional(v.record(v.string(), v.string())),
+    // #188: Frozen copy of the inputs actually dispatched for this run. Test
+    // cases are mutable, so without this the run's "what we sent" view would
+    // silently re-render with the test case's *current* values whenever it is
+    // edited after the run. Written at dispatch; absent on pre-#188 runs (no
+    // backfill — readers fall back to the live test case with a visible note).
+    // `images` maps image-variable name → the _storage blob that was sent; the
+    // blob-retention check in convex/lib/inputSnapshot.ts keeps those blobs
+    // alive even after the test case is edited or deleted.
+    inputSnapshot: v.optional(
+      v.object({
+        text: v.record(v.string(), v.string()),
+        images: v.optional(v.record(v.string(), v.id("_storage"))),
+      }),
+    ),
     model: v.string(),
     temperature: v.number(),
     maxTokens: v.optional(v.number()),

--- a/convex/testCases.ts
+++ b/convex/testCases.ts
@@ -1,7 +1,7 @@
 import { v } from "convex/values";
 import { mutation, query } from "./_generated/server";
 import { requireProjectRole } from "./lib/auth";
-import { safeDeleteStorage } from "./lib/storageCleanup";
+import { safeDeleteTestCaseBlob } from "./lib/storageCleanup";
 
 export const list = query({
   args: { projectId: v.id("projects") },
@@ -92,7 +92,8 @@ export const update = mutation({
       // pass through untouched.
       for (const [varName, prevId] of Object.entries(previous)) {
         if (next[varName] !== prevId) {
-          await safeDeleteStorage(ctx, prevId);
+          // #188: keep blobs still referenced by a past run's inputSnapshot.
+          await safeDeleteTestCaseBlob(ctx, testCase.projectId, prevId);
         }
       }
       updates.variableAttachments = next;
@@ -112,8 +113,10 @@ export const deleteTestCase = mutation({
 
     // M21.10: cascade-delete image variable blobs so test-case removal
     // doesn't leave orphans in storage.
+    // #188: but keep any blob still referenced by a past run's inputSnapshot,
+    // so deleting the test case doesn't corrupt that run's "what we sent".
     for (const storageId of Object.values(testCase.variableAttachments ?? {})) {
-      await safeDeleteStorage(ctx, storageId);
+      await safeDeleteTestCaseBlob(ctx, testCase.projectId, storageId);
     }
 
     await ctx.db.delete(args.testCaseId);

--- a/convex/tests/inputSnapshot.test.ts
+++ b/convex/tests/inputSnapshot.test.ts
@@ -1,0 +1,115 @@
+/// <reference types="vite/client" />
+import { describe, expect, test } from "vitest";
+import type { Id } from "../_generated/dataModel";
+import {
+  buildInputSnapshot,
+  isStorageIdReferencedBySnapshots,
+  type InputSnapshot,
+} from "../lib/inputSnapshot";
+
+// Storage ids are opaque strings at runtime; cast to satisfy the Id<> types
+// without pulling in the Convex runtime.
+const sid = (s: string) => s as Id<"_storage">;
+
+describe("buildInputSnapshot", () => {
+  test("quick run snapshots inline variables as text, no images", () => {
+    const snap = buildInputSnapshot({
+      inlineVariables: { name: "Ada", topic: "compilers" },
+    });
+    expect(snap).toEqual({ text: { name: "Ada", topic: "compilers" } });
+    expect(snap.images).toBeUndefined();
+  });
+
+  test("inline variables win even when a test case is also passed", () => {
+    const snap = buildInputSnapshot({
+      inlineVariables: { name: "Ada" },
+      testCase: { variableValues: { name: "Grace" } },
+    });
+    expect(snap).toEqual({ text: { name: "Ada" } });
+  });
+
+  test("test-case run snapshots variableValues as text", () => {
+    const snap = buildInputSnapshot({
+      testCase: { variableValues: { greeting: "hi", tone: "warm" } },
+    });
+    expect(snap).toEqual({ text: { greeting: "hi", tone: "warm" } });
+  });
+
+  test("test-case run with image variables snapshots images", () => {
+    const snap = buildInputSnapshot({
+      testCase: {
+        variableValues: { caption: "a cat" },
+        variableAttachments: { photo: sid("blob_1") },
+      },
+    });
+    expect(snap).toEqual({
+      text: { caption: "a cat" },
+      images: { photo: sid("blob_1") },
+    });
+  });
+
+  test("empty variableAttachments produces no images key", () => {
+    const snap = buildInputSnapshot({
+      testCase: { variableValues: {}, variableAttachments: {} },
+    });
+    expect(snap).toEqual({ text: {} });
+    expect("images" in snap).toBe(false);
+  });
+
+  test("snapshot is a copy — mutating the source does not change it", () => {
+    const values: Record<string, string> = { a: "1" };
+    const attachments: Record<string, Id<"_storage">> = { img: sid("b1") };
+    const snap = buildInputSnapshot({
+      testCase: { variableValues: values, variableAttachments: attachments },
+    });
+    values.a = "mutated";
+    attachments.img = sid("b2");
+    expect(snap.text).toEqual({ a: "1" });
+    expect(snap.images).toEqual({ img: sid("b1") });
+  });
+
+  test("no inline vars and no test case yields empty text", () => {
+    expect(buildInputSnapshot({})).toEqual({ text: {} });
+    expect(buildInputSnapshot({ testCase: null })).toEqual({ text: {} });
+  });
+});
+
+describe("isStorageIdReferencedBySnapshots", () => {
+  const withImages = (images: Record<string, string>) => ({
+    inputSnapshot: {
+      text: {},
+      images: images as Record<string, Id<"_storage">>,
+    } as InputSnapshot,
+  });
+
+  test("finds a referenced blob", () => {
+    const runs = [withImages({ photo: "blob_1" }), withImages({ x: "blob_2" })];
+    expect(isStorageIdReferencedBySnapshots(runs, sid("blob_2"))).toBe(true);
+  });
+
+  test("returns false when no snapshot references the blob", () => {
+    const runs = [withImages({ photo: "blob_1" })];
+    expect(isStorageIdReferencedBySnapshots(runs, sid("blob_9"))).toBe(false);
+  });
+
+  test("ignores runs with no snapshot or no images", () => {
+    const runs = [
+      { inputSnapshot: null },
+      { inputSnapshot: { text: { a: "1" } } as InputSnapshot },
+      {},
+    ];
+    expect(isStorageIdReferencedBySnapshots(runs, sid("blob_1"))).toBe(false);
+  });
+
+  test("empty run list is not a reference", () => {
+    expect(isStorageIdReferencedBySnapshots([], sid("blob_1"))).toBe(false);
+  });
+
+  test("matches a blob shared across multiple runs", () => {
+    const runs = [
+      withImages({ a: "shared" }),
+      withImages({ b: "shared" }),
+    ];
+    expect(isStorageIdReferencedBySnapshots(runs, sid("shared"))).toBe(true);
+  });
+});

--- a/convex/tests/inputSnapshot.test.ts
+++ b/convex/tests/inputSnapshot.test.ts
@@ -4,6 +4,7 @@ import type { Id } from "../_generated/dataModel";
 import {
   buildInputSnapshot,
   isStorageIdReferencedBySnapshots,
+  resolveDispatchInputs,
   type InputSnapshot,
 } from "../lib/inputSnapshot";
 
@@ -111,5 +112,67 @@ describe("isStorageIdReferencedBySnapshots", () => {
       withImages({ b: "shared" }),
     ];
     expect(isStorageIdReferencedBySnapshots(runs, sid("shared"))).toBe(true);
+  });
+});
+
+describe("resolveDispatchInputs", () => {
+  test("snapshot is authoritative for text and images", () => {
+    const out = resolveDispatchInputs({
+      snapshot: { text: { a: "frozen" }, images: { img: sid("b1") } },
+      testCase: {
+        variableValues: { a: "live" },
+        variableAttachments: { img: sid("b2") },
+      },
+    });
+    expect(out).toEqual({
+      variableValues: { a: "frozen" },
+      variableAttachments: { img: sid("b1") },
+    });
+  });
+
+  test("snapshot without images never falls back to live attachments", () => {
+    // Regression: images added to the test case AFTER run creation must not
+    // be dispatched for a snapshotted run whose snapshot has no images.
+    const out = resolveDispatchInputs({
+      snapshot: { text: { a: "frozen" } },
+      testCase: {
+        variableValues: { a: "live" },
+        variableAttachments: { addedLater: sid("b9") },
+      },
+    });
+    expect(out.variableAttachments).toEqual({});
+    expect(out.variableValues).toEqual({ a: "frozen" });
+  });
+
+  test("no snapshot falls back to live test case (pre-#188 runs)", () => {
+    const out = resolveDispatchInputs({
+      snapshot: null,
+      testCase: {
+        variableValues: { a: "live" },
+        variableAttachments: { img: sid("b1") },
+      },
+    });
+    expect(out).toEqual({
+      variableValues: { a: "live" },
+      variableAttachments: { img: sid("b1") },
+    });
+  });
+
+  test("no snapshot, no test case falls back to inline variables", () => {
+    const out = resolveDispatchInputs({
+      testCase: null,
+      inlineVariables: { q: "inline" },
+    });
+    expect(out).toEqual({
+      variableValues: { q: "inline" },
+      variableAttachments: {},
+    });
+  });
+
+  test("nothing at all yields empty inputs", () => {
+    expect(resolveDispatchInputs({})).toEqual({
+      variableValues: {},
+      variableAttachments: {},
+    });
   });
 });

--- a/convex/variables.ts
+++ b/convex/variables.ts
@@ -1,7 +1,7 @@
 import { v } from "convex/values";
 import { mutation, query } from "./_generated/server";
 import { requireProjectRole } from "./lib/auth";
-import { safeDeleteStorage } from "./lib/storageCleanup";
+import { safeDeleteTestCaseBlob } from "./lib/storageCleanup";
 
 export const list = query({
   args: { projectId: v.id("projects") },
@@ -152,7 +152,8 @@ export const deleteVariable = mutation({
         const attachments = tc.variableAttachments;
         if (!attachments || !(variable.name in attachments)) continue;
         const storageId = attachments[variable.name]!;
-        await safeDeleteStorage(ctx, storageId);
+        // #188: keep blobs still referenced by a past run's inputSnapshot.
+        await safeDeleteTestCaseBlob(ctx, variable.projectId, storageId);
         const { [variable.name]: _removed, ...rest } = attachments;
         await ctx.db.patch(tc._id, { variableAttachments: rest });
       }

--- a/docs/cloudflare-gateway-live-import.md
+++ b/docs/cloudflare-gateway-live-import.md
@@ -8,6 +8,9 @@ eval set.
 their own gateway and pastes/uploads them. This keeps the data boundary
 one-directional and avoids holding any Cloudflare credentials.
 
+For the full end-to-end onboarding checklist (permissions, metadata, baseline
+eval, candidate rows), see [`gateway-onboarding.md`](./gateway-onboarding.md).
+
 ## 1. Export from Cloudflare
 
 Pull request logs from the customer's gateway — either path produces JSONL

--- a/docs/fireworks-cloudflare-routing-prototype.md
+++ b/docs/fireworks-cloudflare-routing-prototype.md
@@ -3,6 +3,9 @@
 Exact, customer-generic steps to deploy a Fireworks fine-tuned/custom model and route it
 through Cloudflare AI Gateway, then feed the captured logs into the existing eval pipeline.
 
+For the user-facing onboarding checklist that precedes this runbook (connect logs → metadata
+→ baseline eval → candidate rows), see [`gateway-onboarding.md`](./gateway-onboarding.md).
+
 **No production or customer data.** Use synthetic prompts (Migo/Eavesly-style) for the smoke
 test. Secrets stay in your secret store / env — they never go into the repo, the generated
 artifacts, or Gateway logs.

--- a/docs/fireworks-cloudflare-routing-prototype.md
+++ b/docs/fireworks-cloudflare-routing-prototype.md
@@ -30,6 +30,51 @@ Outputs (gitignored): `artifacts/fireworks-cloudflare-routing-prototype.{json,md
 4. Confirm the model answers via the Fireworks API directly with a synthetic prompt before
    adding the Gateway hop (isolates provider vs. gateway issues).
 
+### Exact deployment path (`firectl`)
+
+Concrete, customer-generic command sequence. Ids below are placeholders; the real account is
+`accounts/<account>` and `firectl` reads `FIREWORKS_API_KEY` from the env (never inline it).
+
+```bash
+# 0. Auth (key stays in the env / secret store).
+export FIREWORKS_API_KEY=…
+
+# 1. Upload the approved, synthetic-or-reviewed dataset (JSONL of {messages:[…]} rows).
+firectl create dataset migo-eval-ft-0001 ./artifacts/training-dataset.jsonl
+#   → dataset id: accounts/<account>/datasets/migo-eval-ft-0001
+
+# 2. Launch supervised fine-tuning against a base model.
+firectl create fine-tuning-job \
+  --base-model accounts/fireworks/models/llama-v3p1-8b-instruct \
+  --dataset accounts/<account>/datasets/migo-eval-ft-0001 \
+  --output-model migo-eval-ft-0001
+#   → job id: accounts/<account>/fineTuningJobs/<job>
+#   Poll: firectl get fine-tuning-job accounts/<account>/fineTuningJobs/<job>
+#   On COMPLETED the tuned model id is: accounts/<account>/models/migo-eval-ft-0001
+
+# 3a. Serverless: many tuned models serve on-demand with no explicit deployment —
+#     skip to the direct-serve check below and use the model id as-is.
+# 3b. Dedicated: create a deployment for guaranteed capacity / low latency.
+firectl create deployment accounts/<account>/models/migo-eval-ft-0001
+#   → deployment id: accounts/<account>/deployments/<deployment>
+```
+
+- **Model id format**: `accounts/<account>/models/<custom-model>` — this is `FIREWORKS_MODEL`.
+- **Deployment id format**: `accounts/<account>/deployments/<deployment>` — optional
+  (`FIREWORKS_DEPLOYMENT_ID`), only for dedicated deployments.
+- **Confirm it serves directly before the Gateway hop** (isolates provider vs. gateway):
+
+  ```bash
+  curl -sS https://api.fireworks.ai/inference/v1/chat/completions \
+    -H "Authorization: Bearer $FIREWORKS_API_KEY" \
+    -H "Content-Type: application/json" \
+    -d '{"model":"accounts/<account>/models/migo-eval-ft-0001",
+         "messages":[{"role":"user","content":"Synthetic smoke prompt. Reply with: ok."}],
+         "max_tokens":16}'
+  ```
+
+  A normal completion here means the model serves; only then add the Cloudflare Gateway.
+
 ## 2. Create / route the Cloudflare AI Gateway provider
 
 1. Create (or reuse) an AI Gateway in the correct Cloudflare account. Record the gateway id/name.
@@ -57,6 +102,45 @@ Outputs (gitignored): `artifacts/fireworks-cloudflare-routing-prototype.{json,md
    `variant`, `release`, `environment`, `tenant`, `trace_id`, `session_id`.
 3. Use a **real unique** `trace_id`/`session_id` per request; the generated synthetic ids are
    deterministic placeholders for review only.
+
+### Automated: live smoke + log verification
+
+`scripts/fireworks-gateway-smoke.ts` (`npm run smoke:fireworks-gateway`) is the automated,
+env-gated version of steps 3–5: it sends one synthetic request through the Gateway with a
+freshly generated unique `trace_id`, polls the Gateway logs API until that trace appears,
+normalizes it with `cloudflareAiGateway.ts`, runs `verifyGatewayLog`, and writes a **redacted**
+report to `artifacts/fireworks-gateway-smoke.{json,md}` (gitignored). It exits non-zero on
+verification failure.
+
+```bash
+# Fails CLOSED unless all of these are set (secrets stay env-only, never committed):
+export CF_ACCOUNT_ID=…      # gateway account
+export CF_AIG_GATEWAY=…     # gateway id/name
+export CF_AIG_TOKEN=…       # gateway edge-auth token
+export FIREWORKS_API_KEY=…  # upstream provider key
+export FIREWORKS_MODEL=accounts/<account>/models/migo-eval-ft-0001
+export CF_API_TOKEN=…       # Cloudflare API token — reads the Gateway logs API (live only)
+
+npm run smoke:fireworks-gateway -- --dry-run   # prints the redacted request, sends nothing
+npm run smoke:fireworks-gateway                 # live send → poll logs → verify → artifacts
+```
+
+`--dry-run` needs only the five required vars (not `CF_API_TOKEN`) and never touches the
+network. Expected live output:
+
+```text
+Sending synthetic smoke request (trace_id=smoke-…)…
+Gateway responded HTTP 200.
+Polling Gateway logs for trace_id (timeout 60s)…
+Verification: PASS
+  note: cost_usd present: 0.0001            # or "absent … not fatal"
+  note: body redaction observed …           # only if bodies stripped by log settings
+Wrote artifacts/fireworks-gateway-smoke.{json,md}.
+```
+
+The verifier asserts provider slug, resolved model id, usage tokens, `duration_ms`, metadata
+round-trip (incl. `trace_id`), and success status. `cost_usd` being null and body redaction are
+reported as **notes, not failures**.
 
 ## 4. Export and inspect logs
 
@@ -87,14 +171,28 @@ Then `convertTraceToEvalCase()` to seed eval cases and run the scorecard
 (`npm run scorecard:customer-pilot`). Replay seeds derived from real traces stay
 `customer_scoped_review_only`.
 
-## Auth & tenant isolation requirements
+## Auth & key handling / tenant isolation
 
-- **Two distinct credentials**: upstream `FIREWORKS_API_KEY` and gateway `CF_AIG_TOKEN`.
-  Both env-only; never committed, never logged.
+Three **distinct** credentials, each with one job. All env-only — they never enter the repo,
+the generated artifacts, or Gateway logs. The smoke CLI redacts the two request secrets to
+`$FIREWORKS_API_KEY` / `$CF_AIG_TOKEN` placeholders before printing or writing anything.
+
+| Credential | Where it lives | What it does |
+| --- | --- | --- |
+| `FIREWORKS_API_KEY` | request `Authorization: Bearer …` header (upstream) | Authenticates to Fireworks — the provider that actually runs the model. |
+| `CF_AIG_TOKEN` | request `cf-aig-authorization: Bearer …` header (gateway edge) | Authenticates the caller **to the Cloudflare AI Gateway** (Authenticated Gateway). Separate from the upstream key. |
+| `CF_API_TOKEN` | logs read (`Authorization: Bearer …` on the Cloudflare API) | Reads back the Gateway logs API for verification. Never sent to Fireworks. |
+
+**Per-tenant separation requirements:**
+
 - **One Fireworks key + one Gateway (+ `metadata.tenant`) per tenant.** Do not share keys,
   gateways, or models across tenants — isolation is enforced at the credential and gateway
-  boundary, with `tenant` metadata for log attribution.
-- Rotate keys out of band; revoking the Gateway token cuts routing without touching the
-  upstream provider key.
+  boundary, with the `tenant` metadata label for log attribution.
+- Never share a Fireworks account across tenants without model/deployment namespacing; prefer
+  a **separate gateway** per tenant, or at minimum a distinct `metadata.tenant` label **plus
+  BYOK** so one tenant's key can never route another tenant's traffic.
+- Keys never enter the repo, artifacts, or logs. Rotate out of band; revoking `CF_AIG_TOKEN`
+  cuts routing without touching the upstream key, and revoking `CF_API_TOKEN` cuts log access
+  without touching either.
 - Keep environments (`staging` vs `production`) on separate gateways or clearly separated by
   the `environment` metadata so logs never cross-pollinate.

--- a/docs/gateway-onboarding.md
+++ b/docs/gateway-onboarding.md
@@ -201,7 +201,8 @@ artifacts, or Gateway logs (routing runbook §"Auth & key handling"):
 | `CF_AIG_TOKEN` | Authenticates the caller to the Cloudflare AI Gateway edge. |
 | `CF_API_TOKEN` | Reads back the Gateway logs API (the AI Gateway — Read token). |
 
-Per-tenant isolation: **one Fireworks key + one gateway (+ `metadata.tenant`) per
-tenant.** Do not share keys, gateways, or models across tenants — isolation is
-enforced at the credential and gateway boundary (routing runbook §"Per-tenant
-separation requirements").
+Per-tenant isolation: prefer a **separate gateway per tenant**, or at minimum a
+distinct `metadata.tenant` label **plus BYOK / model-deployment namespacing** so
+one tenant's key can never route another tenant's traffic. Isolation is enforced
+at the credential and gateway boundary (routing runbook §"Per-tenant separation
+requirements").

--- a/docs/gateway-onboarding.md
+++ b/docs/gateway-onboarding.md
@@ -1,0 +1,207 @@
+# Cloudflare AI Gateway — user onboarding guide
+
+End-to-end checklist for a Blind Bench user to take a Cloudflare AI Gateway from
+"logs exist somewhere" to "I have a baseline scorecard and a shortlist of rows
+worth training on." It stitches together the pieces that already ship:
+
+- The in-app onboarding page — `src/routes/orgs/GatewayOnboarding.tsx`
+- The no-code import page — `src/routes/orgs/GatewayImport.tsx`
+- The live log import path — [`cloudflare-gateway-live-import.md`](./cloudflare-gateway-live-import.md)
+- The baseline / candidate eval runner — [`baseline-candidate-comparison.md`](./baseline-candidate-comparison.md)
+- The Fireworks → Gateway routing runbook — [`fireworks-cloudflare-routing-prototype.md`](./fireworks-cloudflare-routing-prototype.md)
+
+**Data boundary, up front.** Blind Bench makes **no calls to Cloudflare**. You
+export logs from your own gateway and paste/upload them; Blind Bench never holds
+a Cloudflare credential (see `cloudflare-gateway-live-import.md` §3). Real
+production logs stay `prod_sensitive` and customer-scoped inside the workspace —
+never commit them to the repo. The repo and any demo use **synthetic or redacted
+samples only**.
+
+---
+
+## Onboarding checklist
+
+Work top to bottom. Steps 1–6 need **no Fireworks credentials** — you can reach a
+published baseline scorecard before any model-training work. Fireworks enters
+only at step 7.
+
+1. **Connect Gateway logs (API, Logpush, or dashboard export).** Get request
+   logs out of your Cloudflare AI Gateway as JSONL (one JSON object per line).
+   Three ways, covered under [Two ways to feed logs in](#two-ways-to-feed-logs-in)
+   below. Requires an **AI Gateway — Read** scoped token (see
+   [Required Cloudflare permissions](#required-cloudflare-permissions)).
+2. **Set metadata conventions.** Before (or as) you generate traffic, tag each
+   Gateway request with the [metadata conventions](#metadata-conventions) so
+   imported logs are groupable by product, module, and prompt version. Retrofitting
+   metadata onto already-logged traffic is not possible — logs only carry the
+   metadata that was attached at request time.
+3. **Pick a product / use-case + eval pack.** Choose one or two high-traffic
+   prompts to onboard first so the baseline is meaningful. Blind Bench ships
+   synthetic example surfaces (`migo`, `eavesly`) in
+   `src/routes/orgs/GatewayOnboarding.tsx` to model your own against. The eval
+   pack is the set of deterministic scorers you will run — the shipped pilot pack
+   is `customer-pilot/smoke` (see `docs/customer-ai-quality-scorecard-handoff.md`).
+4. **Create your first dataset from filtered logs.** Filter the export by
+   product / time window, then import it (step 1's path). Each new, non-duplicate
+   trace is stored as a deduplicated `traceImports` row; the importer returns a
+   summary (imported / deduped / parsed / invalid counts, models, providers, and
+   the time window). **Manual/planned:** turning imported traces into runnable
+   eval cases uses `setMaterialized` in the backend, but the Convex importer does
+   not yet expose materialization in the UI (see
+   `cloudflare-gateway-live-import.md` "Follow-up"). Today the local path
+   (`normalizeCloudflareAiGatewayLog → convertTraceToEvalCase`) is how a trace
+   becomes an eval case.
+5. **Run a baseline eval.** Score the current production prompt against the pack
+   to establish the baseline scorecard. The runner is
+   `src/lib/evals/modelComparison.ts` (`npm run compare:customer-pilot`), and the
+   customer-facing scorecard is `npm run scorecard:customer-pilot`. Both are
+   local, deterministic, and management-safe — they emit only case IDs, product
+   labels, scorer IDs, scores, and aggregate counts, never raw prompts or outputs
+   (see [`baseline-candidate-comparison.md`](./baseline-candidate-comparison.md)).
+6. **Identify candidate rows for training / synthetic expansion.** From the
+   baseline, pull the rows worth improving: hard-fail cases, low-scoring cases, or
+   thin coverage areas you want to expand with synthetic edge cases. These become
+   the review candidates that later feed the training-dataset compiler
+   (`src/lib/evals/trainingDataset.ts`, see
+   [`training-dataset-compiler.md`](./training-dataset-compiler.md)). Real rows
+   still require explicit training approval and a policy flag before they can be
+   exported.
+7. **(Later) Add Fireworks credentials + candidate model.** Only once a baseline
+   exists do you wire a Fireworks-hosted candidate to A/B against production. This
+   is the **only** step that needs a Fireworks API key — see
+   [Where Fireworks credentials enter](#where-fireworks-credentials-enter).
+
+---
+
+## Required Cloudflare permissions
+
+Use an **API token scoped to the specific account and gateway** — never a global
+API key.
+
+| Capability | Scope needed | When |
+| --- | --- | --- |
+| Read / export Gateway request logs (API or Logpush) | **AI Gateway — Read** | Steps 1 and 4 — every import path. |
+| Configure gateways or metadata rules | **AI Gateway — Edit** | Only if you set up gateways or metadata routing yourself. |
+| Logpush job to object storage | Logpush configured on the account + the storage destination's own credentials | Only if you use Logpush instead of the logs API. |
+
+Notes:
+
+- The `AI Gateway — Read` token is the `CF_API_TOKEN` used by the live smoke
+  script to read back the logs API (`fireworks-cloudflare-routing-prototype.md`
+  §"Auth & key handling"). It is distinct from the gateway edge-auth token
+  (`CF_AIG_TOKEN`) and from any upstream provider key.
+- Blind Bench never receives any of these tokens — you run the export yourself
+  and paste the resulting JSONL.
+
+---
+
+## Metadata conventions
+
+Attach these keys to every Gateway request so logs stay groupable after import.
+The convention (from `fireworks-cloudflare-routing-prototype.md` §3 and the
+in-app onboarding page):
+
+| Key | Meaning |
+| --- | --- |
+| `product` | Top-level product, e.g. `migo` / `eavesly`. |
+| `module` | Sub-surface within the product, e.g. `assistant` / `summarizer`. |
+| `prompt_version` | Version tag of the prompt that produced the output. |
+| `variant` | `control` / `candidate` — which arm of an A/B. |
+| `release` | App release or deploy identifier. |
+| `environment` | `prod` / `staging` / `dev` — keep prod data customer-scoped. |
+| `tenant` | Tenant label for log attribution and per-tenant isolation. |
+| `trace_id` | Request trace id, to correlate with app logs. Use a **real unique** value per request. |
+| `session_id` | Conversation / session id where available. |
+
+**Cloudflare custom-metadata limits.** AI Gateway custom metadata is limited in
+**key count and value size**. Keep values short. Anything larger — full prompt
+text, long ids, structured context — goes in a **sidecar record keyed by
+`trace_id`**, not inline in Gateway metadata. Note that the Convex importer does
+**not yet accept a sidecar** (the local exported-JSONL adapter does — see
+`cloudflare-gateway-live-import.md` "Follow-up"), so for now keep everything you
+need for grouping inside the short metadata keys above.
+
+Metadata travels two ways on a request: in the request body's `metadata` field
+and in a `cf-aig-metadata` header
+(`fireworks-cloudflare-routing-prototype.md` §3). All keys round-trip into the
+Gateway log, where `src/lib/evals/cloudflareAiGateway.ts` /
+`convex/traceAdapters/cloudflareAiGateway.ts` read them back.
+
+---
+
+## Two ways to feed logs in
+
+### No-code / manual path (Gateway Import UI)
+
+Described by `src/routes/orgs/GatewayImport.tsx` and
+`src/routes/orgs/GatewayOnboarding.tsx` — do not change that code; this is what
+the user sees:
+
+1. Cloudflare dashboard → **AI Gateway** → select your gateway → **Logs**.
+2. Filter by product / time window and **export** the log set (JSON/JSONL).
+3. In Blind Bench, open the org sidebar → **Gateway onboarding**, then
+   **Import Gateway logs** (route `/orgs/<slug>/gateway-import`).
+4. Select the destination **project** (you must be project **owner** or
+   **editor**).
+5. Paste the JSONL and click **Import Gateway logs**.
+6. Read the **import summary** card: imported / deduped / parsed / invalid-line
+   counts, missing-request / missing-response counts, the set of models and
+   providers seen, and the earliest/latest timestamp. The UI **never renders
+   trace content back** — counts, model/provider names, and timestamps only.
+
+Batch limits (from `convex/traceAdapters/cloudflareAiGateway.ts` `DEFAULT_LIMITS`):
+**5,000 lines** and **8 MB** per import — split larger exports into batches; the
+summary flags `truncated` when it stops early.
+
+### CLI / API path
+
+Use the logs API (or a Logpush job) to pull JSONL, then normalize and score
+locally:
+
+```bash
+# Export: pull request logs as JSONL (AI Gateway — Read token)
+GET https://api.cloudflare.com/client/v4/accounts/<account>/ai-gateway/gateways/<gateway>/logs
+
+# Normalize exported JSONL → eval cases (src/lib/evals/cloudflareAiGateway.ts)
+#   parseCloudflareAiGatewayJsonl(...) → convertTraceToEvalCase(...)
+
+# Baseline / candidate comparison + scorecard (local, deterministic)
+npm run compare:customer-pilot
+npm run scorecard:customer-pilot
+```
+
+The same JSONL can also be pasted into the no-code importer above — the two paths
+share the parser. For a live, env-gated smoke that sends one synthetic request
+through the Gateway and verifies the log round-trip, see
+`scripts/fireworks-gateway-smoke.ts` (`npm run smoke:fireworks-gateway`) in
+`fireworks-cloudflare-routing-prototype.md`.
+
+---
+
+## Where Fireworks credentials enter
+
+Fireworks credentials enter the flow **only at model training / deployment and
+the live smoke** — never for log import or for running evals on existing traffic:
+
+- **Not needed** for steps 1–6: connecting logs, setting metadata, importing,
+  baseline evals, and identifying candidate rows all run without any Fireworks
+  key. Everything the local eval runner and scorecard do is offline.
+- **Needed** at step 7 only: creating/deploying the Fireworks fine-tuned model
+  (`FIREWORKS_API_KEY`, used by `firectl` and the direct-serve check) and routing
+  it through the Gateway for a head-to-head. See
+  [`fireworks-cloudflare-routing-prototype.md`](./fireworks-cloudflare-routing-prototype.md)
+  §§1–3.
+
+Three credentials stay distinct and env-only — none ever enters the repo,
+artifacts, or Gateway logs (routing runbook §"Auth & key handling"):
+
+| Credential | Job |
+| --- | --- |
+| `FIREWORKS_API_KEY` | Authenticates to Fireworks (the provider running the model). |
+| `CF_AIG_TOKEN` | Authenticates the caller to the Cloudflare AI Gateway edge. |
+| `CF_API_TOKEN` | Reads back the Gateway logs API (the AI Gateway — Read token). |
+
+Per-tenant isolation: **one Fireworks key + one gateway (+ `metadata.tenant`) per
+tenant.** Do not share keys, gateways, or models across tenants — isolation is
+enforced at the credential and gateway boundary (routing runbook §"Per-tenant
+separation requirements").

--- a/docs/superpowers/plans/2026-07-05-m30-batch-230-188-232-227.md
+++ b/docs/superpowers/plans/2026-07-05-m30-batch-230-188-232-227.md
@@ -1,0 +1,73 @@
+# M30 batch: issues #230, #188, #232, #227
+
+One branch, one PR. Sequential tasks, each maps to one GH issue.
+
+## Global Constraints
+
+- No secrets in repo, artifacts, or test fixtures. Live-call scripts are env-gated and fail closed.
+- No Pennie production/customer data anywhere — synthetic prompts only.
+- Convex conventions from CLAUDE.md: auth checks via `requireAuth`/`requireProjectRole` (convex/lib/auth.ts), no `any`, internal functions for non-client entry points.
+- Blind eval surface rules unchanged: evaluator responses expose only `{ blindLabel, outputContent, annotations }`.
+- Unit tests must not make network calls — mock `fetch`.
+- Follow existing file/test layout: pure logic in `src/lib/evals/*` with colocated `*.test.ts` (vitest), Convex logic in `convex/*`.
+- `npm run build` (tsc + vite) and `npx vitest run` must pass after each task.
+
+## Task 1: #230 — Live Fireworks-behind-Gateway smoke + log verification
+
+The local-only route-plan generator exists (`src/lib/evals/fireworksGatewayPrototype.ts`, run via `npm run prototype:fireworks-gateway`, runbook at `docs/fireworks-cloudflare-routing-prototype.md`). What #230 still needs is the **live** proof path and the remaining docs.
+
+Build:
+
+1. `src/lib/evals/fireworksGatewaySmoke.ts` — pure functions:
+   - `buildSmokeRequest(config)` — builds the Gateway request (URL, headers incl. `cf-aig-authorization` + `Authorization` upstream key + `cf-aig-metadata`, body with synthetic prompt and unique `trace_id`). Reuse route shapes (compat default / provider mode) from `fireworksGatewayPrototype.ts` — import, don't duplicate.
+   - `verifyGatewayLog(normalizedLog, expected)` — given a log normalized by the existing Cloudflare adapter (`src/lib/evals/cloudflareAiGateway.ts`), assert: provider slug, resolved model id, usage tokens present, duration_ms present, metadata keys round-trip, status success. Returns `{ ok, failures: string[] }` — cost_usd may legitimately be null; report presence, don't fail on it.
+   - Unit tests for both with mocked/fixture data (model a redacted-body log too — the normalizer flags redaction; verify that's reported not fatal).
+2. `scripts/fireworks-gateway-smoke.ts` (npm script `smoke:fireworks-gateway`, runner consistent with how `prototype:fireworks-gateway` is wired in package.json) — env-gated live CLI:
+   - Requires `CF_ACCOUNT_ID`, `CF_AIG_GATEWAY`, `CF_AIG_TOKEN`, `FIREWORKS_API_KEY`, `FIREWORKS_MODEL`; fails closed with a clear message listing missing vars. `--dry-run` prints the redacted request without sending.
+   - Sends one synthetic chat request through the Gateway, then polls the Gateway logs API (`GET /accounts/{account}/ai-gateway/gateways/{gateway}/logs` with cf API token env `CF_API_TOKEN`, filter by metadata trace_id; poll with timeout ~60s) until the log for that trace_id appears, normalizes it with the existing adapter, runs `verifyGatewayLog`, writes `artifacts/fireworks-gateway-smoke.{json,md}` (gitignored — artifacts/ already is), exits non-zero on verification failure.
+3. Docs — extend `docs/fireworks-cloudflare-routing-prototype.md` (keep it the single runbook):
+   - "Exact deployment path" section: concrete `firectl` command sequence — create dataset, `firectl create fine-tuning-job` (or current sft command), `firectl create deployment` / serverless note, model id + deployment id formats, how to confirm the model serves directly before the Gateway hop.
+   - "Auth & key handling / tenant isolation" section: which key lives where (Fireworks key = upstream, CF_AIG_TOKEN = gateway edge auth, CF_API_TOKEN = logs read), per-tenant separation requirements (separate gateway or metadata `tenant` label + BYOK, never shared Fireworks accounts across tenants without namespacing), and the rule that keys never enter repo/artifacts/logs.
+   - Section for the new smoke command with expected output.
+4. Comment-summary text is NOT needed; the controller closes the issue.
+
+Done when: unit tests pass, `--dry-run` works without any env set beyond the required list check, docs updated, `npm run build` clean.
+
+## Task 2: #188 — Run history input snapshot
+
+Full issue text (requirements verbatim):
+
+Runs reference live test cases by ID. When a user edits a test case after a run completes (text variable value or image variable), the run's "what we sent" view silently re-renders with current state, not dispatched values.
+
+Approach (from the issue):
+- At dispatch time, snapshot test case inputs onto the run row: `inputSnapshot: v.optional(v.object({ text: v.record(v.string(), v.string()), images: v.optional(v.record(v.string(), v.id("_storage"))) }))` on `promptRuns` (convex/schema.ts:189).
+- Snapshot written in the run-create mutation path (find where `promptRuns` rows are inserted — convex/runs.ts — and where testCase.variableValues / variableAttachments are read for dispatch, convex/runsActions.ts).
+- Quick runs (inlineVariables, no test case) snapshot the inline variables as `text`.
+- Prevent deletion of `_storage` blobs still referenced by any run's `inputSnapshot.images`: find the test-case delete / attachment-replace cascade paths (convex/testCases.ts or imageVariableAttachments.ts) and skip `ctx.storage.delete` for storage ids referenced by an existing run snapshot. Add an index or query strategy that doesn't full-scan promptRuns per delete — if a scan is unavoidable, scope it by project via the existing `by_project_and_status` index and document the ceiling with a `ponytail:` comment.
+- Run history view ("what we sent"): find the frontend component that renders run inputs from the live test case and read from `inputSnapshot` when present; when absent (pre-feature runs), show an "Input not snapshotted — showing current test case values" note rather than silently showing live values.
+- Out of scope: backfill, prompt snapshotting (versions are immutable).
+
+Done when: schema updated, dispatch paths write snapshots, delete paths preserve referenced blobs, UI reads snapshot with fallback note, tests cover snapshot write + blob-retention logic (convex tests follow existing patterns in convex/*.test.ts if present, else vitest on pure helpers), build clean.
+
+## Task 3: #232 — Gateway user onboarding doc
+
+Write `docs/gateway-onboarding.md`. Requirements verbatim from the issue:
+
+- Written onboarding checklist (connect Gateway logs via API or Logpush → set metadata conventions → pick product/use-case + eval pack → create first dataset from filtered logs → run baseline eval → identify candidate rows for training/synthetic expansion).
+- Required Cloudflare permissions documented (API token scopes for AI Gateway read/logs, Logpush if used).
+- Metadata conventions documented despite CF custom metadata limits (the existing convention: product, module, prompt_version, variant, release, environment, tenant, trace_id, session_id — see docs/fireworks-cloudflare-routing-prototype.md and docs/cloudflare-gateway-live-import.md; note CF's key-count/size limits).
+- Defines the no-code/manual path (Gateway Import UI at src/routes/orgs/GatewayImport.tsx — describe the user flow, don't change code) and the CLI/API path (existing scripts + Convex import).
+- Identifies where Fireworks credentials enter the flow (only at training/deployment + smoke steps; never required for log import or evals on existing traffic).
+
+Cross-link from the two existing gateway docs. Docs only — no code changes.
+
+## Task 4: #227 — Product loop one-pager
+
+Write `project-docs/Blind Bench - AI Quality Bench Spec.md` (matches project-docs naming style). Requirements verbatim from the issue:
+
+- One-page product spec with ICP, wedge, and workflow (the 8-step core loop: connect CF AI Gateway/Logpush → normalize logs → curate datasets/eval suites from real traffic + synthetic edge cases → baseline evals → compile training/eval data for Fireworks fine-tuning/RFT → deploy candidate on Fireworks → route candidate through Gateway custom provider/dynamic routing → compare baseline vs candidate, publish scorecard).
+- Defines what Blind Bench owns vs Cloudflare vs Fireworks.
+- Defines MVP success criteria for Pennie and for a generic CF Gateway user.
+- Build/buy boundaries: do not rebuild Gateway; do not rebuild Fireworks training.
+
+Ground it in what's actually shipped (gateway live import, dataset compiler, endpoint eval runner, routing prototype, Polar billing foundation) — cite the docs/ files. Mark it DRAFT for Noah's review; strategy calls are his.

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "dataset:customer-pilot": "npx tsx src/lib/evals/trainingDataset.ts",
     "compare:customer-pilot": "npx tsx src/lib/evals/modelComparison.ts",
     "compare:endpoints": "npx tsx src/lib/evals/compareEndpoints.ts",
-    "prototype:fireworks-gateway": "npx tsx src/lib/evals/fireworksGatewayPrototype.ts"
+    "prototype:fireworks-gateway": "npx tsx src/lib/evals/fireworksGatewayPrototype.ts",
+    "smoke:fireworks-gateway": "npx tsx scripts/fireworks-gateway-smoke.ts"
   },
   "dependencies": {
     "@auth/core": "^0.37.4",

--- a/project-docs/Blind Bench - AI Quality Bench Spec.md
+++ b/project-docs/Blind Bench - AI Quality Bench Spec.md
@@ -1,0 +1,200 @@
+---
+title: "Blind Bench - AI Quality Bench Spec"
+created: 2026-07-05
+modified: 2026-07-05
+type: product-spec
+status: draft
+tags:
+  - blind-bench
+  - product
+  - spec
+  - m30
+---
+
+# Blind Bench — AI Quality Bench Spec
+
+> **DRAFT for Noah's review.** This one-pager defines the M30 "AI Quality Bench"
+> product loop. Every capability claim is grounded in a shipped repo file (cited
+> inline). **Strategy calls — pricing, ICP prioritization, packaging — are
+> stated as recommendations, not decisions.** They are Noah's to make.
+
+> Part of [[MOC - Blind Bench]]. Companion to [[Blind Bench - Positioning]]
+> (reviewer-surface framing) and [[Blind Bench - Architecture]].
+
+---
+
+## What this is
+
+The AI Quality Bench is the closed loop that turns a team's live Cloudflare AI
+Gateway traffic into measurably better fine-tuned models routed back through the
+same Gateway, with a management-safe scorecard as the handoff artifact.
+
+It is a superset framing of Blind Bench's reviewer surface (see
+[[Blind Bench - Positioning]]): the human review step stays the honesty mechanic,
+but the loop now closes all the way from **production logs → evals → training →
+routed candidate → scorecard**.
+
+---
+
+## ICP (recommendation)
+
+**Recommended primary ICP:** a team already running **Cloudflare AI Gateway** in
+production for one or more customer-facing LLM surfaces, that needs to prove and
+improve output quality without standing up an eval/training stack themselves.
+
+- **Beachhead customer:** Pennie (Migo / Eavesly surfaces) — the pilot the loop
+  is being hardened against (`docs/customer-pilot-sow.md`,
+  `docs/customer-ai-quality-scorecard-handoff.md`).
+- **Generic ICP:** any CF AI Gateway user with enough traffic that a baseline is
+  meaningful and enough quality pain to want a fine-tuned candidate.
+- **Buyer vs. user (carry-over from Positioning):** the developer/PM who ships
+  the prompts is the buyer-influencer; the domain reviewer signs off on quality.
+
+> **Open strategy call (Noah):** whether to lead go-to-market with Pennie-style
+> hands-on pilots or the self-serve generic CF user. The billing foundation
+> supports self-serve (see [Billing](#billing-shipped-foundation)); the pilot SOW
+> supports hands-on. Recommendation: land 1–2 hands-on pilots first, use them to
+> harden the loop, then open self-serve. Not decided here.
+
+## Wedge
+
+**"You already send every prompt through Cloudflare AI Gateway. We turn those
+logs into a quality scorecard and a fine-tuned model that beats your baseline —
+without rebuilding your gateway or your training stack."**
+
+Why it wedges:
+
+- The logs already exist; onboarding is an export/paste, not an integration
+  project. Blind Bench holds **no Cloudflare credentials** and makes **no calls
+  to Cloudflare** (`docs/cloudflare-gateway-live-import.md`).
+- The two hard parts — the eval harness that is management-safe by construction,
+  and the training-data curation that is default-deny on customer data — are the
+  parts nobody wants to build in-house and that we already ship.
+
+---
+
+## The core loop (8 steps)
+
+| # | Step | Owner | Shipped? — where |
+| --- | --- | --- | --- |
+| 1 | Connect CF AI Gateway / Logpush; export request logs | Cloudflare emits; user exports | ✅ `docs/cloudflare-gateway-live-import.md`, `docs/gateway-onboarding.md` |
+| 2 | Normalize logs into deduplicated traces | Blind Bench | ✅ `convex/traceAdapters/cloudflareAiGateway.ts`, `src/lib/evals/cloudflareAiGateway.ts`, `convex/gatewayImport.ts` |
+| 3 | Curate datasets / eval suites from real traffic + synthetic edge cases | Blind Bench | ✅ (parse/dedup + local materialize); ⚠️ UI materialization of imported traces is **planned** — `docs/cloudflare-gateway-live-import.md` "Follow-up" |
+| 4 | Run baseline evals (management-safe scorecard) | Blind Bench | ✅ `src/lib/evals/modelComparison.ts`, `npm run scorecard:customer-pilot` — `docs/baseline-candidate-comparison.md`, `docs/customer-ai-quality-scorecard-handoff.md` |
+| 5 | Compile training / eval data for Fireworks fine-tuning / RFT | Blind Bench (curation); user approves | ✅ `src/lib/evals/trainingDataset.ts` — `docs/training-dataset-compiler.md` (default-deny on real data) |
+| 6 | Deploy candidate on Fireworks (fine-tune → serve) | Fireworks; user operates | ✅ runbook only (manual `firectl`) — `docs/fireworks-cloudflare-routing-prototype.md` §1 |
+| 7 | Route candidate through Gateway (custom provider / dynamic routing) | Cloudflare; user configures | ✅ prototype + live smoke — `docs/fireworks-cloudflare-routing-prototype.md` §§2–3, `scripts/fireworks-gateway-smoke.ts` |
+| 8 | Compare baseline vs candidate; publish scorecard | Blind Bench | ✅ `src/lib/evals/modelComparison.ts` (`compare:customer-pilot`) — promote / hold / reject recommendation, `docs/baseline-candidate-comparison.md` |
+
+**Honest status of the loop:** the two ends (import + normalize; baseline /
+candidate comparison + scorecard) are shipped and tested. The middle —
+turning imported production traces into runnable eval cases **through the UI** —
+is partially manual today: the local path
+(`normalizeCloudflareAiGatewayLog → convertTraceToEvalCase`) works, but the Convex
+importer does not yet expose materialization or sidecar merge
+(`docs/cloudflare-gateway-live-import.md` "Follow-up"). Fireworks fine-tune +
+deploy (step 6) is an operator runbook (`firectl`), not an automated product step.
+
+---
+
+## What Blind Bench owns vs Cloudflare vs Fireworks
+
+| Concern | Owner | Notes |
+| --- | --- | --- |
+| Prompt traffic capture, gateway, routing, log storage | **Cloudflare** | AI Gateway + Logpush + dynamic/custom-provider routing. We consume its logs and its routing surface; we do not reproduce them. |
+| Model training (SFT / RFT), model hosting, inference | **Fireworks** | Fine-tune via `firectl`, serve serverless/dedicated. We compile the dataset and read the results; we do not host or train. |
+| Log normalization + deduplication | **Blind Bench** | `traceImports` identity, access-controlled raw payload storage. |
+| Eval packs + deterministic, management-safe scoring | **Blind Bench** | Scorecard exposes only IDs/labels/scores/aggregates — never raw prompts, outputs, or scorer reason strings. |
+| Human review / blind sign-off | **Blind Bench** | The reviewer surface (see [[Blind Bench - Positioning]]). |
+| Training-data curation with data-boundary gates | **Blind Bench** | Default-deny compiler; real rows need explicit training approval + policy flag. |
+| Baseline↔candidate comparison + promote/hold/reject | **Blind Bench** | The decision artifact management actually reads. |
+| Billing / entitlements | **Blind Bench** (via Polar) | See below. |
+
+### Build / buy boundaries
+
+- **Do not rebuild the Gateway.** No log storage, no routing engine, no proxy of
+  our own. We export from and route through Cloudflare. The data boundary is
+  one-directional by design (`docs/cloudflare-gateway-live-import.md` §3).
+- **Do not rebuild Fireworks training.** No training infra, no model hosting. We
+  compile a Fireworks-compatible JSONL dataset + manifest
+  (`docs/training-dataset-compiler.md`) and hand it off; `firectl`/Fireworks does
+  the fine-tune and serving.
+- **Do build** the management-safe eval + scorecard layer, the curation/consent
+  gates, and the reviewer surface — the parts that are our defensible work and
+  that neither Cloudflare nor Fireworks provides.
+
+---
+
+## MVP success criteria
+
+### For Pennie (beachhead pilot)
+
+1. Real Migo/Eavesly Gateway logs import cleanly (dedup + summary), staying
+   `prod_sensitive` and customer-scoped — no raw prompt/output ever leaves the
+   workspace or reaches the repo.
+2. A baseline scorecard is generated and is management-safe (only IDs / labels /
+   scores / aggregates), suitable as the paid handoff artifact
+   (`docs/customer-ai-quality-scorecard-handoff.md`).
+3. A Fireworks candidate is trained from **training-approved** rows and routed
+   through the Gateway; the comparison runner returns an explicit
+   **promote / hold / reject** with no privacy/tool-safety hard-fail regression
+   (`docs/baseline-candidate-comparison.md`).
+4. The live smoke passes end-to-end (send → poll logs → verify round-trip),
+   proving the loop works on real infra (`scripts/fireworks-gateway-smoke.ts`).
+
+### For a generic CF AI Gateway user
+
+1. Self-serve onboarding: follow `docs/gateway-onboarding.md`, export with an
+   **AI Gateway — Read** scoped token, import via the no-code page
+   (`src/routes/orgs/GatewayImport.tsx`) with no Blind Bench↔Cloudflare
+   integration work.
+2. Reach a baseline scorecard **without any Fireworks credentials** — Fireworks
+   is needed only at the candidate step.
+3. Metadata conventions (`product`, `module`, `prompt_version`, `variant`,
+   `release`, `environment`, `tenant`, `trace_id`, `session_id`) let logs group
+   by surface, within Cloudflare's custom-metadata size/count limits.
+4. Optional: purchase a package via Polar self-serve to unlock eval credits /
+   reviewer seats / import headroom.
+
+> **Open strategy call (Noah):** the numeric bars (how much lift over baseline
+> counts as a win; minimum traffic volume; pilot price). Recommendation: define a
+> per-pilot quality-lift target with the customer at SOW time rather than a global
+> threshold. Not decided here.
+
+---
+
+## Billing (shipped foundation)
+
+Self-serve packages through **Polar**, owner-scoped per workspace
+(`docs/polar-self-serve-billing.md`, `convex/lib/billingPlans.ts`):
+
+- Package keys `starter` / `team` / `scale` / `enterprise`; `enterprise` is
+  manual/contact-sales.
+- Each package grants eval credits, reviewer seats, and trace-import headroom.
+- A free trial grant exists in config (50 credits / 2 seats / 10 imports); trial
+  provisioning is not yet auto-seeded.
+- Payment state is isolated from trace data — billing tables never reference
+  trace/eval content.
+
+> **Open strategy call (Noah):** actual prices and what each package includes are
+> config placeholders, not committed pricing. Recommendation: hold pricing until
+> the first pilots reveal willingness-to-pay. Not decided here.
+
+---
+
+## Non-goals
+
+- Not a tracing platform and not an LLM-as-judge harness (carry-over from
+  [[Blind Bench - Positioning]] — that fight is Cloudflare's / a commodity).
+- Not a model host or training platform (Fireworks owns that).
+- Not a Cloudflare replacement or proxy.
+
+## Known gaps / next (not claims of "done")
+
+- UI materialization of imported traces into eval cases + sidecar-metadata merge
+  in the Convex importer (`docs/cloudflare-gateway-live-import.md` "Follow-up").
+- Fireworks fine-tune/deploy is an operator runbook, not an in-product step.
+- Real endpoint-vs-endpoint comparison currently ingests captured fixtures; the
+  comparison/recommendation logic is endpoint-agnostic and ready for a live
+  adapter (`docs/baseline-candidate-comparison.md` "What it is NOT").
+- Trial auto-provisioning and final pricing (see Billing).

--- a/scripts/fireworks-gateway-smoke.ts
+++ b/scripts/fireworks-gateway-smoke.ts
@@ -1,0 +1,244 @@
+/**
+ * Live Fireworks-behind-Cloudflare-AI-Gateway smoke + log verification (env-gated CLI).
+ *
+ * Sends ONE synthetic chat request through the Gateway, polls the Gateway logs API for the
+ * matching trace_id, normalizes it with the existing adapter, runs `verifyGatewayLog`, and
+ * writes a redacted report to `artifacts/fireworks-gateway-smoke.{json,md}` (gitignored).
+ * Exits non-zero on verification failure. Fails CLOSED when required env is missing.
+ *
+ *   npm run smoke:fireworks-gateway -- --dry-run   # print redacted request, send nothing
+ *   npm run smoke:fireworks-gateway                 # live send + poll + verify
+ *
+ * Secrets (FIREWORKS_API_KEY, CF_AIG_TOKEN, CF_API_TOKEN) stay env-only and never enter the
+ * repo, artifacts, or logs — the request is redacted before it is printed or written.
+ */
+import { randomUUID } from "node:crypto";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+import {
+  normalizeCloudflareAiGatewayLog,
+  type CloudflareAiGatewayLog,
+  type NormalizedBlindBenchTrace,
+} from "../src/lib/evals/cloudflareAiGateway";
+import { loadConfig } from "../src/lib/evals/fireworksGatewayPrototype";
+import {
+  buildSmokeRequest,
+  redactSmokeRequest,
+  verifyGatewayLog,
+  type SmokeRequest,
+  type VerifyResult,
+} from "../src/lib/evals/fireworksGatewaySmoke";
+
+/** Env vars required to build + send the smoke request. */
+const REQUIRED_ENV = [
+  "CF_ACCOUNT_ID",
+  "CF_AIG_GATEWAY",
+  "CF_AIG_TOKEN",
+  "FIREWORKS_API_KEY",
+  "FIREWORKS_MODEL",
+] as const;
+
+/** Additional env required only for a live run (reading the Gateway logs API). */
+const LIVE_ENV = ["CF_API_TOKEN"] as const;
+
+const OUT_DIR = "artifacts";
+const POLL_TIMEOUT_MS = 60_000;
+const POLL_INTERVAL_MS = 3_000;
+const CF_API_BASE = "https://api.cloudflare.com/client/v4";
+
+type Env = Record<string, string | undefined>;
+
+export interface CliArgs {
+  dryRun: boolean;
+}
+
+export function parseArgs(argv: string[]): CliArgs {
+  return { dryRun: argv.includes("--dry-run") };
+}
+
+/** Missing entries from a required-env list (unset or empty). */
+function missingEnv(env: Env, keys: readonly string[]): string[] {
+  return keys.filter((k) => env[k] === undefined || env[k] === "");
+}
+
+/** Poll dependencies, injectable so the pure control flow stays testable without network. */
+export interface PollDeps {
+  fetch: typeof fetch;
+  now: () => number;
+  sleep: (ms: number) => Promise<void>;
+}
+
+interface CfLogsResponse {
+  success?: boolean;
+  result?: unknown[];
+  errors?: unknown[];
+}
+
+/** Poll the Gateway logs API until a log carrying `traceId` in its metadata appears, or timeout. */
+export async function pollForTraceLog(
+  deps: PollDeps,
+  opts: { accountId: string; gateway: string; apiToken: string; traceId: string; timeoutMs?: number },
+): Promise<CloudflareAiGatewayLog | undefined> {
+  const url = `${CF_API_BASE}/accounts/${opts.accountId}/ai-gateway/gateways/${opts.gateway}/logs?per_page=50`;
+  const deadline = deps.now() + (opts.timeoutMs ?? POLL_TIMEOUT_MS);
+  do {
+    const res = await deps.fetch(url, { headers: { Authorization: `Bearer ${opts.apiToken}` } });
+    if (res.ok) {
+      const payload = (await res.json()) as CfLogsResponse;
+      for (const entry of payload.result ?? []) {
+        const record = entry as CloudflareAiGatewayLog;
+        if (normalizeCloudflareAiGatewayLog(record).metadata.trace_id === opts.traceId) return record;
+      }
+    }
+    if (deps.now() >= deadline) break;
+    await deps.sleep(POLL_INTERVAL_MS);
+  } while (deps.now() < deadline);
+  return undefined;
+}
+
+/** Send the smoke request through the Gateway. */
+async function sendSmokeRequest(
+  fetchImpl: typeof fetch,
+  req: SmokeRequest,
+): Promise<{ status: number; ok: boolean }> {
+  const res = await fetchImpl(req.url, {
+    method: "POST",
+    headers: req.headers,
+    body: JSON.stringify(req.body),
+  });
+  return { status: res.status, ok: res.ok };
+}
+
+function reportMarkdown(
+  trace: NormalizedBlindBenchTrace,
+  result: VerifyResult,
+  redacted: SmokeRequest,
+): string {
+  const L: string[] = [];
+  L.push("# Fireworks → Cloudflare AI Gateway live smoke");
+  L.push("");
+  L.push(`- Result: **${result.ok ? "PASS" : "FAIL"}**`);
+  L.push(`- trace_id: \`${trace.metadata.trace_id ?? "<none>"}\``);
+  L.push(`- provider: \`${trace.provider ?? "<none>"}\` · model: \`${trace.model ?? "<none>"}\``);
+  L.push(`- status: \`${trace.status ?? "<none>"}\` · duration_ms: \`${trace.duration_ms ?? "<none>"}\``);
+  L.push("");
+  L.push("## Failures");
+  L.push("");
+  L.push(result.failures.length ? result.failures.map((f) => `- ${f}`).join("\n") : "_none_");
+  L.push("");
+  L.push("## Notes");
+  L.push("");
+  L.push(result.notes.length ? result.notes.map((n) => `- ${n}`).join("\n") : "_none_");
+  L.push("");
+  L.push("## Redacted request");
+  L.push("");
+  L.push("```json");
+  L.push(JSON.stringify(redacted, null, 2));
+  L.push("```");
+  L.push("");
+  return L.join("\n");
+}
+
+function writeArtifacts(
+  trace: NormalizedBlindBenchTrace,
+  result: VerifyResult,
+  redacted: SmokeRequest,
+): void {
+  mkdirSync(OUT_DIR, { recursive: true });
+  // Only redacted request + normalized trace (no headers/secrets) are persisted.
+  writeFileSync(
+    `${OUT_DIR}/fireworks-gateway-smoke.json`,
+    JSON.stringify({ ok: result.ok, failures: result.failures, notes: result.notes, request: redacted, trace }, null, 2),
+  );
+  writeFileSync(`${OUT_DIR}/fireworks-gateway-smoke.md`, reportMarkdown(trace, result, redacted));
+}
+
+export async function main(
+  argv: string[],
+  env: Env = process.env,
+  deps: PollDeps = { fetch, now: Date.now, sleep: (ms) => new Promise((r) => setTimeout(r, ms)) },
+): Promise<number> {
+  const { dryRun } = parseArgs(argv);
+
+  const missing = missingEnv(env, REQUIRED_ENV);
+  if (missing.length) {
+    process.stderr.write(
+      `fireworks-gateway-smoke: missing required env: ${missing.join(", ")}. ` +
+        `Set all of ${REQUIRED_ENV.join(", ")} (secrets stay env-only, never committed).\n`,
+    );
+    return 1;
+  }
+
+  // tenant_label / product are metadata-only; default them so the smoke needs just the
+  // required credential + routing vars above.
+  const config = loadConfig({
+    ...env,
+    TENANT_LABEL: env.TENANT_LABEL ?? "smoke-synthetic-tenant",
+    PRODUCT: env.PRODUCT ?? "migo",
+  });
+
+  const traceId = `smoke-${randomUUID()}`;
+  const request = buildSmokeRequest(config, {
+    traceId,
+    sessionId: `smoke-session-${randomUUID()}`,
+    fireworksApiKey: env.FIREWORKS_API_KEY!,
+    gatewayToken: env.CF_AIG_TOKEN!,
+  });
+  const redacted = redactSmokeRequest(request);
+
+  if (dryRun) {
+    process.stdout.write(`Dry run — no request sent. Redacted request:\n`);
+    process.stdout.write(JSON.stringify(redacted, null, 2) + "\n");
+    return 0;
+  }
+
+  const liveMissing = missingEnv(env, LIVE_ENV);
+  if (liveMissing.length) {
+    process.stderr.write(
+      `fireworks-gateway-smoke: live run needs ${liveMissing.join(", ")} to read the Gateway logs API. ` +
+        `Use --dry-run to skip sending.\n`,
+    );
+    return 1;
+  }
+
+  process.stdout.write(`Sending synthetic smoke request (trace_id=${traceId})…\n`);
+  const send = await sendSmokeRequest(deps.fetch, request);
+  process.stdout.write(`Gateway responded HTTP ${send.status}.\n`);
+
+  process.stdout.write(`Polling Gateway logs for trace_id (timeout ${POLL_TIMEOUT_MS / 1000}s)…\n`);
+  const record = await pollForTraceLog(deps, {
+    accountId: config.cf_account_id,
+    gateway: config.cf_gateway,
+    apiToken: env.CF_API_TOKEN!,
+    traceId,
+  });
+  if (!record) {
+    process.stderr.write(`No Gateway log found for trace_id=${traceId} within the timeout.\n`);
+    return 1;
+  }
+
+  const trace = normalizeCloudflareAiGatewayLog(record);
+  const result = verifyGatewayLog(trace, {
+    provider: config.provider_slug,
+    model: config.fireworks_model,
+    traceId,
+  });
+  writeArtifacts(trace, result, redacted);
+
+  process.stdout.write(`Verification: ${result.ok ? "PASS" : "FAIL"}\n`);
+  for (const n of result.notes) process.stdout.write(`  note: ${n}\n`);
+  for (const f of result.failures) process.stderr.write(`  fail: ${f}\n`);
+  process.stdout.write(`Wrote ${OUT_DIR}/fireworks-gateway-smoke.{json,md}.\n`);
+  return result.ok ? 0 : 1;
+}
+
+const invokedDirectly =
+  process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (invokedDirectly) {
+  main(process.argv.slice(2))
+    .then((code) => process.exit(code))
+    .catch((e: unknown) => {
+      process.stderr.write(`${e instanceof Error ? e.message : String(e)}\n`);
+      process.exit(1);
+    });
+}

--- a/scripts/fireworks-gateway-smoke.ts
+++ b/scripts/fireworks-gateway-smoke.ts
@@ -109,7 +109,9 @@ export async function pollForTraceLog(
         if (normalizeCloudflareAiGatewayLog(record).metadata.trace_id === opts.traceId) return record;
       }
     } else {
-      const snippet = redact((await res.text()).slice(0, 300));
+      // Redact the FULL body before slicing — a secret straddling the slice
+      // boundary would otherwise partially leak into the error message.
+      const snippet = redact(await res.text()).slice(0, 300);
       if (res.status === 401 || res.status === 403) {
         throw new Error(
           `Gateway logs API auth failed (HTTP ${res.status}) — check CF_API_TOKEN scope/validity. Body: ${snippet}`,

--- a/scripts/fireworks-gateway-smoke.ts
+++ b/scripts/fireworks-gateway-smoke.ts
@@ -23,6 +23,7 @@ import {
 import { loadConfig } from "../src/lib/evals/fireworksGatewayPrototype";
 import {
   buildSmokeRequest,
+  redactSecrets,
   redactSmokeRequest,
   verifyGatewayLog,
   type SmokeRequest,
@@ -74,20 +75,51 @@ interface CfLogsResponse {
   errors?: unknown[];
 }
 
-/** Poll the Gateway logs API until a log carrying `traceId` in its metadata appears, or timeout. */
+/** Consecutive non-OK Logs API responses tolerated before the poll gives up as fatal. */
+const MAX_CONSECUTIVE_NON_OK = 3;
+
+/**
+ * Poll the Gateway logs API until a log carrying `traceId` in its metadata appears, or timeout.
+ * Throws (fatal) on 401/403 immediately, or after `MAX_CONSECUTIVE_NON_OK` non-OK responses —
+ * error messages carry only the HTTP status plus a `redact`-sanitized body snippet.
+ */
 export async function pollForTraceLog(
   deps: PollDeps,
-  opts: { accountId: string; gateway: string; apiToken: string; traceId: string; timeoutMs?: number },
+  opts: {
+    accountId: string;
+    gateway: string;
+    apiToken: string;
+    traceId: string;
+    timeoutMs?: number;
+    /** Sanitizer applied to response-body snippets before they enter error messages. */
+    redact?: (text: string) => string;
+  },
 ): Promise<CloudflareAiGatewayLog | undefined> {
   const url = `${CF_API_BASE}/accounts/${opts.accountId}/ai-gateway/gateways/${opts.gateway}/logs?per_page=50`;
   const deadline = deps.now() + (opts.timeoutMs ?? POLL_TIMEOUT_MS);
+  const redact = opts.redact ?? ((text: string) => text);
+  let consecutiveNonOk = 0;
   do {
     const res = await deps.fetch(url, { headers: { Authorization: `Bearer ${opts.apiToken}` } });
     if (res.ok) {
+      consecutiveNonOk = 0;
       const payload = (await res.json()) as CfLogsResponse;
       for (const entry of payload.result ?? []) {
         const record = entry as CloudflareAiGatewayLog;
         if (normalizeCloudflareAiGatewayLog(record).metadata.trace_id === opts.traceId) return record;
+      }
+    } else {
+      const snippet = redact((await res.text()).slice(0, 300));
+      if (res.status === 401 || res.status === 403) {
+        throw new Error(
+          `Gateway logs API auth failed (HTTP ${res.status}) — check CF_API_TOKEN scope/validity. Body: ${snippet}`,
+        );
+      }
+      consecutiveNonOk += 1;
+      if (consecutiveNonOk >= MAX_CONSECUTIVE_NON_OK) {
+        throw new Error(
+          `Gateway logs API returned ${consecutiveNonOk} consecutive non-OK responses (last HTTP ${res.status}). Body: ${snippet}`,
+        );
       }
     }
     if (deps.now() >= deadline) break;
@@ -159,12 +191,16 @@ export async function main(
   deps: PollDeps = { fetch, now: Date.now, sleep: (ms) => new Promise((r) => setTimeout(r, ms)) },
 ): Promise<number> {
   const { dryRun } = parseArgs(argv);
+  // Every stderr line is sanitized — no secret env value may reach the terminal.
+  const errOut = (msg: string): void => {
+    process.stderr.write(redactSecrets(msg, env) + "\n");
+  };
 
   const missing = missingEnv(env, REQUIRED_ENV);
   if (missing.length) {
-    process.stderr.write(
+    errOut(
       `fireworks-gateway-smoke: missing required env: ${missing.join(", ")}. ` +
-        `Set all of ${REQUIRED_ENV.join(", ")} (secrets stay env-only, never committed).\n`,
+        `Set all of ${REQUIRED_ENV.join(", ")} (secrets stay env-only, never committed).`,
     );
     return 1;
   }
@@ -194,15 +230,19 @@ export async function main(
 
   const liveMissing = missingEnv(env, LIVE_ENV);
   if (liveMissing.length) {
-    process.stderr.write(
+    errOut(
       `fireworks-gateway-smoke: live run needs ${liveMissing.join(", ")} to read the Gateway logs API. ` +
-        `Use --dry-run to skip sending.\n`,
+        `Use --dry-run to skip sending.`,
     );
     return 1;
   }
 
   process.stdout.write(`Sending synthetic smoke request (trace_id=${traceId})…\n`);
   const send = await sendSmokeRequest(deps.fetch, request);
+  if (!send.ok) {
+    errOut(`Gateway send failed: HTTP ${send.status}. Not polling logs.`);
+    return 1;
+  }
   process.stdout.write(`Gateway responded HTTP ${send.status}.\n`);
 
   process.stdout.write(`Polling Gateway logs for trace_id (timeout ${POLL_TIMEOUT_MS / 1000}s)…\n`);
@@ -211,9 +251,10 @@ export async function main(
     gateway: config.cf_gateway,
     apiToken: env.CF_API_TOKEN!,
     traceId,
+    redact: (text) => redactSecrets(text, env),
   });
   if (!record) {
-    process.stderr.write(`No Gateway log found for trace_id=${traceId} within the timeout.\n`);
+    errOut(`No Gateway log found for trace_id=${traceId} within the timeout.`);
     return 1;
   }
 
@@ -227,7 +268,7 @@ export async function main(
 
   process.stdout.write(`Verification: ${result.ok ? "PASS" : "FAIL"}\n`);
   for (const n of result.notes) process.stdout.write(`  note: ${n}\n`);
-  for (const f of result.failures) process.stderr.write(`  fail: ${f}\n`);
+  for (const f of result.failures) errOut(`  fail: ${f}`);
   process.stdout.write(`Wrote ${OUT_DIR}/fireworks-gateway-smoke.{json,md}.\n`);
   return result.ok ? 0 : 1;
 }
@@ -238,7 +279,9 @@ if (invokedDirectly) {
   main(process.argv.slice(2))
     .then((code) => process.exit(code))
     .catch((e: unknown) => {
-      process.stderr.write(`${e instanceof Error ? e.message : String(e)}\n`);
+      // Thrown messages may echo request/API details — sanitize before they hit stderr.
+      const message = e instanceof Error ? e.message : String(e);
+      process.stderr.write(redactSecrets(message, process.env) + "\n");
       process.exit(1);
     });
 }

--- a/src/lib/evals/fireworksGatewaySmoke.test.ts
+++ b/src/lib/evals/fireworksGatewaySmoke.test.ts
@@ -6,6 +6,7 @@ import {
 import { loadConfig, modelField, gatewayUrlForMode } from "./fireworksGatewayPrototype";
 import {
   buildSmokeRequest,
+  redactSecrets,
   redactSmokeRequest,
   verifyGatewayLog,
   SMOKE_PROMPT,
@@ -91,6 +92,36 @@ describe("redactSmokeRequest", () => {
     expect(text).not.toContain("cf_SUPER_SECRET_TOKEN");
     // metadata + prompt still round-trip so the operator can eyeball the request
     expect(text).toContain(IDS.traceId);
+  });
+});
+
+describe("redactSecrets", () => {
+  const SECRET_ENV = {
+    FIREWORKS_API_KEY: "fw_LIVE_SECRET_1234567890",
+    CF_AIG_TOKEN: "cf_aig_LIVE_SECRET_0987654321",
+    CF_API_TOKEN: "cf_api_LIVE_SECRET_1122334455",
+  };
+
+  it("replaces every occurrence of each secret env value with its placeholder", () => {
+    const text =
+      `Error: 401 from https://x?key=${SECRET_ENV.FIREWORKS_API_KEY} ` +
+      `Authorization: Bearer ${SECRET_ENV.CF_API_TOKEN} ` +
+      `retry with ${SECRET_ENV.FIREWORKS_API_KEY} and ${SECRET_ENV.CF_AIG_TOKEN}`;
+    const out = redactSecrets(text, SECRET_ENV);
+    expect(out).not.toContain(SECRET_ENV.FIREWORKS_API_KEY);
+    expect(out).not.toContain(SECRET_ENV.CF_AIG_TOKEN);
+    expect(out).not.toContain(SECRET_ENV.CF_API_TOKEN);
+    expect(out).toContain("$FIREWORKS_API_KEY");
+    expect(out).toContain("$CF_AIG_TOKEN");
+    expect(out).toContain("$CF_API_TOKEN");
+    // both FIREWORKS_API_KEY occurrences replaced
+    expect(out.match(/\$FIREWORKS_API_KEY/g)).toHaveLength(2);
+  });
+
+  it("leaves text untouched when the secrets are unset or empty", () => {
+    const text = "plain error message with no secrets";
+    expect(redactSecrets(text, {})).toBe(text);
+    expect(redactSecrets(text, { FIREWORKS_API_KEY: "", CF_AIG_TOKEN: undefined })).toBe(text);
   });
 });
 

--- a/src/lib/evals/fireworksGatewaySmoke.test.ts
+++ b/src/lib/evals/fireworksGatewaySmoke.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from "vitest";
+import {
+  normalizeCloudflareAiGatewayLog,
+  type CloudflareAiGatewayLog,
+} from "./cloudflareAiGateway";
+import { loadConfig, modelField, gatewayUrlForMode } from "./fireworksGatewayPrototype";
+import {
+  buildSmokeRequest,
+  redactSmokeRequest,
+  verifyGatewayLog,
+  SMOKE_PROMPT,
+  type VerifyExpectations,
+} from "./fireworksGatewaySmoke";
+
+const ENV = {
+  CF_ACCOUNT_ID: "acct_TEST",
+  CF_AIG_GATEWAY: "gw_TEST",
+  FIREWORKS_MODEL: "accounts/test/models/migo-ft-0001",
+  TENANT_LABEL: "tenant-test",
+  PRODUCT: "migo",
+};
+
+const IDS = { traceId: "smoke-trace-abc123", sessionId: "smoke-session-abc123" };
+const SECRETS = { fireworksApiKey: "fw_SUPER_SECRET_KEY", gatewayToken: "cf_SUPER_SECRET_TOKEN" };
+
+/** Build a normalized trace from a synthetic gateway log carrying the smoke trace_id. */
+function normalizedLog(overrides: Partial<CloudflareAiGatewayLog> = {}) {
+  const record: CloudflareAiGatewayLog = {
+    account_id: "acct_TEST",
+    gateway_id: "gw_TEST",
+    log_id: "log_smoke_001",
+    timestamp: "2026-07-05T12:00:00Z",
+    provider: "fireworks-ai",
+    model: "accounts/test/models/migo-ft-0001",
+    status: "success",
+    request: { messages: [{ role: "user", content: SMOKE_PROMPT }] },
+    response: { choices: [{ message: { content: "ok" } }] },
+    usage: { input_tokens: 20, output_tokens: 2, total_tokens: 22, cost_usd: 0.0001 },
+    duration_ms: 540,
+    metadata: {
+      product: "migo",
+      module: "prototype_smoke",
+      prompt_version: "pv_prototype_0001",
+      variant: "control",
+      release: "rel_prototype",
+      environment: "staging",
+      tenant: "tenant-test",
+      trace_id: IDS.traceId,
+      session_id: IDS.sessionId,
+    },
+    ...overrides,
+  };
+  return normalizeCloudflareAiGatewayLog(record);
+}
+
+const EXPECTED: VerifyExpectations = {
+  provider: "fireworks-ai",
+  model: "accounts/test/models/migo-ft-0001",
+  traceId: IDS.traceId,
+};
+
+describe("buildSmokeRequest", () => {
+  it("targets the configured gateway endpoint with the resolved model field", () => {
+    const c = loadConfig(ENV);
+    const req = buildSmokeRequest(c, { ...IDS, ...SECRETS });
+    expect(req.url).toBe(gatewayUrlForMode(c));
+    expect(req.body.model).toBe(modelField(c));
+    expect(req.body.messages).toEqual([{ role: "user", content: SMOKE_PROMPT }]);
+    expect(req.traceId).toBe(IDS.traceId);
+  });
+
+  it("carries both credentials and a unique trace_id in metadata", () => {
+    const req = buildSmokeRequest(loadConfig(ENV), { ...IDS, ...SECRETS });
+    expect(req.headers.Authorization).toBe("Bearer fw_SUPER_SECRET_KEY");
+    expect(req.headers["cf-aig-authorization"]).toBe("Bearer cf_SUPER_SECRET_TOKEN");
+    const meta = JSON.parse(req.headers["cf-aig-metadata"] ?? "{}") as Record<string, string>;
+    expect(meta.trace_id).toBe(IDS.traceId);
+    expect(meta.session_id).toBe(IDS.sessionId);
+    expect(req.body.metadata.trace_id).toBe(IDS.traceId);
+  });
+});
+
+describe("redactSmokeRequest", () => {
+  it("replaces secret header values with env-var placeholders", () => {
+    const req = buildSmokeRequest(loadConfig(ENV), { ...IDS, ...SECRETS });
+    const redacted = redactSmokeRequest(req);
+    expect(redacted.headers.Authorization).toBe("Bearer $FIREWORKS_API_KEY");
+    expect(redacted.headers["cf-aig-authorization"]).toBe("Bearer $CF_AIG_TOKEN");
+    const text = JSON.stringify(redacted);
+    expect(text).not.toContain("fw_SUPER_SECRET_KEY");
+    expect(text).not.toContain("cf_SUPER_SECRET_TOKEN");
+    // metadata + prompt still round-trip so the operator can eyeball the request
+    expect(text).toContain(IDS.traceId);
+  });
+});
+
+describe("verifyGatewayLog", () => {
+  it("passes a well-formed log and reports cost presence (non-fatal)", () => {
+    const result = verifyGatewayLog(normalizedLog(), EXPECTED);
+    expect(result.ok).toBe(true);
+    expect(result.failures).toEqual([]);
+    expect(result.notes.some((n) => n.includes("cost_usd"))).toBe(true);
+  });
+
+  it("does not fail when cost_usd is absent — only notes it", () => {
+    const result = verifyGatewayLog(
+      normalizedLog({ usage: { input_tokens: 20, output_tokens: 2, total_tokens: 22 } }),
+      EXPECTED,
+    );
+    expect(result.ok).toBe(true);
+    expect(result.notes.some((n) => /cost_usd/.test(n))).toBe(true);
+  });
+
+  it("fails when usage tokens are missing", () => {
+    const result = verifyGatewayLog(normalizedLog({ usage: {} }), EXPECTED);
+    expect(result.ok).toBe(false);
+    expect(result.failures.join(" ")).toMatch(/token/i);
+  });
+
+  it("fails on provider mismatch", () => {
+    const result = verifyGatewayLog(normalizedLog({ provider: "anthropic" }), EXPECTED);
+    expect(result.ok).toBe(false);
+    expect(result.failures.join(" ")).toMatch(/provider/i);
+  });
+
+  it("fails when the trace_id does not round-trip", () => {
+    const result = verifyGatewayLog(normalizedLog(), { ...EXPECTED, traceId: "different-trace" });
+    expect(result.ok).toBe(false);
+    expect(result.failures.join(" ")).toMatch(/trace_id/i);
+  });
+
+  it("fails when status is not success", () => {
+    const result = verifyGatewayLog(normalizedLog({ status: "error" }), EXPECTED);
+    expect(result.ok).toBe(false);
+    expect(result.failures.join(" ")).toMatch(/status/i);
+  });
+
+  it("reports redaction as a note, not a failure, when bodies are stripped", () => {
+    const result = verifyGatewayLog(
+      normalizedLog({ request: { redacted: true }, response: undefined }),
+      EXPECTED,
+    );
+    // provider/model/usage/duration/metadata/status still present → verification passes
+    expect(result.ok).toBe(true);
+    expect(result.notes.some((n) => /redact/i.test(n))).toBe(true);
+  });
+
+  it("flags missing duration_ms", () => {
+    const result = verifyGatewayLog(normalizedLog({ duration_ms: undefined }), EXPECTED);
+    expect(result.ok).toBe(false);
+    expect(result.failures.join(" ")).toMatch(/duration/i);
+  });
+});

--- a/src/lib/evals/fireworksGatewaySmoke.ts
+++ b/src/lib/evals/fireworksGatewaySmoke.ts
@@ -1,0 +1,200 @@
+/**
+ * Fireworks-behind-Cloudflare-AI-Gateway live smoke helpers (pure, no network).
+ *
+ * `buildSmokeRequest` assembles the exact request the live CLI
+ * (`scripts/fireworks-gateway-smoke.ts`) sends through the Gateway; `verifyGatewayLog`
+ * asserts the normalized Gateway log for that request proves the hop worked end-to-end.
+ *
+ * Route shapes (compat default / provider mode), the model field, and the metadata keys
+ * are reused verbatim from `fireworksGatewayPrototype.ts` so the smoke path stays 1:1 with
+ * the runbook. Secrets are never embedded: they are passed in per-request and stripped by
+ * `redactSmokeRequest` before anything is printed or written to an artifact.
+ */
+import type { NormalizedBlindBenchTrace } from "./cloudflareAiGateway";
+import {
+  buildMetadata,
+  gatewayUrlForMode,
+  modelField,
+  type PrototypeConfig,
+} from "./fireworksGatewayPrototype";
+
+/** Synthetic prompt — never production or customer data. */
+export const SMOKE_PROMPT = "Synthetic smoke prompt — no production or customer data. Reply with: ok.";
+
+/** Metadata keys the smoke request sets and expects to round-trip through the Gateway log. */
+export const SMOKE_METADATA_KEYS = [
+  "product",
+  "module",
+  "prompt_version",
+  "variant",
+  "release",
+  "environment",
+  "tenant",
+  "trace_id",
+  "session_id",
+] as const;
+
+export interface SmokeRequestBody {
+  model: string;
+  messages: { role: string; content: string }[];
+  max_tokens: number;
+  metadata: Record<string, string>;
+}
+
+export interface SmokeRequest {
+  url: string;
+  headers: Record<string, string>;
+  body: SmokeRequestBody;
+  traceId: string;
+}
+
+export interface SmokeRequestParams {
+  /** Unique per-request trace id (the CLI generates a random one). */
+  traceId: string;
+  /** Unique per-request session id; defaults to `traceId`. */
+  sessionId?: string;
+  /** Upstream Fireworks provider key. */
+  fireworksApiKey: string;
+  /** Cloudflare AI Gateway edge-auth token (distinct from the upstream key). */
+  gatewayToken: string;
+}
+
+/** Metadata for a live smoke request: prototype metadata with unique per-request ids. */
+export function buildSmokeMetadata(
+  config: PrototypeConfig,
+  ids: { traceId: string; sessionId?: string },
+): Record<string, string> {
+  return {
+    ...buildMetadata(config),
+    trace_id: ids.traceId,
+    session_id: ids.sessionId ?? ids.traceId,
+  };
+}
+
+/**
+ * Build the live Gateway request. Carries real credentials in headers so it can be sent;
+ * use `redactSmokeRequest` before printing or persisting.
+ * - `Authorization` — upstream Fireworks key.
+ * - `cf-aig-authorization` — Gateway edge token.
+ * - `cf-aig-metadata` — routing metadata (also mirrored in the body).
+ */
+export function buildSmokeRequest(config: PrototypeConfig, params: SmokeRequestParams): SmokeRequest {
+  const metadata = buildSmokeMetadata(config, params);
+  return {
+    url: gatewayUrlForMode(config),
+    headers: {
+      Authorization: `Bearer ${params.fireworksApiKey}`,
+      "cf-aig-authorization": `Bearer ${params.gatewayToken}`,
+      "cf-aig-metadata": JSON.stringify(metadata),
+      "Content-Type": "application/json",
+    },
+    body: {
+      model: modelField(config),
+      messages: [{ role: "user", content: SMOKE_PROMPT }],
+      max_tokens: 64,
+      metadata,
+    },
+    traceId: params.traceId,
+  };
+}
+
+/** Copy of a smoke request with both secret header values replaced by env-var placeholders. */
+export function redactSmokeRequest(req: SmokeRequest): SmokeRequest {
+  return {
+    ...req,
+    headers: {
+      ...req.headers,
+      Authorization: "Bearer $FIREWORKS_API_KEY",
+      "cf-aig-authorization": "Bearer $CF_AIG_TOKEN",
+    },
+  };
+}
+
+// --- log verification --------------------------------------------------------
+
+export interface VerifyExpectations {
+  /** Expected provider slug, e.g. `fireworks-ai`. */
+  provider: string;
+  /** Expected resolved Fireworks model id. */
+  model: string;
+  /** The unique trace_id the request carried; must round-trip in log metadata. */
+  traceId: string;
+  /** Metadata keys expected to round-trip; defaults to `SMOKE_METADATA_KEYS`. */
+  metadataKeys?: readonly string[];
+}
+
+export interface VerifyResult {
+  ok: boolean;
+  /** Hard failures — any entry means the smoke did not prove the hop. */
+  failures: string[];
+  /** Informational observations (cost presence, redaction) — never fatal. */
+  notes: string[];
+}
+
+/** Tolerant slug/id comparison: present and equal or a substring either direction (case-insensitive). */
+function looselyMatches(actual: string | undefined, expected: string): boolean {
+  if (actual === undefined) return false;
+  const a = actual.toLowerCase();
+  const e = expected.toLowerCase();
+  return a === e || a.includes(e) || e.includes(a);
+}
+
+/**
+ * Verify a normalized Gateway log proves the Fireworks-behind-Gateway hop for one request.
+ * Returns `{ ok, failures, notes }`. `cost_usd` may legitimately be null and body redaction
+ * is expected under strict log settings — both are reported as notes, never failures.
+ */
+export function verifyGatewayLog(
+  trace: NormalizedBlindBenchTrace,
+  expected: VerifyExpectations,
+): VerifyResult {
+  const failures: string[] = [];
+  const notes: string[] = [];
+
+  if (!looselyMatches(trace.provider, expected.provider)) {
+    failures.push(`provider mismatch: expected ~"${expected.provider}", got "${trace.provider ?? "<none>"}"`);
+  }
+  if (!looselyMatches(trace.model, expected.model)) {
+    failures.push(`resolved model mismatch: expected ~"${expected.model}", got "${trace.model ?? "<none>"}"`);
+  }
+
+  const { input_tokens, output_tokens, total_tokens } = trace.usage;
+  if (input_tokens === undefined && output_tokens === undefined && total_tokens === undefined) {
+    failures.push("usage tokens missing: no input/output/total token counts in log");
+  }
+
+  if (trace.duration_ms === undefined) {
+    failures.push("duration_ms missing: end-to-end latency not captured");
+  }
+
+  if (trace.status === undefined) {
+    failures.push("status missing: no request status recorded");
+  } else if (trace.status.toLowerCase() !== "success") {
+    failures.push(`status not success: "${trace.status}"`);
+  }
+
+  const metadataKeys = expected.metadataKeys ?? SMOKE_METADATA_KEYS;
+  const missingMeta = metadataKeys.filter((k) => trace.metadata[k] === undefined || trace.metadata[k] === "");
+  if (missingMeta.length) {
+    failures.push(`metadata keys did not round-trip: ${missingMeta.join(", ")}`);
+  }
+  if (trace.metadata.trace_id !== expected.traceId) {
+    failures.push(
+      `trace_id did not round-trip: expected "${expected.traceId}", got "${String(trace.metadata.trace_id ?? "<none>")}"`,
+    );
+  }
+
+  notes.push(
+    trace.cost_usd === undefined
+      ? "cost_usd absent (provider did not report it — not fatal)"
+      : `cost_usd present: ${trace.cost_usd}`,
+  );
+  if (trace.redaction.request_missing || trace.redaction.response_missing) {
+    notes.push(
+      `body redaction observed (request_missing=${trace.redaction.request_missing}, ` +
+        `response_missing=${trace.redaction.response_missing}) — expected under strict log settings, not fatal`,
+    );
+  }
+
+  return { ok: failures.length === 0, failures, notes };
+}

--- a/src/lib/evals/fireworksGatewaySmoke.ts
+++ b/src/lib/evals/fireworksGatewaySmoke.ts
@@ -98,6 +98,23 @@ export function buildSmokeRequest(config: PrototypeConfig, params: SmokeRequestP
   };
 }
 
+/** Env vars whose values must never appear in any output; replaced by `$NAME` placeholders. */
+export const SECRET_ENV_VARS = ["FIREWORKS_API_KEY", "CF_AIG_TOKEN", "CF_API_TOKEN"] as const;
+
+/**
+ * Replace every occurrence of each secret env value in `text` with its `$NAME` placeholder.
+ * Run this over ANY string that could carry a secret (error messages, API response bodies)
+ * before it reaches stderr/stdout or an artifact. Unset/empty secrets are skipped.
+ */
+export function redactSecrets(text: string, env: Record<string, string | undefined>): string {
+  let out = text;
+  for (const name of SECRET_ENV_VARS) {
+    const value = env[name];
+    if (value !== undefined && value !== "") out = out.split(value).join(`$${name}`);
+  }
+  return out;
+}
+
 /** Copy of a smoke request with both secret header values replaced by env-var placeholders. */
 export function redactSmokeRequest(req: SmokeRequest): SmokeRequest {
   return {

--- a/src/routes/orgs/projects/RunView.tsx
+++ b/src/routes/orgs/projects/RunView.tsx
@@ -23,6 +23,64 @@ function formatTime(ts: number | undefined): string {
   return new Date(ts).toLocaleTimeString();
 }
 
+/**
+ * #188: Renders the inputs that were sent with a run ("what we sent"). Values
+ * come from the run's frozen inputSnapshot, so editing the test case later
+ * never rewrites this history. When a pre-#188 run has no snapshot, we fall
+ * back to the live test case values behind a visible warning — never a silent
+ * live render.
+ */
+function RunInputs({
+  inputVariables,
+  snapshotMissing,
+  isQuickRun,
+}: {
+  inputVariables: Record<string, string> | null;
+  snapshotMissing: boolean;
+  isQuickRun: boolean;
+}) {
+  const entries = Object.entries(inputVariables ?? {}).filter(
+    ([, value]) => value !== undefined && value !== "",
+  );
+
+  if (entries.length === 0 && !snapshotMissing) return null;
+
+  return (
+    <div className="rounded-lg border bg-muted/20 p-3">
+      <div className="mb-2 flex items-baseline justify-between gap-2">
+        <span className="text-xs font-medium text-foreground">
+          {isQuickRun ? "Inputs sent (quick run)" : "Inputs sent"}
+        </span>
+      </div>
+      {snapshotMissing && (
+        <p className="mb-2.5 text-xs text-amber-700 dark:text-amber-400">
+          Input not snapshotted — showing current test case values. This run
+          predates input snapshots, so these may differ from what was actually
+          sent.
+        </p>
+      )}
+      {entries.length === 0 ? (
+        <p className="text-xs text-muted-foreground">
+          No input variables were sent with this run.
+        </p>
+      ) : (
+        <dl className="space-y-2">
+          {entries.map(([name, value]) => (
+            <div key={name} className="flex flex-col gap-0.5">
+              <dt className="text-xs font-medium text-muted-foreground">
+                {`{{${name}}}`}
+              </dt>
+              <dd className="whitespace-pre-wrap break-words text-xs text-foreground">
+                {value}
+              </dd>
+            </div>
+          ))}
+        </dl>
+      )}
+    </div>
+  );
+}
+
 export function RunView() {
   const { projectId } = useProject();
   const { orgSlug, runId } = useParams<{
@@ -175,6 +233,15 @@ export function RunView() {
 
       {/* Dynamic output grid */}
       <div className="flex-1 overflow-auto p-4 space-y-4">
+        {/* #188: "What we sent" — inputs frozen at dispatch. Reads the run's
+            inputSnapshot (via inputVariables); for pre-#188 test-case runs
+            with no snapshot it shows the current test case values behind an
+            explicit warning rather than passing live state off as history. */}
+        <RunInputs
+          inputVariables={run.inputVariables}
+          snapshotMissing={run.inputSnapshotMissing}
+          isQuickRun={run.isQuickRun}
+        />
         {run.outputs.length === 0 && run.status !== "failed" && (
           // M28.5: pre-activation eval-grid empty state — outputs haven't
           // materialized yet (pending or running). Forward-looking copy that

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -3,6 +3,7 @@
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsBuildInfo",
     "target": "ES2022",
     "lib": ["ES2023"],
+    "types": ["node"],
     "module": "ESNext",
     "skipLibCheck": true,
     "moduleResolution": "bundler",
@@ -15,5 +16,5 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["vite.config.ts"]
+  "include": ["vite.config.ts", "scripts"]
 }


### PR DESCRIPTION
Closes #230, closes #188, closes #232, closes #227.

Four issues, each implemented by a fresh Opus subagent with a Codex review gate per task plus a final whole-branch Codex review (verdict: Ready-to-merge).

## #230 — Live Fireworks-behind-Gateway smoke + log verification
- `src/lib/evals/fireworksGatewaySmoke.ts`: `buildSmokeRequest` / `verifyGatewayLog` / `redactSecrets`, reusing the #250 prototype's route/metadata helpers.
- `scripts/fireworks-gateway-smoke.ts` (`npm run smoke:fireworks-gateway`): env-gated live CLI — sends one synthetic request through the Gateway, polls the Gateway logs API for the trace_id, normalizes with the existing adapter, verifies captured fields, writes gitignored artifacts. Fails closed on missing env; `--dry-run` prints a fully redacted request; all error paths sanitize the three secrets (incl. redact-before-truncate on body snippets).
- Runbook extended: exact `firectl` deployment path, three-credential auth model, tenant isolation requirements, smoke command + expected output.

## #188 — Run history input snapshots
- `promptRuns.inputSnapshot` (optional `{text, images?}`) written at dispatch; snapshot is authoritative for both text and images (`resolveDispatchInputs`) — also closes the create→async-action edit race.
- Blob retention: `safeDeleteTestCaseBlob` consulted in every test-case blob delete path (testCases update/delete, imageVariableAttachments, variables.deleteVariable, projects.deleteProject); project-scoped index query, ceiling documented with a `ponytail:` comment.
- RunView renders "Inputs sent" from the snapshot; pre-feature runs show a visible "not snapshotted" note instead of silently rendering live values.
- Blind-eval surface untouched; blind evaluators still denied on `runs.get`.

## #232 / #227 — Docs
- `docs/gateway-onboarding.md`: onboarding checklist, required CF permissions, metadata conventions (+ CF limits), no-code vs CLI/API paths, where Fireworks credentials enter; cross-linked from both existing gateway docs.
- `project-docs/Blind Bench - AI Quality Bench Spec.md`: DRAFT one-pager — ICP, wedge, 8-step loop, Blind Bench vs Cloudflare vs Fireworks ownership, MVP success criteria (Pennie + generic), build/buy boundaries. Strategy calls marked as recommendations for Noah.

## Testing
- 195/195 tests pass locally (30 new: smoke request/verify/redaction, input snapshot + retention incl. the no-images-fallback regression).
- 6 test *files* fail locally only on the missing `convex/_generated` import (no CONVEX_DEPLOYMENT in this environment; identical on main) — CI typecheck gate is the real check.
- Known follow-up (reviewer-triaged, non-blocking): add a direct `runs.execute` test for the both-`testCaseId`+`inlineVariables` rejection guard once a generated-code test env is available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)