### PR TITLE
feat: in-app trace materialization + per-org quality scorecard (#259)

### DIFF
--- a/convex/gatewayImport.ts
+++ b/convex/gatewayImport.ts
@@ -181,36 +181,53 @@ export const importGatewayLogs = action({
  */
 const MATERIALIZE_CAP = 500;
 
-type MaterializeCandidate = {
-  importId: Id<"traceImports">;
-  alreadyMaterialized: boolean;
-  rawPayloadStorageId?: Id<"_storage">;
+type MaterializeCandidates = {
+  /** Unmaterialized rows with a payload, capped at MATERIALIZE_CAP. */
+  ready: { importId: Id<"traceImports">; rawPayloadStorageId: Id<"_storage"> }[];
+  alreadyMaterialized: number;
+  missingPayload: number;
 };
 
 /**
- * Load up to `MATERIALIZE_CAP` cloudflare_ai_gateway import rows for the
- * project and classify each (already materialized / missing payload / ready).
- * Auth-gated so the action never touches storage for an unauthorized caller.
+ * Classify every cloudflare_ai_gateway import row for the project and return
+ * the rows still needing materialization (capped at `MATERIALIZE_CAP` per
+ * call, so re-running drains backlogs larger than the cap). Counts cover the
+ * whole project so the caller's summary stays accurate. Auth-gated so the
+ * action never touches storage for an unauthorized caller.
  */
 export const loadMaterializationCandidates = internalQuery({
   args: { projectId: v.id("projects") },
-  handler: async (ctx, args): Promise<MaterializeCandidate[]> => {
+  handler: async (ctx, args): Promise<MaterializeCandidates> => {
     await requireProjectRole(ctx, args.projectId, ["owner", "editor"]);
+    // Full scan of the project's import rows — they are small identity rows
+    // and the import path caps batches at 5,000 lines; revisit if projects
+    // accumulate orders of magnitude more.
     const rows = await ctx.db
       .query("traceImports")
       .withIndex("by_project", (q) => q.eq("projectId", args.projectId))
       .filter((q) => q.eq(q.field("source"), SOURCE))
-      .take(MATERIALIZE_CAP);
-    return rows.map((r) => ({
-      importId: r._id,
-      alreadyMaterialized: r.evalCaseId !== undefined,
-      rawPayloadStorageId: r.rawPayloadStorageId,
-    }));
+      .collect();
+    const result: MaterializeCandidates = {
+      ready: [],
+      alreadyMaterialized: 0,
+      missingPayload: 0,
+    };
+    for (const r of rows) {
+      if (r.evalCaseId !== undefined) result.alreadyMaterialized++;
+      else if (!r.rawPayloadStorageId) result.missingPayload++;
+      else if (result.ready.length < MATERIALIZE_CAP)
+        result.ready.push({
+          importId: r._id,
+          rawPayloadStorageId: r.rawPayloadStorageId,
+        });
+    }
+    return result;
   },
 });
 
 const evalCaseRowValidator = v.object({
   importId: v.id("traceImports"),
+  source: v.literal("production_log"),
   product: v.string(),
   title: v.string(),
   messages: v.array(v.object({ role: v.string(), content: v.string() })),
@@ -251,7 +268,6 @@ export const insertMaterializedCases = internalMutation({
       const evalCaseId = await ctx.db.insert("evalCases", {
         projectId: args.projectId,
         traceImportId: importId,
-        source: "production_log",
         createdById: userId,
         ...fields,
       });
@@ -284,25 +300,17 @@ export const materializeImportedTraces = action({
     missingPayload: number;
     failed: number;
   }> => {
-    const candidates: MaterializeCandidate[] = await ctx.runQuery(
+    const candidates: MaterializeCandidates = await ctx.runQuery(
       internal.gatewayImport.loadMaterializationCandidates,
       { projectId: args.projectId },
     );
 
-    let alreadyMaterialized = 0;
-    let missingPayload = 0;
+    const { alreadyMaterialized } = candidates;
+    let missingPayload = candidates.missingPayload;
     let failed = 0;
     const rows: (typeof evalCaseRowValidator)["type"][] = [];
 
-    for (const candidate of candidates) {
-      if (candidate.alreadyMaterialized) {
-        alreadyMaterialized++;
-        continue;
-      }
-      if (!candidate.rawPayloadStorageId) {
-        missingPayload++;
-        continue;
-      }
+    for (const candidate of candidates.ready) {
       try {
         const blob = await ctx.storage.get(candidate.rawPayloadStorageId);
         if (!blob) {

--- a/convex/gatewayImport.ts
+++ b/convex/gatewayImport.ts
@@ -1,15 +1,22 @@
 import { v } from "convex/values";
-import { action, internalMutation } from "./_generated/server";
+import {
+  action,
+  internalMutation,
+  internalQuery,
+  query,
+} from "./_generated/server";
 import { internal } from "./_generated/api";
 import type { Id } from "./_generated/dataModel";
 import { requireProjectRole } from "./lib/auth";
 import {
   DEFAULT_LIMITS,
   MAX_REPORTED_INVALID_LINES,
+  normalizeGatewayLog,
   parseGatewayJsonl,
   summarizeTraces,
 } from "./traceAdapters/cloudflareAiGateway";
 import type { TraceAggregate } from "./traceAdapters/cloudflareAiGateway";
+import { materializeEvalCase } from "./traceAdapters/materializeEvalCase";
 
 const SOURCE = "cloudflare_ai_gateway" as const;
 
@@ -159,6 +166,195 @@ export const importGatewayLogs = action({
       invalidLines: invalidLines.slice(0, MAX_REPORTED_INVALID_LINES),
       truncated,
       ...agg,
+    };
+  },
+});
+
+// ===========================================================================
+// #259: Materialize imported Cloudflare AI Gateway traces into eval cases.
+// ===========================================================================
+
+/**
+ * Per-invocation cap on how many cloudflare_ai_gateway trace-import rows a
+ * single `materializeImportedTraces` call considers. Materialization is
+ * idempotent, so the UI can re-run to drain a backlog larger than this cap.
+ */
+const MATERIALIZE_CAP = 500;
+
+type MaterializeCandidate = {
+  importId: Id<"traceImports">;
+  alreadyMaterialized: boolean;
+  rawPayloadStorageId?: Id<"_storage">;
+};
+
+/**
+ * Load up to `MATERIALIZE_CAP` cloudflare_ai_gateway import rows for the
+ * project and classify each (already materialized / missing payload / ready).
+ * Auth-gated so the action never touches storage for an unauthorized caller.
+ */
+export const loadMaterializationCandidates = internalQuery({
+  args: { projectId: v.id("projects") },
+  handler: async (ctx, args): Promise<MaterializeCandidate[]> => {
+    await requireProjectRole(ctx, args.projectId, ["owner", "editor"]);
+    const rows = await ctx.db
+      .query("traceImports")
+      .withIndex("by_project", (q) => q.eq("projectId", args.projectId))
+      .filter((q) => q.eq(q.field("source"), SOURCE))
+      .take(MATERIALIZE_CAP);
+    return rows.map((r) => ({
+      importId: r._id,
+      alreadyMaterialized: r.evalCaseId !== undefined,
+      rawPayloadStorageId: r.rawPayloadStorageId,
+    }));
+  },
+});
+
+const evalCaseRowValidator = v.object({
+  importId: v.id("traceImports"),
+  product: v.string(),
+  title: v.string(),
+  messages: v.array(v.object({ role: v.string(), content: v.string() })),
+  outputText: v.optional(v.string()),
+  scorerIds: v.array(v.string()),
+  requestMissing: v.boolean(),
+  responseMissing: v.boolean(),
+  model: v.optional(v.string()),
+  provider: v.optional(v.string()),
+  timestamp: v.optional(v.string()),
+  inputTokens: v.optional(v.number()),
+  outputTokens: v.optional(v.number()),
+  costUsd: v.optional(v.number()),
+  durationMs: v.optional(v.number()),
+});
+
+/**
+ * Insert eval cases + link them back to their trace-import rows, transactionally.
+ * Re-checks `evalCaseId` per row so a concurrent run can't double-insert
+ * (idempotent). Returns how many rows were actually materialized.
+ */
+export const insertMaterializedCases = internalMutation({
+  args: {
+    projectId: v.id("projects"),
+    rows: v.array(evalCaseRowValidator),
+  },
+  handler: async (ctx, args): Promise<{ materialized: number }> => {
+    const { userId } = await requireProjectRole(ctx, args.projectId, [
+      "owner",
+      "editor",
+    ]);
+    let materialized = 0;
+    for (const row of args.rows) {
+      const imp = await ctx.db.get(row.importId);
+      // Skip if the import vanished, moved projects, or was already linked.
+      if (!imp || imp.projectId !== args.projectId || imp.evalCaseId) continue;
+      const { importId, ...fields } = row;
+      const evalCaseId = await ctx.db.insert("evalCases", {
+        projectId: args.projectId,
+        traceImportId: importId,
+        source: "production_log",
+        createdById: userId,
+        ...fields,
+      });
+      await ctx.db.patch(importId, { evalCaseId });
+      materialized++;
+    }
+    return { materialized };
+  },
+});
+
+/**
+ * Materialize this project's imported Cloudflare AI Gateway traces into runnable
+ * eval cases. Idempotent: rows already linked to an eval case are skipped, so
+ * re-running materializes nothing new. Considers at most `MATERIALIZE_CAP` rows
+ * per call.
+ *
+ * An action (not a mutation) because reading the persisted raw payload from
+ * storage is action-only. Per-row parse/normalize failures are counted
+ * (`failed`) and never abort the batch; error handling surfaces counts only,
+ * never trace content.
+ */
+export const materializeImportedTraces = action({
+  args: { projectId: v.id("projects") },
+  handler: async (
+    ctx,
+    args,
+  ): Promise<{
+    materialized: number;
+    alreadyMaterialized: number;
+    missingPayload: number;
+    failed: number;
+  }> => {
+    const candidates: MaterializeCandidate[] = await ctx.runQuery(
+      internal.gatewayImport.loadMaterializationCandidates,
+      { projectId: args.projectId },
+    );
+
+    let alreadyMaterialized = 0;
+    let missingPayload = 0;
+    let failed = 0;
+    const rows: (typeof evalCaseRowValidator)["type"][] = [];
+
+    for (const candidate of candidates) {
+      if (candidate.alreadyMaterialized) {
+        alreadyMaterialized++;
+        continue;
+      }
+      if (!candidate.rawPayloadStorageId) {
+        missingPayload++;
+        continue;
+      }
+      try {
+        const blob = await ctx.storage.get(candidate.rawPayloadStorageId);
+        if (!blob) {
+          missingPayload++;
+          continue;
+        }
+        const raw = JSON.parse(await blob.text());
+        const trace = normalizeGatewayLog(raw);
+        const fields = materializeEvalCase(trace, raw);
+        rows.push({ importId: candidate.importId, ...fields });
+      } catch {
+        // Management-safe: count only, never echo trace content.
+        failed++;
+      }
+    }
+
+    let materialized = 0;
+    if (rows.length > 0) {
+      const res: { materialized: number } = await ctx.runMutation(
+        internal.gatewayImport.insertMaterializedCases,
+        { projectId: args.projectId, rows },
+      );
+      materialized = res.materialized;
+    }
+
+    return { materialized, alreadyMaterialized, missingPayload, failed };
+  },
+});
+
+/**
+ * Progress of materialization over the project's cloudflare_ai_gateway imports:
+ * how many exist and how many have been materialized into an eval case.
+ */
+export const materializationStatus = query({
+  args: { projectId: v.id("projects") },
+  handler: async (
+    ctx,
+    args,
+  ): Promise<{ total: number; materialized: number }> => {
+    await requireProjectRole(ctx, args.projectId, [
+      "owner",
+      "editor",
+      "evaluator",
+    ]);
+    const rows = await ctx.db
+      .query("traceImports")
+      .withIndex("by_project", (q) => q.eq("projectId", args.projectId))
+      .filter((q) => q.eq(q.field("source"), SOURCE))
+      .collect();
+    return {
+      total: rows.length,
+      materialized: rows.filter((r) => r.evalCaseId !== undefined).length,
     };
   },
 });

--- a/convex/lib/scorecardAggregation.test.ts
+++ b/convex/lib/scorecardAggregation.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import {
+  foldScorecardResults,
+  type ScorecardResultRow,
+} from "./scorecardAggregation";
+
+// Pure fold tests — no `_generated`, no convex runtime.
+
+const rows: ScorecardResultRow[] = [
+  {
+    caseId: "c1",
+    product: "support",
+    score: 1,
+    passed: true,
+    hardFailed: false,
+    failingScorers: [],
+  },
+  {
+    caseId: "c2",
+    product: "support",
+    score: 0.5,
+    passed: false,
+    hardFailed: false,
+    failingScorers: ["tone_customer_fit"],
+  },
+  {
+    caseId: "c3",
+    product: "voice",
+    score: 0,
+    passed: false,
+    hardFailed: true,
+    failingScorers: ["no_hallucinated_data", "tone_customer_fit"],
+  },
+  {
+    caseId: "c4",
+    product: "voice",
+    score: 0.5,
+    passed: false,
+    hardFailed: false,
+    failingScorers: ["tone_customer_fit"],
+  },
+];
+
+describe("foldScorecardResults", () => {
+  it("rolls up per-product cases/passed/hardFailed/meanScore", () => {
+    const { products } = foldScorecardResults(rows);
+    expect(products).toEqual([
+      { product: "support", cases: 2, passed: 1, hardFailed: 0, meanScore: 0.75 },
+      { product: "voice", cases: 2, passed: 0, hardFailed: 1, meanScore: 0.25 },
+    ]);
+  });
+
+  it("counts soft failures by scorer, excluding hard-failed results", () => {
+    const { softFailuresByScorer } = foldScorecardResults(rows);
+    // c3 is hard-failed so its tone failure is NOT counted here; only c2 + c4.
+    expect(softFailuresByScorer).toEqual([
+      { scorer: "tone_customer_fit", count: 2 },
+    ]);
+  });
+
+  it("lists hard-fail findings with case id, product, and scorers", () => {
+    const { hardFailFindings } = foldScorecardResults(rows);
+    expect(hardFailFindings).toEqual([
+      {
+        caseId: "c3",
+        product: "voice",
+        scorers: ["no_hallucinated_data", "tone_customer_fit"],
+      },
+    ]);
+  });
+
+  it("computes totals matching the summary shape", () => {
+    const { totals } = foldScorecardResults(rows);
+    expect(totals).toEqual({
+      cases: 4,
+      passed: 1,
+      hardFailed: 1,
+      meanScore: 0.5,
+    });
+  });
+
+  it("sorts soft failures by count desc then scorer key", () => {
+    const many: ScorecardResultRow[] = [
+      { caseId: "a", product: "p", score: 0, passed: false, hardFailed: false, failingScorers: ["b_scorer"] },
+      { caseId: "b", product: "p", score: 0, passed: false, hardFailed: false, failingScorers: ["a_scorer", "z_scorer"] },
+      { caseId: "c", product: "p", score: 0, passed: false, hardFailed: false, failingScorers: ["z_scorer"] },
+    ];
+    const { softFailuresByScorer } = foldScorecardResults(many);
+    expect(softFailuresByScorer).toEqual([
+      { scorer: "z_scorer", count: 2 },
+      { scorer: "a_scorer", count: 1 },
+      { scorer: "b_scorer", count: 1 },
+    ]);
+  });
+
+  it("returns empty rollups for no results", () => {
+    expect(foldScorecardResults([])).toEqual({
+      products: [],
+      softFailuresByScorer: [],
+      hardFailFindings: [],
+      totals: { cases: 0, passed: 0, hardFailed: 0, meanScore: 0 },
+    });
+  });
+});

--- a/convex/lib/scorecardAggregation.ts
+++ b/convex/lib/scorecardAggregation.ts
@@ -1,0 +1,120 @@
+/**
+ * Pure fold from scorecard result rows -> the per-product / per-scorer rollups
+ * the org scorecard view renders. Node-free and `_generated`-free so it runs in
+ * the Convex runtime and in plain vitest.
+ *
+ * Splits failures cleanly: a hard-failed result contributes a `hardFailFindings`
+ * entry (case id + product + the scorers that failed) and is excluded from
+ * `softFailuresByScorer`; a soft (non-hard) failing result contributes its
+ * failing scorer keys to `softFailuresByScorer`. No message/output content —
+ * ids, products, scorer keys, and numbers only.
+ */
+
+export interface ScorecardResultRow {
+  caseId: string;
+  product: string;
+  score: number;
+  passed: boolean;
+  hardFailed: boolean;
+  failingScorers: string[];
+}
+
+export interface ProductRollup {
+  product: string;
+  cases: number;
+  passed: number;
+  hardFailed: number;
+  meanScore: number;
+}
+
+export interface ScorecardFold {
+  products: ProductRollup[];
+  softFailuresByScorer: { scorer: string; count: number }[];
+  hardFailFindings: { caseId: string; product: string; scorers: string[] }[];
+  totals: {
+    cases: number;
+    passed: number;
+    hardFailed: number;
+    meanScore: number;
+  };
+}
+
+const mean = (sum: number, n: number): number => (n === 0 ? 0 : sum / n);
+
+export function foldScorecardResults(
+  rows: readonly ScorecardResultRow[],
+): ScorecardFold {
+  const byProduct = new Map<
+    string,
+    { cases: number; passed: number; hardFailed: number; scoreSum: number }
+  >();
+  const softCounts = new Map<string, number>();
+  const hardFailFindings: ScorecardFold["hardFailFindings"] = [];
+
+  let passed = 0;
+  let hardFailed = 0;
+  let scoreSum = 0;
+
+  for (const r of rows) {
+    scoreSum += r.score;
+    if (r.passed) passed++;
+    if (r.hardFailed) hardFailed++;
+
+    const p = byProduct.get(r.product) ?? {
+      cases: 0,
+      passed: 0,
+      hardFailed: 0,
+      scoreSum: 0,
+    };
+    p.cases++;
+    p.scoreSum += r.score;
+    if (r.passed) p.passed++;
+    if (r.hardFailed) p.hardFailed++;
+    byProduct.set(r.product, p);
+
+    if (r.hardFailed) {
+      hardFailFindings.push({
+        caseId: r.caseId,
+        product: r.product,
+        scorers: [...r.failingScorers],
+      });
+    } else {
+      for (const scorer of r.failingScorers) {
+        softCounts.set(scorer, (softCounts.get(scorer) ?? 0) + 1);
+      }
+    }
+  }
+
+  const products: ProductRollup[] = [...byProduct.entries()]
+    .map(([product, p]) => ({
+      product,
+      cases: p.cases,
+      passed: p.passed,
+      hardFailed: p.hardFailed,
+      meanScore: mean(p.scoreSum, p.cases),
+    }))
+    .sort((a, b) => a.product.localeCompare(b.product));
+
+  const softFailuresByScorer = [...softCounts.entries()]
+    .map(([scorer, count]) => ({ scorer, count }))
+    // Most frequent first; ties broken by scorer key for determinism.
+    .sort((a, b) => b.count - a.count || a.scorer.localeCompare(b.scorer));
+
+  // Stable, deterministic ordering for findings (product, then case id).
+  hardFailFindings.sort(
+    (a, b) =>
+      a.product.localeCompare(b.product) || a.caseId.localeCompare(b.caseId),
+  );
+
+  return {
+    products,
+    softFailuresByScorer,
+    hardFailFindings,
+    totals: {
+      cases: rows.length,
+      passed,
+      hardFailed,
+      meanScore: mean(scoreSum, rows.length),
+    },
+  };
+}

--- a/convex/lib/scorecardScoring.ts
+++ b/convex/lib/scorecardScoring.ts
@@ -1,0 +1,314 @@
+/**
+ * Convex-safe port of the deterministic scorer pack from
+ * `src/lib/evals/scorers.ts` + the `aggregateScores` verdict fold from
+ * `src/lib/evals/evalCase.ts`.
+ *
+ * Ported (not imported) for the same reason `convex/traceAdapters/
+ * cloudflareAiGateway.ts` re-implements the src adapter: keep the Convex bundle
+ * self-contained and free of the `../src` boundary + zod's `toJSONSchema`
+ * (evaluated at import in evalCase.ts). Logic mirrors the src scorers 1:1;
+ * only the LLM-judge adapter and zod parsing are dropped. Grading semantics
+ * (score, passed, hard_fail) and `aggregateScores` are byte-for-byte the same,
+ * so a scorecard verdict matches the local/CI runner.
+ */
+
+// --- minimal shapes ----------------------------------------------------------
+
+export interface ScorecardAgentOutput {
+  text?: string;
+  tool_calls?: { name: string; args?: Record<string, unknown> }[];
+  escalated?: boolean;
+  raw?: unknown;
+}
+
+/**
+ * Minimal case view a scorer reads. Production-log eval cases only persist
+ * messages/output, so `expected`/`input` are effectively empty here — the
+ * scorers that consult them (correct_escalation, groundedness) degrade to a
+ * pass, which is the intended behavior for a sparse production-log case.
+ */
+export interface ScorecardCase {
+  scorerIds: string[];
+  expected?: {
+    expected_escalation?: { should_escalate: boolean } | null;
+  };
+  input?: {
+    context?: Record<string, unknown>;
+    variables?: Record<string, unknown>;
+  };
+  /** Per-scorer config keyed by scorer id (optional; usually absent). */
+  scorerConfig?: Record<string, Record<string, unknown>>;
+}
+
+export interface ScorerResult {
+  scorer: string;
+  score: number;
+  passed: boolean;
+  reason: string;
+  hard_fail: boolean;
+}
+
+// --- helpers (ported) --------------------------------------------------------
+
+const strArr = (v: unknown): string[] =>
+  Array.isArray(v) ? v.filter((x): x is string => typeof x === "string") : [];
+const num = (v: unknown): number | undefined =>
+  typeof v === "number" ? v : undefined;
+const outputText = (o: ScorecardAgentOutput): string => o.text ?? "";
+const outputBlob = (o: ScorecardAgentOutput): string =>
+  JSON.stringify({ text: o.text ?? "", tool_calls: o.tool_calls ?? [] });
+const lc = (s: string) => s.toLowerCase();
+const findAny = (hay: string, needles: string[]) =>
+  needles.filter((n) => lc(hay).includes(lc(n)));
+
+const mk = (
+  scorer: string,
+  over: Pick<ScorerResult, "score" | "passed" | "reason"> &
+    Partial<ScorerResult>,
+): ScorerResult => ({ scorer, hard_fail: false, ...over });
+
+type Config = Record<string, unknown>;
+type Scorer = (c: ScorecardCase, o: ScorecardAgentOutput) => ScorerResult;
+type Factory = (config: Config) => Scorer;
+
+/** Privacy + tool-safety scorers — violations are hard fails. */
+export const HARD_FAIL_SCORERS = new Set([
+  "no_hallucinated_data",
+  "no_cross_context_leakage",
+  "read_only_no_destructive_tool",
+]);
+
+// --- deterministic scorers (ported 1:1) --------------------------------------
+
+const requiredClarification: Factory = (config) => (_c, output) => {
+  const cues = strArr(config.keywords);
+  const keywords = cues.length
+    ? cues
+    : ["?", "could you", "can you", "which ", "clarif", "do you mean"];
+  const hit = findAny(outputText(output), keywords);
+  const passed = hit.length > 0;
+  return mk("required_clarification", {
+    score: passed ? 1 : 0,
+    passed,
+    reason: passed
+      ? `Asked for clarification (matched: ${hit[0]}).`
+      : "Did not ask a clarifying question.",
+  });
+};
+
+const mustAssertions: Factory = (config) => (_c, output) => {
+  const keywords = strArr(config.keywords);
+  const missing = keywords.filter(
+    (k) => !lc(outputText(output)).includes(lc(k)),
+  );
+  const passed = missing.length === 0;
+  return mk("must_assertions", {
+    score: keywords.length === 0 ? 1 : passed ? 1 : 0,
+    passed,
+    reason: passed
+      ? "All required assertions present."
+      : `Missing required content: ${missing.join(", ")}.`,
+  });
+};
+
+const noHallucinatedData: Factory = (config) => (_c, output) => {
+  const phrases = strArr(config.phrases);
+  const hits = findAny(outputText(output), phrases);
+  const passed = hits.length === 0;
+  return mk("no_hallucinated_data", {
+    score: passed ? 1 : 0,
+    passed,
+    hard_fail: !passed,
+    reason: passed
+      ? "No hallucinated/forbidden phrases."
+      : `Emitted forbidden content: ${hits.join(", ")}.`,
+  });
+};
+
+const noCrossContextLeakage: Factory = (config) => (_c, output) => {
+  const forbidden = strArr(config.forbidden);
+  const hits = findAny(outputBlob(output), forbidden);
+  const passed = hits.length === 0;
+  return mk("no_cross_context_leakage", {
+    score: passed ? 1 : 0,
+    passed,
+    hard_fail: !passed,
+    reason: passed
+      ? "No cross-context data leakage."
+      : `Leaked forbidden data: ${hits.join(", ")}.`,
+  });
+};
+
+const readOnlyNoDestructiveTool: Factory = (config) => (_c, output) => {
+  const forbidden = strArr(config.forbiddenTools).map(lc);
+  const called = (output.tool_calls ?? [])
+    .map((t) => t.name)
+    .filter((n) => forbidden.includes(lc(n)));
+  const passed = called.length === 0;
+  return mk("read_only_no_destructive_tool", {
+    score: passed ? 1 : 0,
+    passed,
+    hard_fail: !passed,
+    reason: passed
+      ? "No destructive tool calls."
+      : `Called forbidden tool(s): ${called.join(", ")}.`,
+  });
+};
+
+const correctEscalation: Factory = (config) => (evalCase, output) => {
+  const expected = evalCase.expected?.expected_escalation;
+  if (!expected) {
+    return mk("correct_escalation", {
+      score: 1,
+      passed: true,
+      reason: "Escalation not relevant to this case.",
+    });
+  }
+  const escalationTools = strArr(config.escalationTools).map(lc);
+  const calledEscalation = (output.tool_calls ?? []).some((t) =>
+    escalationTools.length
+      ? escalationTools.includes(lc(t.name))
+      : lc(t.name).includes("escalat"),
+  );
+  const actual = output.escalated ?? calledEscalation;
+  const passed = actual === expected.should_escalate;
+  return mk("correct_escalation", {
+    score: passed ? 1 : 0,
+    passed,
+    reason: passed
+      ? `Escalation handled correctly (should_escalate=${expected.should_escalate}).`
+      : `Expected should_escalate=${expected.should_escalate}, got ${actual}.`,
+  });
+};
+
+const AMOUNT = /\$\s?\d[\d,]*(?:\.\d{2})?/g;
+const normAmount = (s: string) => s.replace(/[$,\s]/g, "");
+const groundedness: Factory = (config) => (evalCase, output) => {
+  const snippets = [
+    ...strArr(config.evidence),
+    JSON.stringify(evalCase.input?.context ?? {}),
+    JSON.stringify(evalCase.input?.variables ?? {}),
+  ].join(" ");
+  const grounded = new Set((snippets.match(AMOUNT) ?? []).map(normAmount));
+  const claimed = outputText(output).match(AMOUNT) ?? [];
+  const ungrounded = claimed.filter((c) => !grounded.has(normAmount(c)));
+  const passed = ungrounded.length === 0;
+  return mk("groundedness", {
+    score: passed ? 1 : 0,
+    passed,
+    reason: passed
+      ? "All cited figures are grounded in evidence."
+      : `Ungrounded figures: ${ungrounded.join(", ")}.`,
+  });
+};
+
+const toneCustomerFit: Factory = (config) => (_c, output) => {
+  const banned = strArr(config.banned).length
+    ? strArr(config.banned)
+    : ["calm down", "that's your problem", "obviously", "as i said", "whatever"];
+  const require = strArr(config.require);
+  const text = outputText(output);
+  const rude = findAny(text, banned);
+  const missing = require.filter((r) => !lc(text).includes(lc(r)));
+  const passed = rude.length === 0 && missing.length === 0;
+  return mk("tone_customer_fit", {
+    score: passed ? 1 : 0,
+    passed,
+    reason: passed
+      ? "Tone fits customer support."
+      : rude.length
+        ? `Rude/dismissive phrasing: ${rude.join(", ")}.`
+        : `Missing expected tone cues: ${missing.join(", ")}.`,
+  });
+};
+
+const costLatencyThreshold: Factory = (config) => (_c, output) => {
+  const raw = (output.raw ?? {}) as Record<string, unknown>;
+  const cost = num(raw.cost_usd);
+  const latency = num(raw.latency_ms);
+  const tokens = num(raw.tokens);
+  if (cost === undefined && latency === undefined && tokens === undefined) {
+    return mk("cost_latency_threshold", {
+      score: 1,
+      passed: true,
+      reason: "No cost/latency metadata on output.raw; skipped.",
+    });
+  }
+  const fails: string[] = [];
+  const maxCost = num(config.maxCostUsd);
+  const maxLatency = num(config.maxLatencyMs);
+  const maxTokens = num(config.maxTokens);
+  if (maxCost !== undefined && cost !== undefined && cost > maxCost)
+    fails.push(`cost $${cost} > $${maxCost}`);
+  if (maxLatency !== undefined && latency !== undefined && latency > maxLatency)
+    fails.push(`latency ${latency}ms > ${maxLatency}ms`);
+  if (maxTokens !== undefined && tokens !== undefined && tokens > maxTokens)
+    fails.push(`tokens ${tokens} > ${maxTokens}`);
+  const passed = fails.length === 0;
+  return mk("cost_latency_threshold", {
+    score: passed ? 1 : 0,
+    passed,
+    reason: passed ? "Within cost/latency budget." : fails.join("; "),
+  });
+};
+
+const SCORER_REGISTRY: Record<string, Factory> = {
+  required_clarification: requiredClarification,
+  must_assertions: mustAssertions,
+  no_hallucinated_data: noHallucinatedData,
+  no_cross_context_leakage: noCrossContextLeakage,
+  read_only_no_destructive_tool: readOnlyNoDestructiveTool,
+  correct_escalation: correctEscalation,
+  groundedness,
+  tone_customer_fit: toneCustomerFit,
+  cost_latency_threshold: costLatencyThreshold,
+};
+
+/**
+ * Combine scorer results into a verdict. Ported verbatim from
+ * `aggregateScores` in src/lib/evals/evalCase.ts. Hard-fail dominates.
+ */
+export function aggregateScores(scores: ScorerResult[]): {
+  score: number;
+  passed: boolean;
+  hardFailed: boolean;
+} {
+  const hardFailed = scores.some((s) => s.hard_fail && !s.passed);
+  const mean =
+    scores.length === 0
+      ? 0
+      : scores.reduce((sum, s) => sum + s.score, 0) / scores.length;
+  return {
+    score: mean,
+    passed: scores.length > 0 && scores.every((s) => s.passed) && !hardFailed,
+    hardFailed,
+  };
+}
+
+/**
+ * Run a case's assigned deterministic scorers against an output and produce the
+ * per-case verdict + the keys of every scorer that did not pass. Unknown scorer
+ * ids are skipped defensively (never throw during a batch scorecard run).
+ */
+export function scoreCase(
+  evalCase: ScorecardCase,
+  output: ScorecardAgentOutput,
+): {
+  score: number;
+  passed: boolean;
+  hardFailed: boolean;
+  failingScorers: string[];
+} {
+  const scores: ScorerResult[] = [];
+  for (const id of evalCase.scorerIds) {
+    const factory = SCORER_REGISTRY[id];
+    if (!factory) continue;
+    const config = evalCase.scorerConfig?.[id] ?? {};
+    scores.push(factory(config)(evalCase, output));
+  }
+  const verdict = aggregateScores(scores);
+  return {
+    ...verdict,
+    failingScorers: scores.filter((s) => !s.passed).map((s) => s.scorer),
+  };
+}

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -650,8 +650,88 @@ const schema = defineSchema({
     // can re-parse without re-fetching from the source.
     rawPayloadStorageId: v.optional(v.id("_storage")),
   })
+    // #259: once a cloudflare_ai_gateway import is materialized into an eval
+    // case this points at that row. Presence is the idempotency signal for
+    // `gatewayImport.materializeImportedTraces` (skip already-materialized).
+    evalCaseId: v.optional(v.id("evalCases")),
+  })
     .index("by_project", ["projectId"])
     .index("by_source_trace", ["source", "sourceTraceId"]),
+
+  // #259: imported production-log traces materialized into runnable eval cases.
+  // Project-scoped. One row per materialized traceImport (`by_trace_import`
+  // enforces idempotency). Stores the captured production output alongside the
+  // request messages so the per-org scorecard can grade the real output; it is
+  // NEVER exposed to blind reviewers and scorecard client queries return only
+  // ids/products/scorer keys/numbers, never messages/outputText.
+  evalCases: defineTable({
+    projectId: v.id("projects"),
+    traceImportId: v.id("traceImports"),
+    // Only production-log cases for now; keep as a literal so a future
+    // synthetic/replay source is an explicit, migrated schema change.
+    source: v.literal("production_log"),
+    // From the trace's metadata.product, fallback "unknown".
+    product: v.string(),
+    title: v.string(),
+    messages: v.array(v.object({ role: v.string(), content: v.string() })),
+    // The captured production output; absent when the response was redacted.
+    outputText: v.optional(v.string()),
+    // Deterministic scorer ids assigned at materialization (see
+    // convex/traceAdapters/materializeEvalCase.ts).
+    scorerIds: v.array(v.string()),
+    requestMissing: v.boolean(),
+    responseMissing: v.boolean(),
+    model: v.optional(v.string()),
+    provider: v.optional(v.string()),
+    timestamp: v.optional(v.string()),
+    inputTokens: v.optional(v.number()),
+    outputTokens: v.optional(v.number()),
+    costUsd: v.optional(v.number()),
+    durationMs: v.optional(v.number()),
+    createdById: v.id("users"),
+  })
+    .index("by_project", ["projectId"])
+    .index("by_trace_import", ["traceImportId"]),
+
+  // #259: per-org scorecard runs. Grades every org eval case that has a
+  // captured production output against its assigned deterministic scorers.
+  // `summary` and `errorMessage` are sanitized — counts + generic strings only,
+  // never trace/message/output content.
+  scorecardRuns: defineTable({
+    orgId: v.id("organizations"),
+    status: v.union(
+      v.literal("pending"),
+      v.literal("running"),
+      v.literal("completed"),
+      v.literal("failed"),
+    ),
+    triggeredById: v.id("users"),
+    startedAt: v.number(),
+    completedAt: v.optional(v.number()),
+    errorMessage: v.optional(v.string()),
+    summary: v.optional(
+      v.object({
+        cases: v.number(),
+        passed: v.number(),
+        hardFailed: v.number(),
+        meanScore: v.number(),
+        skippedNoOutput: v.number(),
+      }),
+    ),
+  }).index("by_org", ["orgId"]),
+
+  // #259: one row per graded case in a scorecard run. `failingScorers` holds the
+  // scorer keys whose result did not pass. No content — ids, product, scorer
+  // keys, numbers, booleans only.
+  scorecardResults: defineTable({
+    runId: v.id("scorecardRuns"),
+    caseId: v.id("evalCases"),
+    product: v.string(),
+    score: v.number(),
+    passed: v.boolean(),
+    hardFailed: v.boolean(),
+    failingScorers: v.array(v.string()),
+  }).index("by_run", ["runId"]),
 
   // M26: dedup ledger for "new draft published" emails to non-blind
   // reviewers. One row per (reviewer, project, version) so we can rate-limit

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -649,7 +649,6 @@ const schema = defineSchema({
     // Original provider payload, persisted verbatim so adapter improvements
     // can re-parse without re-fetching from the source.
     rawPayloadStorageId: v.optional(v.id("_storage")),
-  })
     // #259: once a cloudflare_ai_gateway import is materialized into an eval
     // case this points at that row. Presence is the idempotency signal for
     // `gatewayImport.materializeImportedTraces` (skip already-materialized).

--- a/convex/scorecards.ts
+++ b/convex/scorecards.ts
@@ -33,11 +33,24 @@ const summaryValidator = v.object({
 /**
  * Kick off a scorecard run for an org. Inserts a pending run and schedules the
  * grading action; returns the run id so the client can subscribe via `latest`.
+ * If a run is already pending/running for the org, returns that run's id
+ * instead of starting an overlapping one (concurrent clients / stale UI).
  */
 export const start = mutation({
   args: { orgId: v.id("organizations") },
   handler: async (ctx, args): Promise<Id<"scorecardRuns">> => {
     const { userId } = await requireOrgRole(ctx, args.orgId, ["owner", "admin"]);
+    const inFlight = await ctx.db
+      .query("scorecardRuns")
+      .withIndex("by_org", (q) => q.eq("orgId", args.orgId))
+      .filter((q) =>
+        q.or(
+          q.eq(q.field("status"), "pending"),
+          q.eq(q.field("status"), "running"),
+        ),
+      )
+      .first();
+    if (inFlight) return inFlight._id;
     const runId = await ctx.db.insert("scorecardRuns", {
       orgId: args.orgId,
       status: "pending",

--- a/convex/scorecards.ts
+++ b/convex/scorecards.ts
@@ -1,0 +1,193 @@
+import { v } from "convex/values";
+import {
+  internalMutation,
+  internalQuery,
+  mutation,
+  query,
+} from "./_generated/server";
+import { internal } from "./_generated/api";
+import type { Id } from "./_generated/dataModel";
+import { requireOrgRole } from "./lib/auth";
+import {
+  foldScorecardResults,
+  type ScorecardResultRow,
+} from "./lib/scorecardAggregation";
+
+// ===========================================================================
+// #259: Per-org scorecard runs.
+//
+// Grades every eval case in the org (across all its projects) that has a
+// captured production output against its assigned deterministic scorers.
+// SECURITY: client-facing functions here return ids, products, scorer keys, and
+// numbers only — never messages / outputText / prompt content.
+// ===========================================================================
+
+const summaryValidator = v.object({
+  cases: v.number(),
+  passed: v.number(),
+  hardFailed: v.number(),
+  meanScore: v.number(),
+  skippedNoOutput: v.number(),
+});
+
+/**
+ * Kick off a scorecard run for an org. Inserts a pending run and schedules the
+ * grading action; returns the run id so the client can subscribe via `latest`.
+ */
+export const start = mutation({
+  args: { orgId: v.id("organizations") },
+  handler: async (ctx, args): Promise<Id<"scorecardRuns">> => {
+    const { userId } = await requireOrgRole(ctx, args.orgId, ["owner", "admin"]);
+    const runId = await ctx.db.insert("scorecardRuns", {
+      orgId: args.orgId,
+      status: "pending",
+      triggeredById: userId,
+      startedAt: Date.now(),
+    });
+    await ctx.scheduler.runAfter(0, internal.scorecardsActions.runScorecard, {
+      runId,
+    });
+    return runId;
+  },
+});
+
+/**
+ * Latest scorecard run for the org (by startedAt) plus its rolled-up results.
+ * Returns null when the org has never run one. Content-free: ids, products,
+ * scorer keys, and numbers only.
+ */
+export const latest = query({
+  args: { orgId: v.id("organizations") },
+  handler: async (ctx, args) => {
+    await requireOrgRole(ctx, args.orgId, ["owner", "admin", "member"]);
+    const runs = await ctx.db
+      .query("scorecardRuns")
+      .withIndex("by_org", (q) => q.eq("orgId", args.orgId))
+      .collect();
+    if (runs.length === 0) return null;
+    const run = runs.reduce((a, b) => (b.startedAt > a.startedAt ? b : a));
+
+    const resultRows = await ctx.db
+      .query("scorecardResults")
+      .withIndex("by_run", (q) => q.eq("runId", run._id))
+      .collect();
+    const fold = foldScorecardResults(
+      resultRows.map((r): ScorecardResultRow => ({
+        caseId: r.caseId,
+        product: r.product,
+        score: r.score,
+        passed: r.passed,
+        hardFailed: r.hardFailed,
+        failingScorers: r.failingScorers,
+      })),
+    );
+
+    return {
+      runId: run._id,
+      status: run.status,
+      startedAt: run.startedAt,
+      completedAt: run.completedAt,
+      errorMessage: run.errorMessage,
+      summary: run.summary,
+      products: fold.products,
+      softFailuresByScorer: fold.softFailuresByScorer,
+      hardFailFindings: fold.hardFailFindings,
+    };
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Internal helpers (invoked by the scheduled grading action; no auth — the
+// public `start` mutation is the gate, and scheduled actions run as system).
+// ---------------------------------------------------------------------------
+
+type ScorecardCaseRow = {
+  caseId: Id<"evalCases">;
+  product: string;
+  scorerIds: string[];
+  outputText?: string;
+};
+
+/** Fetch a run row for the grading action (org id + status). */
+export const getRun = internalQuery({
+  args: { runId: v.id("scorecardRuns") },
+  handler: async (ctx, args) => {
+    return await ctx.db.get(args.runId);
+  },
+});
+
+/** Every eval case across the org's projects, with just the grading fields. */
+export const loadOrgEvalCases = internalQuery({
+  args: { orgId: v.id("organizations") },
+  handler: async (ctx, args): Promise<ScorecardCaseRow[]> => {
+    const projects = await ctx.db
+      .query("projects")
+      .withIndex("by_org", (q) => q.eq("organizationId", args.orgId))
+      .collect();
+    const cases: ScorecardCaseRow[] = [];
+    for (const project of projects) {
+      const rows = await ctx.db
+        .query("evalCases")
+        .withIndex("by_project", (q) => q.eq("projectId", project._id))
+        .collect();
+      for (const r of rows) {
+        cases.push({
+          caseId: r._id,
+          product: r.product,
+          scorerIds: r.scorerIds,
+          outputText: r.outputText,
+        });
+      }
+    }
+    return cases;
+  },
+});
+
+/** Flip a run's status (pending -> running, or -> failed with a sanitized message). */
+export const setRunStatus = internalMutation({
+  args: {
+    runId: v.id("scorecardRuns"),
+    status: v.union(
+      v.literal("running"),
+      v.literal("failed"),
+      v.literal("completed"),
+    ),
+    errorMessage: v.optional(v.string()),
+    completedAt: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const updates: Record<string, unknown> = { status: args.status };
+    if (args.errorMessage !== undefined) updates.errorMessage = args.errorMessage;
+    if (args.completedAt !== undefined) updates.completedAt = args.completedAt;
+    await ctx.db.patch(args.runId, updates);
+  },
+});
+
+/** Persist graded result rows + the run summary and mark the run completed. */
+export const writeResults = internalMutation({
+  args: {
+    runId: v.id("scorecardRuns"),
+    results: v.array(
+      v.object({
+        caseId: v.id("evalCases"),
+        product: v.string(),
+        score: v.number(),
+        passed: v.boolean(),
+        hardFailed: v.boolean(),
+        failingScorers: v.array(v.string()),
+      }),
+    ),
+    summary: summaryValidator,
+    completedAt: v.number(),
+  },
+  handler: async (ctx, args) => {
+    for (const r of args.results) {
+      await ctx.db.insert("scorecardResults", { runId: args.runId, ...r });
+    }
+    await ctx.db.patch(args.runId, {
+      status: "completed",
+      summary: args.summary,
+      completedAt: args.completedAt,
+    });
+  },
+});

--- a/convex/scorecardsActions.ts
+++ b/convex/scorecardsActions.ts
@@ -1,0 +1,90 @@
+import { v } from "convex/values";
+import { internalAction } from "./_generated/server";
+import { internal } from "./_generated/api";
+import type { Id } from "./_generated/dataModel";
+import { scoreCase } from "./lib/scorecardScoring";
+import { foldScorecardResults } from "./lib/scorecardAggregation";
+
+/**
+ * #259: Grade every eval case in the org that has a captured production output.
+ * Runs deterministic scorers only (no LLM/provider calls), so it is safe to run
+ * synchronously inside a single scheduled action.
+ *
+ * Flow: mark running -> load cases -> score each case with an output -> write
+ * results + summary -> mark completed. Cases without `outputText` are counted as
+ * `skippedNoOutput`, not graded. Any unexpected error marks the run failed with
+ * a generic, content-free message.
+ */
+export const runScorecard = internalAction({
+  args: { runId: v.id("scorecardRuns") },
+  handler: async (ctx, args) => {
+    const { runId } = args;
+    try {
+      const run = await ctx.runQuery(internal.scorecards.getRun, { runId });
+      if (!run) return; // Run was deleted before we started.
+
+      await ctx.runMutation(internal.scorecards.setRunStatus, {
+        runId,
+        status: "running",
+      });
+
+      const cases = await ctx.runQuery(internal.scorecards.loadOrgEvalCases, {
+        orgId: run.orgId,
+      });
+
+      let skippedNoOutput = 0;
+      const results: {
+        caseId: Id<"evalCases">;
+        product: string;
+        score: number;
+        passed: boolean;
+        hardFailed: boolean;
+        failingScorers: string[];
+      }[] = [];
+
+      for (const c of cases) {
+        if (c.outputText === undefined || c.outputText === "") {
+          skippedNoOutput++;
+          continue;
+        }
+        const verdict = scoreCase(
+          { scorerIds: c.scorerIds },
+          { text: c.outputText },
+        );
+        results.push({
+          caseId: c.caseId,
+          product: c.product,
+          score: verdict.score,
+          passed: verdict.passed,
+          hardFailed: verdict.hardFailed,
+          failingScorers: verdict.failingScorers,
+        });
+      }
+
+      const { totals } = foldScorecardResults(
+        results.map((r) => ({
+          caseId: r.caseId,
+          product: r.product,
+          score: r.score,
+          passed: r.passed,
+          hardFailed: r.hardFailed,
+          failingScorers: r.failingScorers,
+        })),
+      );
+
+      await ctx.runMutation(internal.scorecards.writeResults, {
+        runId,
+        results,
+        summary: { ...totals, skippedNoOutput },
+        completedAt: Date.now(),
+      });
+    } catch {
+      await ctx.runMutation(internal.scorecards.setRunStatus, {
+        runId,
+        status: "failed",
+        errorMessage: "Scorecard run failed. Try again.",
+        completedAt: Date.now(),
+      });
+    }
+  },
+});

--- a/convex/traceAdapters/materializeEvalCase.test.ts
+++ b/convex/traceAdapters/materializeEvalCase.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest";
+import { normalizeGatewayLog } from "./cloudflareAiGateway";
+import {
+  DEFAULT_PRODUCTION_LOG_SCORER_IDS,
+  materializeEvalCase,
+  readProduct,
+} from "./materializeEvalCase";
+import { aggregateScores, scoreCase } from "../lib/scorecardScoring";
+
+// Pure converter tests — no `_generated`, no convex runtime.
+
+const chat = {
+  log_id: "log_MAT_001",
+  timestamp: "2026-06-23T12:00:00Z",
+  provider: "anthropic",
+  model: "claude-sonnet-4-0",
+  metadata: { product: "support-assistant" },
+  request: {
+    messages: [
+      { role: "system", content: "You are a synthetic assistant." },
+      { role: "user", content: "What is my synthetic payoff?" },
+    ],
+  },
+  response: { choices: [{ message: { content: "Happy to help — here it is." } }] },
+  usage: { input_tokens: 42, output_tokens: 12, total_tokens: 54 },
+  cost_usd: 0.0021,
+  duration_ms: 1180,
+};
+
+const redacted = {
+  log_id: "log_MAT_002",
+  timestamp: "2026-06-23T12:01:00Z",
+  provider: "openai",
+  model: "gpt-4.1-mini",
+  request: { redacted: true },
+};
+
+describe("materializeEvalCase", () => {
+  it("maps a normalized trace + raw record into eval-case fields", () => {
+    const trace = normalizeGatewayLog(chat);
+    const fields = materializeEvalCase(trace, chat);
+    expect(fields.source).toBe("production_log");
+    expect(fields.product).toBe("support-assistant");
+    expect(fields.title).toBe("support-assistant replay log_MAT_001");
+    expect(fields.messages).toEqual([
+      { role: "system", content: "You are a synthetic assistant." },
+      { role: "user", content: "What is my synthetic payoff?" },
+    ]);
+    expect(fields.outputText).toBe("Happy to help — here it is.");
+    expect(fields.requestMissing).toBe(false);
+    expect(fields.responseMissing).toBe(false);
+    expect(fields.model).toBe("claude-sonnet-4-0");
+    expect(fields.provider).toBe("anthropic");
+    expect(fields.timestamp).toBe("2026-06-23T12:00:00Z");
+    expect(fields.inputTokens).toBe(42);
+    expect(fields.outputTokens).toBe(12);
+    expect(fields.costUsd).toBe(0.0021);
+    expect(fields.durationMs).toBe(1180);
+  });
+
+  it("assigns the default production-log scorer set", () => {
+    const fields = materializeEvalCase(normalizeGatewayLog(chat), chat);
+    expect(fields.scorerIds).toEqual([
+      "no_hallucinated_data",
+      "no_cross_context_leakage",
+      "read_only_no_destructive_tool",
+      "tone_customer_fit",
+    ]);
+    // Returned array is a copy — mutating it must not affect the constant.
+    fields.scorerIds.push("mutated");
+    expect(DEFAULT_PRODUCTION_LOG_SCORER_IDS).not.toContain("mutated");
+  });
+
+  it("falls back to product 'unknown' and carries redaction flags", () => {
+    const trace = normalizeGatewayLog(redacted);
+    const fields = materializeEvalCase(trace, redacted);
+    expect(fields.product).toBe("unknown");
+    expect(fields.title).toBe("unknown replay log_MAT_002");
+    expect(fields.messages).toEqual([]);
+    expect(fields.outputText).toBeUndefined();
+    expect(fields.requestMissing).toBe(true);
+    expect(fields.responseMissing).toBe(true);
+  });
+
+  it("readProduct reads metadata.product with an unknown fallback", () => {
+    expect(readProduct({ metadata: { product: "voice-agent" } })).toBe(
+      "voice-agent",
+    );
+    expect(readProduct({ request: { metadata: { product: "chat" } } })).toBe(
+      "chat",
+    );
+    expect(readProduct({})).toBe("unknown");
+    expect(readProduct(undefined)).toBe("unknown");
+  });
+
+  it("default scorers do NOT hard-fail vacuously on a normal captured output", () => {
+    const fields = materializeEvalCase(normalizeGatewayLog(chat), chat);
+    const verdict = scoreCase(
+      { scorerIds: fields.scorerIds },
+      { text: fields.outputText },
+    );
+    expect(verdict.hardFailed).toBe(false);
+    expect(verdict.passed).toBe(true);
+    expect(verdict.score).toBe(1);
+    expect(verdict.failingScorers).toEqual([]);
+  });
+
+  it("hard-fails only on a real safety violation via scorer config", () => {
+    // With a forbidden phrase configured and present in the output, the
+    // hard-fail scorer fires — proving the pass above is a real signal.
+    const verdict = scoreCase(
+      {
+        scorerIds: ["no_hallucinated_data"],
+        scorerConfig: { no_hallucinated_data: { phrases: ["ssn 123"] } },
+      },
+      { text: "your ssn 123 is on file" },
+    );
+    expect(verdict.hardFailed).toBe(true);
+    expect(verdict.passed).toBe(false);
+    expect(verdict.failingScorers).toEqual(["no_hallucinated_data"]);
+  });
+
+  it("aggregateScores matches src semantics (hard-fail dominates)", () => {
+    expect(
+      aggregateScores([
+        { scorer: "a", score: 1, passed: true, reason: "", hard_fail: false },
+        { scorer: "b", score: 0, passed: false, reason: "", hard_fail: true },
+      ]),
+    ).toEqual({ score: 0.5, passed: false, hardFailed: true });
+    expect(aggregateScores([])).toEqual({
+      score: 0,
+      passed: false,
+      hardFailed: false,
+    });
+  });
+});

--- a/convex/traceAdapters/materializeEvalCase.ts
+++ b/convex/traceAdapters/materializeEvalCase.ts
@@ -1,0 +1,105 @@
+/**
+ * Pure converter: a normalized Cloudflare AI Gateway trace -> the field set for
+ * an `evalCases` row (see convex/schema.ts). Node-free and `_generated`-free so
+ * it runs inside the Convex runtime and in plain vitest.
+ *
+ * Mirrors the field mapping in `src/lib/evals/cloudflareAiGateway.ts`
+ * `convertTraceToEvalCase`, adapted to the Convex trace shape
+ * (`NormalizedGatewayTrace`): `product` is read from the raw record's metadata
+ * (the normalized trace doesn't carry it), and the request/response redaction
+ * flags come straight off the trace. The importer supplies auth, storage, and
+ * persistence; this module is only the pure mapping.
+ */
+import type { NormalizedGatewayTrace } from "./cloudflareAiGateway";
+
+/**
+ * Default deterministic scorers for a production-log case whose `expected` is
+ * sparse (no curated must / must_not lists): the three HARD_FAIL safety scorers
+ * — no_hallucinated_data, no_cross_context_leakage, read_only_no_destructive_tool
+ * — which pass (never hard-fail) when their forbidden lists are empty, plus
+ * tone_customer_fit as a standalone quality scorer that grades output tone
+ * against built-in defaults. None fails vacuously on a normal captured output.
+ */
+export const DEFAULT_PRODUCTION_LOG_SCORER_IDS: readonly string[] = [
+  "no_hallucinated_data",
+  "no_cross_context_leakage",
+  "read_only_no_destructive_tool",
+  "tone_customer_fit",
+];
+
+/** Field set for an `evalCases` insert, minus projectId/traceImportId/createdById. */
+export interface EvalCaseFields {
+  source: "production_log";
+  product: string;
+  title: string;
+  messages: { role: string; content: string }[];
+  outputText?: string;
+  scorerIds: string[];
+  requestMissing: boolean;
+  responseMissing: boolean;
+  model?: string;
+  provider?: string;
+  timestamp?: string;
+  inputTokens?: number;
+  outputTokens?: number;
+  costUsd?: number;
+  durationMs?: number;
+}
+
+// --- tiny readers (node-free, mirror the adapter's) --------------------------
+
+const asRecord = (v: unknown): Record<string, unknown> | undefined =>
+  v && typeof v === "object" && !Array.isArray(v)
+    ? (v as Record<string, unknown>)
+    : undefined;
+const str = (v: unknown): string | undefined =>
+  typeof v === "string" && v.length ? v : undefined;
+
+const get = (obj: unknown, paths: string[]): unknown => {
+  for (const path of paths) {
+    let cur: unknown = obj;
+    for (const key of path.split(".")) cur = asRecord(cur)?.[key];
+    if (cur !== undefined && cur !== null) return cur;
+  }
+  return undefined;
+};
+
+/**
+ * Read `product` from the raw source record's metadata. Matches the src
+ * adapter's metadata resolution paths. Falls back to "unknown".
+ */
+export function readProduct(rawRecord: unknown): string {
+  const metadata = asRecord(
+    get(rawRecord, ["metadata", "request.metadata", "event.metadata"]),
+  );
+  return str(metadata?.product) ?? "unknown";
+}
+
+/**
+ * Convert a normalized trace + its raw source record into `evalCases` fields.
+ * `rawRecord` is the JSON-parsed source log — only its metadata is read (for
+ * `product`); message/output content comes from the normalized trace.
+ */
+export function materializeEvalCase(
+  trace: NormalizedGatewayTrace,
+  rawRecord?: unknown,
+): EvalCaseFields {
+  const product = readProduct(rawRecord);
+  return {
+    source: "production_log",
+    product,
+    title: `${product} replay ${trace.sourceTraceId}`,
+    messages: trace.messages.map((m) => ({ role: m.role, content: m.content })),
+    outputText: trace.outputText,
+    scorerIds: [...DEFAULT_PRODUCTION_LOG_SCORER_IDS],
+    requestMissing: trace.requestMissing,
+    responseMissing: trace.responseMissing,
+    model: trace.model,
+    provider: trace.provider,
+    timestamp: trace.timestamp,
+    inputTokens: trace.usage.inputTokens,
+    outputTokens: trace.usage.outputTokens,
+    costUsd: trace.costUsd,
+    durationMs: trace.durationMs,
+  };
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ const WelcomeFirstRun = lazy(() => import("./routes/welcome/WelcomeFirstRun").th
 const OrgHome = lazy(() => import("./routes/orgs/OrgHome").then(m => ({ default: m.OrgHome })));
 const GatewayOnboarding = lazy(() => import("./routes/orgs/GatewayOnboarding").then(m => ({ default: m.GatewayOnboarding })));
 const GatewayImport = lazy(() => import("./routes/orgs/GatewayImport").then(m => ({ default: m.GatewayImport })));
+const Scorecard = lazy(() => import("./routes/orgs/Scorecard").then(m => ({ default: m.Scorecard })));
 const OrgSettings = lazy(() => import("./routes/orgs/settings/OrgSettings").then(m => ({ default: m.OrgSettings })));
 const OrgMembers = lazy(() => import("./routes/orgs/settings/OrgMembers").then(m => ({ default: m.OrgMembers })));
 const OpenRouterKey = lazy(() => import("./routes/orgs/settings/OpenRouterKey").then(m => ({ default: m.OpenRouterKey })));
@@ -77,6 +78,7 @@ export function App() {
             <Route index element={<OrgHome />} />
             <Route path="gateway-onboarding" element={<GatewayOnboarding />} />
             <Route path="gateway-import" element={<GatewayImport />} />
+            <Route path="scorecard" element={<Scorecard />} />
             <Route path="settings" element={<OrgSettings />} />
             <Route path="settings/members" element={<OrgMembers />} />
             <Route path="settings/openrouter-key" element={<OpenRouterKey />} />

--- a/src/components/SideNavContent.tsx
+++ b/src/components/SideNavContent.tsx
@@ -4,6 +4,7 @@ import { api } from "../../convex/_generated/api";
 import { useOrg } from "@/contexts/OrgContext";
 import { cn } from "@/lib/utils";
 import {
+  ClipboardCheck,
   CloudDownload,
   CreditCard,
   FolderOpen,
@@ -107,6 +108,14 @@ export function SideNavContent({
       >
         <CloudDownload aria-hidden="true" className="h-4 w-4 shrink-0" />
         Import Gateway logs
+      </NavLink>
+      <NavLink
+        to={`/orgs/${org.slug}/scorecard`}
+        className={linkClass}
+        onClick={onNavigate}
+      >
+        <ClipboardCheck aria-hidden="true" className="h-4 w-4 shrink-0" />
+        Quality scorecard
       </NavLink>
 
       {role === "owner" && (

--- a/src/routes/orgs/GatewayImport.tsx
+++ b/src/routes/orgs/GatewayImport.tsx
@@ -10,10 +10,20 @@ import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { friendlyError } from "@/lib/errors";
-import { CloudDownload, ShieldAlert, ArrowLeft } from "lucide-react";
+import {
+  CloudDownload,
+  ShieldAlert,
+  ArrowLeft,
+  Layers,
+  ClipboardCheck,
+} from "lucide-react";
 
 type ImportSummary = FunctionReturnType<
   typeof api.gatewayImport.importGatewayLogs
+>;
+
+type MaterializeResult = FunctionReturnType<
+  typeof api.gatewayImport.materializeImportedTraces
 >;
 
 export function GatewayImport() {
@@ -147,6 +157,13 @@ export function GatewayImport() {
       {summary && <ImportSummaryCard summary={summary} />}
 
       {projectId && (
+        <MaterializationCard
+          projectId={projectId as Id<"projects">}
+          scorecardHref={`${base}/scorecard`}
+        />
+      )}
+
+      {projectId && (
         <p className="mt-6 text-sm">
           <Link
             to={`${base}/projects/${projectId}/history`}
@@ -205,6 +222,121 @@ function ImportSummaryCard({ summary }: { summary: ImportSummary }) {
         {(summary.earliest || summary.latest) && (
           <p className="text-xs text-muted-foreground">
             Window: {summary.earliest ?? "?"} → {summary.latest ?? "?"}
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function MaterializationCard({
+  projectId,
+  scorecardHref,
+}: {
+  projectId: Id<"projects">;
+  scorecardHref: string;
+}) {
+  const status = useQuery(api.gatewayImport.materializationStatus, {
+    projectId,
+  });
+  const materialize = useAction(api.gatewayImport.materializeImportedTraces);
+
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState("");
+  const [result, setResult] = useState<MaterializeResult | null>(null);
+
+  const total = status?.total;
+  const materialized = status?.materialized;
+  const fullyMaterialized =
+    total !== undefined && materialized !== undefined && total === materialized;
+
+  async function handleMaterialize() {
+    setBusy(true);
+    setError("");
+    setResult(null);
+    try {
+      const res = await materialize({ projectId });
+      setResult(res);
+    } catch (err) {
+      setError(
+        friendlyError(
+          err,
+          "Could not materialize imported traces. Try again in a moment.",
+        ),
+      );
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <Card className="mt-6">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-base">
+          <Layers aria-hidden="true" className="h-4 w-4 text-primary" />
+          Materialize into eval cases
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3 text-sm">
+        {status === undefined ? (
+          <p className="text-muted-foreground">Loading materialization status…</p>
+        ) : total === 0 ? (
+          <p className="text-muted-foreground">
+            No imported traces yet — import Gateway logs above, then materialize
+            them into eval cases here.
+          </p>
+        ) : (
+          <p>
+            <span className="font-semibold tabular-nums">{materialized}</span> of{" "}
+            <span className="font-semibold tabular-nums">{total}</span> imported
+            traces materialized as eval cases.
+          </p>
+        )}
+
+        {error && (
+          <p className="text-destructive" role="alert">
+            {error}
+          </p>
+        )}
+
+        <Button
+          onClick={handleMaterialize}
+          disabled={busy || !total || fullyMaterialized}
+        >
+          {busy
+            ? "Materializing…"
+            : fullyMaterialized
+              ? "All traces materialized"
+              : "Materialize into eval cases"}
+        </Button>
+
+        {result && (
+          <dl className="grid grid-cols-2 gap-3 pt-1 sm:grid-cols-4">
+            {[
+              { label: "Materialized", value: result.materialized },
+              { label: "Already done", value: result.alreadyMaterialized },
+              { label: "Missing payload", value: result.missingPayload },
+              { label: "Failed", value: result.failed },
+            ].map((s) => (
+              <div key={s.label}>
+                <dt className="text-xs text-muted-foreground">{s.label}</dt>
+                <dd className="text-lg font-semibold tabular-nums">
+                  {s.value}
+                </dd>
+              </div>
+            ))}
+          </dl>
+        )}
+
+        {materialized !== undefined && materialized > 0 && (
+          <p className="pt-1">
+            <Link
+              to={scorecardHref}
+              className="inline-flex items-center gap-1 text-primary hover:underline"
+            >
+              <ClipboardCheck aria-hidden="true" className="h-3.5 w-3.5" />
+              Run the quality scorecard →
+            </Link>
           </p>
         )}
       </CardContent>

--- a/src/routes/orgs/OrgHome.tsx
+++ b/src/routes/orgs/OrgHome.tsx
@@ -47,21 +47,39 @@ export function OrgHome() {
         </div>
       )}
 
-      <Link
-        to={`/orgs/${org.slug}/gateway-onboarding`}
-        className="mt-4 flex items-center justify-between rounded-lg border px-4 py-3 hover:bg-accent transition-colors"
-      >
-        <div className="flex items-center gap-3">
-          <Plug aria-hidden="true" className="h-4 w-4 text-primary shrink-0" />
-          <div>
-            <div className="text-sm font-medium">Gateway onboarding</div>
-            <div className="text-xs text-muted-foreground">
-              Feed Cloudflare AI Gateway logs into Blind Bench.
+      <div className="mt-4 grid gap-3 sm:grid-cols-2">
+        <Link
+          to={`/orgs/${org.slug}/gateway-onboarding`}
+          className="flex items-center justify-between rounded-lg border px-4 py-3 hover:bg-accent transition-colors"
+        >
+          <div className="flex items-center gap-3">
+            <Plug aria-hidden="true" className="h-4 w-4 text-primary shrink-0" />
+            <div>
+              <div className="text-sm font-medium">Gateway onboarding</div>
+              <div className="text-xs text-muted-foreground">
+                Feed Cloudflare AI Gateway logs into Blind Bench.
+              </div>
             </div>
           </div>
-        </div>
-        <ChevronRight aria-hidden="true" className="h-4 w-4 text-muted-foreground" />
-      </Link>
+          <ChevronRight aria-hidden="true" className="h-4 w-4 text-muted-foreground" />
+        </Link>
+
+        <Link
+          to={`/orgs/${org.slug}/scorecard`}
+          className="flex items-center justify-between rounded-lg border px-4 py-3 hover:bg-accent transition-colors"
+        >
+          <div className="flex items-center gap-3">
+            <ClipboardCheck aria-hidden="true" className="h-4 w-4 text-primary shrink-0" />
+            <div>
+              <div className="text-sm font-medium">Quality scorecard</div>
+              <div className="text-xs text-muted-foreground">
+                Run deterministic quality checks over your imported traffic.
+              </div>
+            </div>
+          </div>
+          <ChevronRight aria-hidden="true" className="h-4 w-4 text-muted-foreground" />
+        </Link>
+      </div>
 
       <div className="mt-6">
         {projects === undefined ? (

--- a/src/routes/orgs/Scorecard.tsx
+++ b/src/routes/orgs/Scorecard.tsx
@@ -293,8 +293,8 @@ function CompletedScorecard({ latest }: { latest: Latest }) {
               <p className="text-muted-foreground">
                 {summary?.hardFailed} hard-fail
                 {summary?.hardFailed === 1 ? "" : "s"} must be resolved before
-                this traffic can be promoted. Hard-fails are tracked separately
-                and never averaged into the quality score.
+                this traffic can be promoted. A single hard-fail blocks
+                promotion regardless of the mean quality score.
               </p>
             </div>
           </CardContent>
@@ -345,7 +345,7 @@ function CompletedScorecard({ latest }: { latest: Latest }) {
               icon={Gauge}
               label="Mean score"
               value={formatScore(summary.meanScore)}
-              detail="Soft quality score, hard-fails excluded"
+              detail="Mean across all scored cases"
             />
             <MetricCard
               icon={ClipboardCheck}

--- a/src/routes/orgs/Scorecard.tsx
+++ b/src/routes/orgs/Scorecard.tsx
@@ -1,0 +1,508 @@
+import { useState } from "react";
+import { useMutation, useQuery } from "convex/react";
+import type { FunctionReturnType } from "convex/server";
+import { Link } from "react-router-dom";
+import { api } from "../../../convex/_generated/api";
+import { useOrg } from "@/contexts/OrgContext";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Separator } from "@/components/ui/separator";
+import { friendlyError } from "@/lib/errors";
+import {
+  ClipboardCheck,
+  ShieldAlert,
+  ShieldCheck,
+  Gauge,
+  CheckCircle2,
+  FileWarning,
+  AlertTriangle,
+  Play,
+} from "lucide-react";
+
+function formatTimestamp(ms: number | undefined): string {
+  if (!ms) return "—";
+  try {
+    return new Date(ms).toLocaleString(undefined, {
+      dateStyle: "medium",
+      timeStyle: "short",
+    });
+  } catch {
+    return "—";
+  }
+}
+
+function formatScore(n: number): string {
+  return Number.isFinite(n) ? n.toFixed(3) : "—";
+}
+
+function formatPct(passed: number, cases: number): string {
+  if (cases <= 0) return "—";
+  return `${Math.round((passed / cases) * 100)}%`;
+}
+
+export function Scorecard() {
+  const { org, orgId, role } = useOrg();
+  const base = `/orgs/${org.slug}`;
+  const canRun = role === "owner" || role === "admin";
+
+  const latest = useQuery(api.scorecards.latest, { orgId });
+  const startRun = useMutation(api.scorecards.start);
+
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState("");
+
+  const inFlight =
+    latest?.status === "pending" || latest?.status === "running";
+
+  async function handleRun() {
+    setBusy(true);
+    setError("");
+    try {
+      await startRun({ orgId });
+    } catch (err) {
+      setError(
+        friendlyError(
+          err,
+          "Could not start the scorecard run. Wait for any active run to finish, then try again.",
+        ),
+      );
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const runButton = canRun ? (
+    <div className="flex flex-col items-end gap-1">
+      <Button onClick={handleRun} disabled={busy || inFlight}>
+        <Play aria-hidden="true" className="h-4 w-4" />
+        {inFlight ? "Scorecard running…" : busy ? "Starting…" : "Run scorecard"}
+      </Button>
+      {error && (
+        <p className="text-xs text-destructive" role="alert">
+          {error}
+        </p>
+      )}
+    </div>
+  ) : null;
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-8 p-6">
+      <header className="flex items-start justify-between gap-4">
+        <div>
+          <div className="flex items-center gap-2">
+            <ClipboardCheck aria-hidden="true" className="h-5 w-5 text-primary" />
+            <h1 className="text-2xl font-bold">Quality scorecard</h1>
+          </div>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Deterministic quality checks over the traces you imported from your
+            AI Gateway — pass rate, hard-fails, and per-product breakdown.
+          </p>
+        </div>
+        {runButton}
+      </header>
+
+      {latest === undefined ? (
+        <LoadingState />
+      ) : latest === null ? (
+        <EmptyState base={base} canRun={canRun} />
+      ) : inFlight ? (
+        <RunningState cases={latest.summary?.cases} />
+      ) : latest.status === "failed" ? (
+        <FailedState
+          startedAt={latest.startedAt}
+          errorMessage={latest.errorMessage}
+        />
+      ) : (
+        <CompletedScorecard latest={latest} />
+      )}
+    </div>
+  );
+}
+
+function LoadingState() {
+  return (
+    <div
+      className="space-y-6"
+      role="status"
+      aria-live="polite"
+      aria-label="Loading scorecard"
+    >
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        {[1, 2, 3, 4].map((i) => (
+          <Skeleton key={i} className="h-28 w-full" />
+        ))}
+      </div>
+      <Skeleton className="h-14 w-full" />
+      <Skeleton className="h-48 w-full" />
+      <span className="sr-only">Loading scorecard…</span>
+    </div>
+  );
+}
+
+function EmptyState({ base, canRun }: { base: string; canRun: boolean }) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">No scorecard yet</CardTitle>
+        <CardDescription>
+          The scorecard grades imported Gateway traffic. Set it up in three
+          steps:
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4 text-sm">
+        <ol className="space-y-3">
+          <li className="flex gap-3">
+            <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-primary/10 text-xs font-semibold text-primary">
+              1
+            </span>
+            <span className="text-muted-foreground">
+              <Link
+                to={`${base}/gateway-import`}
+                className="font-medium text-primary hover:underline"
+              >
+                Import Gateway logs
+              </Link>{" "}
+              — paste your exported Cloudflare AI Gateway records.
+            </span>
+          </li>
+          <li className="flex gap-3">
+            <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-primary/10 text-xs font-semibold text-primary">
+              2
+            </span>
+            <span className="text-muted-foreground">
+              Materialize those imports into eval cases from the{" "}
+              <Link
+                to={`${base}/gateway-import`}
+                className="font-medium text-primary hover:underline"
+              >
+                Import Gateway logs
+              </Link>{" "}
+              page.
+            </span>
+          </li>
+          <li className="flex gap-3">
+            <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-primary/10 text-xs font-semibold text-primary">
+              3
+            </span>
+            <span className="text-muted-foreground">
+              {canRun
+                ? "Run the scorecard to grade every materialized case."
+                : "Ask an org owner or admin to run the scorecard once cases exist."}
+            </span>
+          </li>
+        </ol>
+      </CardContent>
+    </Card>
+  );
+}
+
+function RunningState({ cases }: { cases?: number }) {
+  return (
+    <Card className="border-primary/30 bg-primary/5">
+      <CardContent className="flex items-center gap-3 py-6 text-sm">
+        <Gauge aria-hidden="true" className="h-5 w-5 animate-pulse text-primary" />
+        <div>
+          <p className="font-medium">
+            {cases && cases > 0
+              ? `Scoring ${cases} case${cases === 1 ? "" : "s"}…`
+              : "Scoring cases…"}
+          </p>
+          <p className="text-xs text-muted-foreground">
+            This page updates automatically when the run finishes.
+          </p>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function FailedState({
+  startedAt,
+  errorMessage,
+}: {
+  startedAt: number;
+  errorMessage?: string;
+}) {
+  return (
+    <Card className="border-amber-500/40 bg-amber-500/5">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-base">
+          <AlertTriangle
+            aria-hidden="true"
+            className="h-4 w-4 text-amber-600 dark:text-amber-400"
+          />
+          Scorecard run didn’t finish
+        </CardTitle>
+        <CardDescription>
+          The scorecard run started {formatTimestamp(startedAt)} failed before
+          producing results. Re-run the scorecard to try again.
+        </CardDescription>
+      </CardHeader>
+      {errorMessage && (
+        <CardContent className="text-sm text-muted-foreground">
+          {errorMessage}
+        </CardContent>
+      )}
+    </Card>
+  );
+}
+
+type Latest = NonNullable<
+  FunctionReturnType<typeof api.scorecards.latest>
+>;
+
+function CompletedScorecard({ latest }: { latest: Latest }) {
+  const summary = latest.summary;
+  const products = latest.products ?? [];
+  const softFailures = latest.softFailuresByScorer ?? [];
+  const hardFailFindings = latest.hardFailFindings ?? [];
+  const blocked = (summary?.hardFailed ?? 0) > 0;
+
+  return (
+    <div className="space-y-8">
+      <p className="text-xs text-muted-foreground">
+        as of {formatTimestamp(latest.completedAt ?? latest.startedAt)}
+      </p>
+
+      {/* Promotion gate banner — amber (blocked) / blue-purple (clear); no red/green */}
+      {blocked ? (
+        <Card className="border-amber-500/40 bg-amber-500/5">
+          <CardContent className="flex items-start gap-3 py-4 text-sm">
+            <ShieldAlert
+              aria-hidden="true"
+              className="mt-0.5 h-5 w-5 shrink-0 text-amber-600 dark:text-amber-400"
+            />
+            <div>
+              <p className="font-semibold">Promotion blocked</p>
+              <p className="text-muted-foreground">
+                {summary?.hardFailed} hard-fail
+                {summary?.hardFailed === 1 ? "" : "s"} must be resolved before
+                this traffic can be promoted. Hard-fails are tracked separately
+                and never averaged into the quality score.
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+      ) : (
+        <Card className="border-primary/30 bg-primary/5">
+          <CardContent className="flex items-start gap-3 py-4 text-sm">
+            <ShieldCheck
+              aria-hidden="true"
+              className="mt-0.5 h-5 w-5 shrink-0 text-primary"
+            />
+            <div>
+              <p className="font-semibold">Promotion gate clear</p>
+              <p className="text-muted-foreground">
+                No hard-fails in this run. The graded traffic clears the
+                promotion gate.
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Headline metrics */}
+      {summary && (
+        <section>
+          <h2 className="mb-3 text-sm font-medium uppercase tracking-wider text-muted-foreground">
+            Headline metrics
+          </h2>
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+            <MetricCard
+              icon={CheckCircle2}
+              label="Pass rate"
+              value={formatPct(summary.passed, summary.cases)}
+              detail={`${summary.passed} / ${summary.cases} cases passing`}
+            />
+            <MetricCard
+              icon={ShieldAlert}
+              label="Hard-fails"
+              value={String(summary.hardFailed)}
+              detail={
+                summary.hardFailed > 0
+                  ? "Blocking — gates promotion"
+                  : "None — gate is clear"
+              }
+              alert={summary.hardFailed > 0}
+            />
+            <MetricCard
+              icon={Gauge}
+              label="Mean score"
+              value={formatScore(summary.meanScore)}
+              detail="Soft quality score, hard-fails excluded"
+            />
+            <MetricCard
+              icon={ClipboardCheck}
+              label="Cases evaluated"
+              value={String(summary.cases)}
+              detail="Materialized eval cases graded"
+            />
+          </div>
+          {summary.skippedNoOutput > 0 && (
+            <div className="mt-3">
+              <MetricCard
+                icon={FileWarning}
+                label="Skipped — no output"
+                value={String(summary.skippedNoOutput)}
+                detail="Imported traces with no captured output to grade"
+              />
+            </div>
+          )}
+        </section>
+      )}
+
+      {/* Per-product breakdown */}
+      {products.length > 0 && (
+        <section>
+          <h2 className="mb-3 text-sm font-medium uppercase tracking-wider text-muted-foreground">
+            Per-product breakdown
+          </h2>
+          <div className="overflow-x-auto rounded-lg border">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Product</TableHead>
+                  <TableHead className="text-right">Cases</TableHead>
+                  <TableHead className="text-right">Passed</TableHead>
+                  <TableHead className="text-right">Hard-fails</TableHead>
+                  <TableHead className="text-right">Mean score</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {products.map((p) => (
+                  <TableRow key={p.product}>
+                    <TableCell className="font-medium">{p.product}</TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {p.cases}
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {p.passed}
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {p.hardFailed > 0 ? (
+                        <span className="font-semibold text-amber-600 dark:text-amber-400">
+                          {p.hardFailed}
+                        </span>
+                      ) : (
+                        p.hardFailed
+                      )}
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {formatScore(p.meanScore)}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        </section>
+      )}
+
+      {/* Soft failures by scorer */}
+      {softFailures.length > 0 && (
+        <section>
+          <h2 className="mb-3 text-sm font-medium uppercase tracking-wider text-muted-foreground">
+            Soft failures by scorer
+          </h2>
+          <div className="flex flex-wrap gap-2">
+            {softFailures.map((s) => (
+              <Badge key={s.scorer} variant="secondary" className="gap-1.5">
+                <code className="font-mono">{s.scorer}</code>
+                <span className="tabular-nums">{s.count}</span>
+              </Badge>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {/* Hard-fail findings */}
+      {hardFailFindings.length > 0 && (
+        <section>
+          <h2 className="mb-3 text-sm font-medium uppercase tracking-wider text-muted-foreground">
+            Hard-fail findings
+          </h2>
+          <div className="divide-y rounded-lg border">
+            {hardFailFindings.map((f) => (
+              <div
+                key={f.caseId}
+                className="flex flex-wrap items-center justify-between gap-2 px-4 py-3"
+              >
+                <div className="flex items-center gap-3">
+                  <ShieldAlert
+                    aria-hidden="true"
+                    className="h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400"
+                  />
+                  <div>
+                    <p className="font-mono text-sm">{f.caseId}</p>
+                    <p className="text-xs text-muted-foreground">{f.product}</p>
+                  </div>
+                </div>
+                <div className="flex flex-wrap gap-1.5">
+                  {f.scorers.map((scorer) => (
+                    <Badge key={scorer} variant="outline" className="gap-1">
+                      <code className="font-mono">{scorer}</code>
+                    </Badge>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+
+      <Separator />
+      <p className="text-xs text-muted-foreground">
+        This surface shows only case IDs, product labels, scorer keys, and
+        aggregate counts — never prompts, model outputs, or scorer reasons.
+      </p>
+    </div>
+  );
+}
+
+function MetricCard({
+  icon: Icon,
+  label,
+  value,
+  detail,
+  alert,
+}: {
+  icon: React.ComponentType<{ className?: string; "aria-hidden"?: boolean }>;
+  label: string;
+  value: string;
+  detail: string;
+  alert?: boolean;
+}) {
+  return (
+    <Card className={alert ? "border-amber-500/40 bg-amber-500/5" : ""}>
+      <CardHeader className="pb-2">
+        <CardTitle className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
+          <Icon
+            aria-hidden={true}
+            className={`h-4 w-4 ${alert ? "text-amber-600 dark:text-amber-400" : ""}`}
+          />
+          {label}
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="text-2xl font-bold tabular-nums">{value}</div>
+        <p className="mt-1 text-xs text-muted-foreground">{detail}</p>
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
Closes #259.

## What this does

Closes the two CLI-only legs of the AI Quality Bench loop so any org gets the full pipeline in-app: **import Gateway logs → materialize into eval cases → run scorecard → per-org quality scorecard**, no scripts required. This is the real, data-driven replacement for the static Pilot Scorecard removed in PR #258.

## Backend (Convex)

- **New tables:** `evalCases` (project-scoped, built from imported traces; captured production output + default scorer assignments), `scorecardRuns` (org-scoped, async status + summary), `scorecardResults` (per-case scores). `traceImports` gains an `evalCaseId` materialization target alongside the pre-existing (never-wired) `promptVersionId`/`runOutputId` hooks.
- **`gatewayImport.materializeImportedTraces`** (action): re-fetches raw payload blobs from storage, re-normalizes, converts via a new pure node-free adapter (`traceAdapters/materializeEvalCase.ts`), batch-inserts with per-row idempotency re-checks. Classifies the whole project but processes ≤500 ready rows per call — re-running drains larger backlogs. Returns management-safe counts only. Plus `materializationStatus` query.
- **`scorecards.start`** (mutation → scheduled internal action, per the house async pattern): grades every org eval case with captured output using deterministic scorers ported node-free into `convex/lib/scorecardScoring.ts` (aggregation semantics byte-matched to `src/lib/evals` `aggregateScores`; hard-fail dominance). Returns an in-flight run instead of scheduling overlapping ones. Default production-log scorer set: the three hard-fail safety scorers + `tone_customer_fit` (`must_assertions` excluded as vacuous without curated keywords).
- **`scorecards.latest`** query: headline summary, per-product rollup, soft-failures-by-scorer, hard-fail findings — **ids, products, scorer keys, and numbers only; never messages or output content**.
- Auth: materialize = project owner/editor; status adds evaluator; start = org owner/admin; latest = any org member. All internals are `internalQuery`/`internalMutation`/`internalAction`.

## Frontend

- **New `/orgs/:slug/scorecard` route** with five reactive states: skeleton loading, actionable 3-step empty state, live "Scoring N cases…" (resolves via Convex reactivity), failed-run card, and the completed scorecard (promotion-gate banner, headline metrics, per-product table, scorer breakdowns). Amber/blue-purple styling — no red/green.
- Side-nav "Quality scorecard" link + org-home tile (static copy, no fabricated stats).
- Gateway Import page: "X of Y imported traces materialized" card with the materialize action and per-call result counts.

## Review & verification

- Codex round 1: 1 Blocker (schema syntax error that would have broken Convex codegen) + 3 Major (validator/`source` mismatch, >500-row materialization wedge, overlapping scorecard runs) + 1 Minor (copy vs. metric) — all fixed in aac017e.
- Codex round 2: **Ready-to-merge**, all five confirmed fixed, no new issues.
- 230/230 tests pass (13 new pure-logic tests for the converter and aggregation fold, none importing `_generated`); esbuild parses all touched Convex modules; 6 pre-existing `convex/_generated` file-level failures unchanged (Vercel CI authoritative).

## Post-merge note

`npx convex deploy` (or `npx convex dev` against dev) is needed to push the new schema/functions before the UI paths go live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)