### PR TITLE
fix: Gateway live-smoke fixes — 5-key metadata cap, real log status derivation

### DIFF
--- a/docs/fireworks-cloudflare-routing-prototype.md
+++ b/docs/fireworks-cloudflare-routing-prototype.md
@@ -101,9 +101,12 @@ firectl create deployment accounts/<account>/models/migo-eval-ft-0001
    export CF_AIG_TOKEN=…        # gateway token
    ```
 2. Run the redacted cURL from the runbook artifact. The body carries `metadata` (and the
-   request also sends a `cf-aig-metadata` header) with: `product`, `module`, `prompt_version`,
-   `variant`, `release`, `environment`, `tenant`, `trace_id`, `session_id`.
-3. Use a **real unique** `trace_id`/`session_id` per request; the generated synthetic ids are
+   request also sends a `cf-aig-metadata` header). **The Gateway keeps at most 5 metadata
+   entries per request and silently drops the rest** (verified live 2026-07-06), so the smoke
+   sends exactly the priority set `trace_id`, `tenant`, `product`, `prompt_version`, `variant`
+   (`SMOKE_METADATA_KEYS` / `capMetadataForGateway` in `fireworksGatewaySmoke.ts`). `trace_id`
+   must always survive the cap — it is the only way to correlate the log back to the request.
+3. Use a **real unique** `trace_id` per request; the generated synthetic ids are
    deterministic placeholders for review only.
 
 ### Automated: live smoke + log verification
@@ -157,7 +160,7 @@ what `cloudflareAiGateway.ts` reads:
 | `cost_usd` | Per-request cost where reported (may be null). |
 | `duration_ms` | End-to-end latency. |
 | `usage` | input / output / total tokens. |
-| `metadata` | all metadata keys round-trip. |
+| `metadata` | the ≤5 sent keys round-trip (Gateway cap — see §3). |
 | `status` | success/error. |
 | `redaction` | if bodies are stripped by log settings, the normalizer flags them — expected/safe. |
 

--- a/docs/gateway-onboarding.md
+++ b/docs/gateway-onboarding.md
@@ -113,18 +113,24 @@ in-app onboarding page):
 | `trace_id` | Request trace id, to correlate with app logs. Use a **real unique** value per request. |
 | `session_id` | Conversation / session id where available. |
 
-**Cloudflare custom-metadata limits.** AI Gateway custom metadata is limited in
-**key count and value size**. Keep values short. Anything larger — full prompt
-text, long ids, structured context — goes in a **sidecar record keyed by
-`trace_id`**, not inline in Gateway metadata. Note that the Convex importer does
-**not yet accept a sidecar** (the local exported-JSONL adapter does — see
-`cloudflare-gateway-live-import.md` "Follow-up"), so for now keep everything you
-need for grouping inside the short metadata keys above.
+**Cloudflare custom-metadata limits.** AI Gateway stores **at most 5 custom
+metadata entries per request and silently drops the rest** (verified live
+2026-07-06: a 9-key `cf-aig-metadata` header came back in the log with only its
+first 5 keys). Choose your ≤5 keys deliberately — `trace_id` must always be one
+of them, or you lose log↔app correlation entirely. Blind Bench's default
+priority is `trace_id, tenant, product, prompt_version, variant`
+(`SMOKE_METADATA_KEYS` in `src/lib/evals/fireworksGatewaySmoke.ts`). Values must
+also stay short. Anything larger — full prompt text, long ids, structured
+context, and any keys that didn't make the cut — goes in a **sidecar record
+keyed by `trace_id`**, not inline in Gateway metadata. Note that the Convex
+importer does **not yet accept a sidecar** (the local exported-JSONL adapter
+does — see `cloudflare-gateway-live-import.md` "Follow-up"), so for now keep
+everything you need for grouping inside your 5 metadata keys.
 
 Metadata travels two ways on a request: in the request body's `metadata` field
 and in a `cf-aig-metadata` header
-(`fireworks-cloudflare-routing-prototype.md` §3). All keys round-trip into the
-Gateway log, where `src/lib/evals/cloudflareAiGateway.ts` /
+(`fireworks-cloudflare-routing-prototype.md` §3). The Gateway log records the
+first 5 header keys, where `src/lib/evals/cloudflareAiGateway.ts` /
 `convex/traceAdapters/cloudflareAiGateway.ts` read them back.
 
 ---

--- a/docs/gateway-onboarding.md
+++ b/docs/gateway-onboarding.md
@@ -97,9 +97,12 @@ Notes:
 
 ## Metadata conventions
 
-Attach these keys to every Gateway request so logs stay groupable after import.
-The convention (from `fireworks-cloudflare-routing-prototype.md` §3 and the
-in-app onboarding page):
+**Send at most 5 of these keys per request** — Cloudflare's cap, see the limits
+note below. The default set is `trace_id, tenant, product, prompt_version,
+variant` (trace_id always included); the full table is a catalog to choose
+from, with everything that doesn't make your 5 going to a sidecar. The
+convention (from `fireworks-cloudflare-routing-prototype.md` §3 and the in-app
+onboarding page):
 
 | Key | Meaning |
 | --- | --- |

--- a/src/lib/evals/cloudflareAiGateway.test.ts
+++ b/src/lib/evals/cloudflareAiGateway.test.ts
@@ -97,6 +97,31 @@ describe("Cloudflare AI Gateway adapter", () => {
     expect(row.redaction.notes).toContain("response_missing_or_redacted");
   });
 
+  it("derives status from success/status_code when no string status exists (live log shape, 2026-07-06)", () => {
+    // Field shape captured from a real /ai-gateway/gateways/{gw}/logs response.
+    const liveShape = {
+      id: "01KWVJZHEK0YQ4S0J37D840R5E",
+      created_at: "2026-07-06T11:28:26.144Z",
+      event_id: "de3a17ba-422b-4149-964b-14127f42f2ac",
+      provider: "custom-fireworks",
+      model: "accounts/fireworks/models/gpt-oss-120b",
+      path: "chat/completions",
+      duration: 381,
+      status_code: 200,
+      success: true,
+      tokens_in: 87,
+      tokens_out: 43,
+      metadata: { product: "migo", trace_id: "smoke-test-trace" },
+      cost: 0,
+      request: "",
+      response: "",
+    };
+    expect(normalizeCloudflareAiGatewayLog(liveShape).status).toBe("success");
+    expect(normalizeCloudflareAiGatewayLog({ ...liveShape, success: false }).status).toBe("error");
+    const { success: _drop, ...noSuccess } = liveShape;
+    expect(normalizeCloudflareAiGatewayLog({ ...noSuccess, status_code: 502 }).status).toBe("error");
+  });
+
   it("maps DLP and human feedback fields", () => {
     const row = normalizeCloudflareAiGatewayLog(feedbackDlpRecord);
     expect(row.dlp).toEqual({ action: "allow", flagged: false });

--- a/src/lib/evals/cloudflareAiGateway.test.ts
+++ b/src/lib/evals/cloudflareAiGateway.test.ts
@@ -120,6 +120,8 @@ describe("Cloudflare AI Gateway adapter", () => {
     expect(normalizeCloudflareAiGatewayLog({ ...liveShape, success: false }).status).toBe("error");
     const { success: _drop, ...noSuccess } = liveShape;
     expect(normalizeCloudflareAiGatewayLog({ ...noSuccess, status_code: 502 }).status).toBe("error");
+    // 3xx is not a completed generation — must not verify as success.
+    expect(normalizeCloudflareAiGatewayLog({ ...noSuccess, status_code: 302 }).status).toBe("error");
   });
 
   it("maps DLP and human feedback fields", () => {

--- a/src/lib/evals/cloudflareAiGateway.test.ts
+++ b/src/lib/evals/cloudflareAiGateway.test.ts
@@ -122,6 +122,10 @@ describe("Cloudflare AI Gateway adapter", () => {
     expect(normalizeCloudflareAiGatewayLog({ ...noSuccess, status_code: 502 }).status).toBe("error");
     // 3xx is not a completed generation — must not verify as success.
     expect(normalizeCloudflareAiGatewayLog({ ...noSuccess, status_code: 302 }).status).toBe("error");
+    // status_code outranks a contradictory success:true.
+    expect(normalizeCloudflareAiGatewayLog({ ...liveShape, status_code: 500 }).status).toBe("error");
+    // success:false outranks a 200.
+    expect(normalizeCloudflareAiGatewayLog({ ...liveShape, success: false }).status).toBe("error");
   });
 
   it("maps DLP and human feedback fields", () => {

--- a/src/lib/evals/cloudflareAiGateway.ts
+++ b/src/lib/evals/cloudflareAiGateway.ts
@@ -78,6 +78,15 @@ const getStr = (obj: unknown, paths: string[]) => str(get(obj, paths));
 const getNum = (obj: unknown, paths: string[]) => num(get(obj, paths));
 const getBool = (obj: unknown, paths: string[]) => bool(get(obj, paths));
 
+/** Derive a status string from `success`/`status_code` when the log has no string status. */
+const deriveStatus = (record: unknown): string | undefined => {
+  const success = getBool(record, ["success"]);
+  if (success !== undefined) return success ? "success" : "error";
+  const code = getNum(record, ["status_code", "response.status_code"]);
+  if (code !== undefined) return code >= 200 && code < 400 ? "success" : "error";
+  return undefined;
+};
+
 const stableHash = (value: unknown): string =>
   createHash("sha256").update(stableStringify(value)).digest("hex").slice(0, 16);
 
@@ -156,7 +165,9 @@ export function normalizeCloudflareAiGatewayLog(
     timestamp: getStr(record, ["timestamp", "created_at", "datetime"]),
     provider: getStr(record, ["provider", "request.provider", "response.provider"]),
     model: getStr(record, ["model", "request.model", "response.model"]),
-    status: getStr(record, ["status", "response.status", "error.type"]),
+    // Live Gateway logs (verified 2026-07-06) carry no string status — only
+    // `success: boolean` and `status_code: number`; derive one when absent.
+    status: getStr(record, ["status", "response.status", "error.type"]) ?? deriveStatus(record),
     request_type: getStr(record, ["request_type", "type"]),
     messages,
     output_text: outputText,

--- a/src/lib/evals/cloudflareAiGateway.ts
+++ b/src/lib/evals/cloudflareAiGateway.ts
@@ -81,11 +81,12 @@ const getBool = (obj: unknown, paths: string[]) => bool(get(obj, paths));
 /** Derive a status string from `success`/`status_code` when the log has no string status. */
 const deriveStatus = (record: unknown): string | undefined => {
   const success = getBool(record, ["success"]);
-  if (success !== undefined) return success ? "success" : "error";
+  if (success === false) return "error";
+  // 2xx only, and status_code outranks success:true — a 3xx/5xx log is not a
+  // completed generation even if the record claims success.
   const code = getNum(record, ["status_code", "response.status_code"]);
-  // 2xx only: a 3xx log is not a completed generation and must not verify as success.
   if (code !== undefined) return code >= 200 && code < 300 ? "success" : "error";
-  return undefined;
+  return success === true ? "success" : undefined;
 };
 
 const stableHash = (value: unknown): string =>

--- a/src/lib/evals/cloudflareAiGateway.ts
+++ b/src/lib/evals/cloudflareAiGateway.ts
@@ -83,7 +83,8 @@ const deriveStatus = (record: unknown): string | undefined => {
   const success = getBool(record, ["success"]);
   if (success !== undefined) return success ? "success" : "error";
   const code = getNum(record, ["status_code", "response.status_code"]);
-  if (code !== undefined) return code >= 200 && code < 400 ? "success" : "error";
+  // 2xx only: a 3xx log is not a completed generation and must not verify as success.
+  if (code !== undefined) return code >= 200 && code < 300 ? "success" : "error";
   return undefined;
 };
 

--- a/src/lib/evals/endpointAdapter.ts
+++ b/src/lib/evals/endpointAdapter.ts
@@ -16,6 +16,7 @@ import { z } from "zod/v4";
 import { AgentOutput, EvalCase, type EvalCaseInput } from "./evalCase";
 import {
   buildMetadata,
+  capMetadataForGateway,
   gatewayUrlForMode,
   loadConfig,
   modelField,
@@ -71,7 +72,8 @@ export function fireworksCandidateEndpoint(
     headers: {
       Authorization: "Bearer $FIREWORKS_API_KEY",
       "cf-aig-authorization": "Bearer $CF_AIG_TOKEN",
-      "cf-aig-metadata": JSON.stringify(buildMetadata(c)),
+      // Capped: the Gateway keeps only 5 metadata entries; trace_id must survive.
+      "cf-aig-metadata": JSON.stringify(capMetadataForGateway(buildMetadata(c))),
     },
   });
 }

--- a/src/lib/evals/fireworksGatewayPrototype.ts
+++ b/src/lib/evals/fireworksGatewayPrototype.ts
@@ -156,6 +156,43 @@ export function buildMetadata(c: PrototypeConfig): Record<string, string> {
   };
 }
 
+/**
+ * Cloudflare AI Gateway stores at most this many custom-metadata entries per request and
+ * silently drops the rest (observed live 2026-07-06: a 9-key `cf-aig-metadata` header came
+ * back in the log with only its first 5 keys).
+ */
+export const CF_METADATA_MAX_KEYS = 5;
+
+/**
+ * Keys that must survive the Gateway cap, in priority order: correlation → tenancy →
+ * eval grouping. `trace_id` first — it is the only way to match a log to its request.
+ */
+export const GATEWAY_METADATA_PRIORITY = [
+  "trace_id",
+  "tenant",
+  "product",
+  "prompt_version",
+  "variant",
+] as const;
+
+/**
+ * Reduce full routing metadata to the Gateway's key cap: priority keys first, then any
+ * remaining keys in insertion order, truncated to `CF_METADATA_MAX_KEYS`. Every builder
+ * that emits `cf-aig-metadata` must send capped metadata or risk losing `trace_id`.
+ */
+export function capMetadataForGateway(metadata: Record<string, string>): Record<string, string> {
+  const priority = GATEWAY_METADATA_PRIORITY.filter((k) => k in metadata);
+  const rest = Object.keys(metadata).filter(
+    (k) => !(GATEWAY_METADATA_PRIORITY as readonly string[]).includes(k),
+  );
+  const capped: Record<string, string> = {};
+  for (const k of [...priority, ...rest].slice(0, CF_METADATA_MAX_KEYS)) {
+    const v = metadata[k];
+    if (v !== undefined) capped[k] = v;
+  }
+  return capped;
+}
+
 /** Model string the request body should carry (compat mode prefixes the provider slug). */
 export function modelField(c: PrototypeConfig): string {
   return c.gateway_mode === "compat" ? `${c.provider_slug}/${c.fireworks_model}` : c.fireworks_model;
@@ -169,16 +206,17 @@ const SYNTHETIC_BODY_MESSAGE = "Synthetic smoke prompt — no production or cust
  * carries the Gateway token (separate from the upstream provider key).
  */
 export function buildExampleCurl(c: PrototypeConfig): string {
+  const metadata = capMetadataForGateway(buildMetadata(c));
   const body = {
     model: modelField(c),
     messages: [{ role: "user", content: SYNTHETIC_BODY_MESSAGE }],
     max_tokens: 64,
-    metadata: buildMetadata(c),
+    metadata,
   };
   const headers = [
     `-H 'Authorization: Bearer $FIREWORKS_API_KEY'`,
     `-H 'cf-aig-authorization: Bearer $CF_AIG_TOKEN'`,
-    `-H 'cf-aig-metadata: ${JSON.stringify(buildMetadata(c))}'`,
+    `-H 'cf-aig-metadata: ${JSON.stringify(metadata)}'`,
     `-H 'Content-Type: application/json'`,
   ];
   return [
@@ -198,7 +236,7 @@ export function buildVerificationChecklist(): { field: string; expect: string }[
     { field: "cost_usd", expect: "Per-request cost present where the provider reports it (may be null)." },
     { field: "duration_ms", expect: "End-to-end latency captured." },
     { field: "usage", expect: "input/output/total tokens present." },
-    { field: "metadata", expect: "product, module, prompt_version, variant, release, environment, tenant, trace_id, session_id all round-trip." },
+    { field: "metadata", expect: "the ≤5 sent keys (trace_id, tenant, product, prompt_version, variant) round-trip — the Gateway drops entries beyond 5." },
     { field: "status", expect: "Success/error status recorded." },
     { field: "redaction", expect: "If request/response bodies are stripped by log settings, normalizer flags request_missing/response_missing — expected and safe." },
   ];

--- a/src/lib/evals/fireworksGatewaySmoke.test.ts
+++ b/src/lib/evals/fireworksGatewaySmoke.test.ts
@@ -6,9 +6,12 @@ import {
 import { loadConfig, modelField, gatewayUrlForMode } from "./fireworksGatewayPrototype";
 import {
   buildSmokeRequest,
+  capMetadataForGateway,
   redactSecrets,
   redactSmokeRequest,
   verifyGatewayLog,
+  CF_METADATA_MAX_KEYS,
+  SMOKE_METADATA_KEYS,
   SMOKE_PROMPT,
   type VerifyExpectations,
 } from "./fireworksGatewaySmoke";
@@ -76,8 +79,38 @@ describe("buildSmokeRequest", () => {
     expect(req.headers["cf-aig-authorization"]).toBe("Bearer cf_SUPER_SECRET_TOKEN");
     const meta = JSON.parse(req.headers["cf-aig-metadata"] ?? "{}") as Record<string, string>;
     expect(meta.trace_id).toBe(IDS.traceId);
-    expect(meta.session_id).toBe(IDS.sessionId);
     expect(req.body.metadata.trace_id).toBe(IDS.traceId);
+  });
+
+  it("caps header metadata at the Gateway limit with trace_id first", () => {
+    const req = buildSmokeRequest(loadConfig(ENV), { ...IDS, ...SECRETS });
+    const meta = JSON.parse(req.headers["cf-aig-metadata"] ?? "{}") as Record<string, string>;
+    expect(Object.keys(meta).length).toBeLessThanOrEqual(CF_METADATA_MAX_KEYS);
+    // The keys we verify against must all survive the cap — trace_id above all.
+    expect(Object.keys(meta)[0]).toBe("trace_id");
+    for (const key of SMOKE_METADATA_KEYS) expect(meta[key]).toBeDefined();
+    expect(req.body.metadata).toEqual(meta);
+  });
+});
+
+describe("capMetadataForGateway", () => {
+  it("keeps priority keys, fills with remaining insertion order, truncates to the cap", () => {
+    const capped = capMetadataForGateway({
+      a: "1",
+      b: "2",
+      product: "p",
+      c: "3",
+      trace_id: "t",
+      tenant: "ten",
+      prompt_version: "pv",
+      variant: "v",
+    });
+    expect(Object.keys(capped)).toEqual(["trace_id", "tenant", "product", "prompt_version", "variant"]);
+  });
+
+  it("backfills below-cap metadata without inventing keys", () => {
+    const capped = capMetadataForGateway({ x: "1", trace_id: "t" });
+    expect(Object.keys(capped)).toEqual(["trace_id", "x"]);
   });
 });
 

--- a/src/lib/evals/fireworksGatewaySmoke.test.ts
+++ b/src/lib/evals/fireworksGatewaySmoke.test.ts
@@ -112,6 +112,19 @@ describe("capMetadataForGateway", () => {
     const capped = capMetadataForGateway({ x: "1", trace_id: "t" });
     expect(Object.keys(capped)).toEqual(["trace_id", "x"]);
   });
+
+  it("backfills with extras then truncates when most priority keys are missing", () => {
+    const capped = capMetadataForGateway({
+      e1: "1",
+      e2: "2",
+      trace_id: "t",
+      e3: "3",
+      e4: "4",
+      product: "p",
+      e5: "5",
+    });
+    expect(Object.keys(capped)).toEqual(["trace_id", "product", "e1", "e2", "e3"]);
+  });
 });
 
 describe("redactSmokeRequest", () => {

--- a/src/lib/evals/fireworksGatewaySmoke.ts
+++ b/src/lib/evals/fireworksGatewaySmoke.ts
@@ -13,8 +13,11 @@
 import type { NormalizedBlindBenchTrace } from "./cloudflareAiGateway";
 import {
   buildMetadata,
+  capMetadataForGateway,
   gatewayUrlForMode,
   modelField,
+  CF_METADATA_MAX_KEYS,
+  GATEWAY_METADATA_PRIORITY,
   type PrototypeConfig,
 } from "./fireworksGatewayPrototype";
 
@@ -22,34 +25,12 @@ import {
 export const SMOKE_PROMPT = "Synthetic smoke prompt — no production or customer data. Reply with: ok.";
 
 /**
- * Cloudflare AI Gateway stores at most this many custom-metadata entries per request and
- * silently drops the rest (observed live 2026-07-06: a 9-key `cf-aig-metadata` header came
- * back in the log with only its first 5 keys). Every key we need back — above all
- * `trace_id` — must be inside this cap.
+ * Metadata keys the smoke request sends and expects to round-trip through the Gateway log —
+ * the shared Gateway priority set (see `GATEWAY_METADATA_PRIORITY` / `capMetadataForGateway`
+ * in `fireworksGatewayPrototype.ts` for the 5-key Cloudflare cap they exist to survive).
  */
-export const CF_METADATA_MAX_KEYS = 5;
-
-/**
- * Metadata keys the smoke request sends and expects to round-trip through the Gateway log,
- * in priority order (correlation → tenancy → eval grouping), capped at `CF_METADATA_MAX_KEYS`.
- */
-export const SMOKE_METADATA_KEYS = [
-  "trace_id",
-  "tenant",
-  "product",
-  "prompt_version",
-  "variant",
-] as const;
-
-/**
- * Reduce full routing metadata to the Gateway's key cap: priority keys first, then any
- * remaining keys in insertion order, truncated to `CF_METADATA_MAX_KEYS`.
- */
-export function capMetadataForGateway(metadata: Record<string, string>): Record<string, string> {
-  const priority = SMOKE_METADATA_KEYS.filter((k) => k in metadata);
-  const rest = Object.keys(metadata).filter((k) => !(SMOKE_METADATA_KEYS as readonly string[]).includes(k));
-  return Object.fromEntries([...priority, ...rest].slice(0, CF_METADATA_MAX_KEYS).map((k) => [k, metadata[k]]));
-}
+export const SMOKE_METADATA_KEYS = GATEWAY_METADATA_PRIORITY;
+export { capMetadataForGateway, CF_METADATA_MAX_KEYS };
 
 export interface SmokeRequestBody {
   model: string;

--- a/src/lib/evals/fireworksGatewaySmoke.ts
+++ b/src/lib/evals/fireworksGatewaySmoke.ts
@@ -21,18 +21,35 @@ import {
 /** Synthetic prompt — never production or customer data. */
 export const SMOKE_PROMPT = "Synthetic smoke prompt — no production or customer data. Reply with: ok.";
 
-/** Metadata keys the smoke request sets and expects to round-trip through the Gateway log. */
+/**
+ * Cloudflare AI Gateway stores at most this many custom-metadata entries per request and
+ * silently drops the rest (observed live 2026-07-06: a 9-key `cf-aig-metadata` header came
+ * back in the log with only its first 5 keys). Every key we need back — above all
+ * `trace_id` — must be inside this cap.
+ */
+export const CF_METADATA_MAX_KEYS = 5;
+
+/**
+ * Metadata keys the smoke request sends and expects to round-trip through the Gateway log,
+ * in priority order (correlation → tenancy → eval grouping), capped at `CF_METADATA_MAX_KEYS`.
+ */
 export const SMOKE_METADATA_KEYS = [
+  "trace_id",
+  "tenant",
   "product",
-  "module",
   "prompt_version",
   "variant",
-  "release",
-  "environment",
-  "tenant",
-  "trace_id",
-  "session_id",
 ] as const;
+
+/**
+ * Reduce full routing metadata to the Gateway's key cap: priority keys first, then any
+ * remaining keys in insertion order, truncated to `CF_METADATA_MAX_KEYS`.
+ */
+export function capMetadataForGateway(metadata: Record<string, string>): Record<string, string> {
+  const priority = SMOKE_METADATA_KEYS.filter((k) => k in metadata);
+  const rest = Object.keys(metadata).filter((k) => !(SMOKE_METADATA_KEYS as readonly string[]).includes(k));
+  return Object.fromEntries([...priority, ...rest].slice(0, CF_METADATA_MAX_KEYS).map((k) => [k, metadata[k]]));
+}
 
 export interface SmokeRequestBody {
   model: string;
@@ -76,10 +93,11 @@ export function buildSmokeMetadata(
  * use `redactSmokeRequest` before printing or persisting.
  * - `Authorization` — upstream Fireworks key.
  * - `cf-aig-authorization` — Gateway edge token.
- * - `cf-aig-metadata` — routing metadata (also mirrored in the body).
+ * - `cf-aig-metadata` — routing metadata (also mirrored in the body), capped to the
+ *   Gateway's `CF_METADATA_MAX_KEYS` limit with `trace_id` guaranteed to survive.
  */
 export function buildSmokeRequest(config: PrototypeConfig, params: SmokeRequestParams): SmokeRequest {
-  const metadata = buildSmokeMetadata(config, params);
+  const metadata = capMetadataForGateway(buildSmokeMetadata(config, params));
   return {
     url: gatewayUrlForMode(config),
     headers: {

--- a/src/routes/orgs/GatewayOnboarding.tsx
+++ b/src/routes/orgs/GatewayOnboarding.tsx
@@ -86,19 +86,20 @@ const PRODUCTS = [
   },
 ] as const;
 
+// Cloudflare keeps at most 5 metadata entries per request and silently drops the
+// rest, so the default set is exactly these five, trace_id first. Everything else
+// (module, release, environment, session_id, …) belongs in a sidecar keyed by trace_id.
 const METADATA_FIELDS = [
+  { key: "trace_id", desc: "Request trace id — always first; it is the only log↔app correlation key." },
+  { key: "tenant", desc: "Tenant label for attribution and per-tenant isolation." },
   { key: "product", desc: "Top-level product, e.g. migo / eavesly." },
-  { key: "module", desc: "Sub-surface within the product, e.g. assistant / summarizer." },
   { key: "prompt_version", desc: "Version tag of the prompt that produced the output." },
   { key: "variant", desc: "control / candidate (which arm of an A/B)." },
-  { key: "release", desc: "App release or deploy identifier." },
-  { key: "environment", desc: "prod / staging / dev — keep prod data customer-scoped." },
-  { key: "trace_id", desc: "Request trace id, where available, to correlate with app logs." },
-  { key: "session_id", desc: "Conversation / session id, where available." },
 ] as const;
 
 const CLI_SNIPPET = `# Request path: attach compact metadata before the AI Gateway call
-METADATA='{"product":"migo","module":"assistant","prompt_version":"2026-06-01","variant":"control","environment":"prod","trace_id":"<trace>"}'
+# (max 5 keys — Cloudflare drops the rest; trace_id must be one of them)
+METADATA='{"trace_id":"<trace>","tenant":"<tenant>","product":"migo","prompt_version":"2026-06-01","variant":"control"}'
 curl https://gateway.ai.cloudflare.com/v1/<account>/<gateway>/openai/chat/completions
   -H "cf-aig-metadata: $METADATA"
   -d '{ "model": "gpt-4o-mini", "messages": [ ... ] }'


### PR DESCRIPTION
Follow-up to #256 / issue #230, from the first live smoke run against a real Cloudflare AI Gateway (Fireworks behind the `custom-fireworks` custom provider). Three integration facts differed from the docs the code was written against:

1. **Cloudflare keeps at most 5 custom-metadata entries per request** and silently drops the rest — our 9-key header lost `trace_id` (key 8), so log polling could never correlate the request. `capMetadataForGateway` (in `fireworksGatewayPrototype.ts`, shared by the smoke, the example cURL, and the live endpoint adapter) now sends exactly `trace_id, tenant, product, prompt_version, variant`, trace_id first. Onboarding UI snippet + both docs corrected.
2. **Live Gateway logs have no string `status` field** — only `success: boolean` and `status_code: number`. The normalizer now derives status: `success:false` → error; else 2xx-only on `status_code`; else `success:true`. Regression tests use the captured live log shape.
3. Fireworks is **not** a native Gateway provider (`Invalid provider`, code 2008) — routing requires an AI Gateway **custom provider** (slug `custom-fireworks`, base URL `https://api.fireworks.ai/inference/v1/`), which is cleanly supported via the existing `FIREWORKS_PROVIDER_SLUG` env override; no code change needed, docs already cover it.

## Live validation

Run against the migo gateway (synthetic data only, `tenant=smoke-synthetic-tenant`):

```
Sending synthetic smoke request (trace_id=smoke-56a25378-…)…
Gateway responded HTTP 200.
Polling Gateway logs for trace_id (timeout 60s)…
Verification: PASS
  note: cost_usd present: 0
  note: body redaction observed … — expected under strict log settings, not fatal
```

Two consecutive PASSes after the refactor. That completes issue #230's acceptance criteria with live evidence: request routed through the Gateway, log captured with provider/model/tokens/latency/metadata, correlated by trace_id.

## Testing

- 214/214 tests pass locally (+2 test files worth of new coverage: cap priority/backfill/truncation, live-log status derivation incl. 302/500/contradictory-success cases).
- Same 6 pre-existing convex-test file skips (missing `convex/_generated` locally); CI typecheck gate is authoritative.
- Codex-reviewed: two rounds of findings applied (cap shared across all request builders, status_code precedence), final verdict Ready-to-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)