### PR TITLE
feat: Gateway polish — payload-logging guidance + metadata sidecar import

### DIFF
--- a/convex/gatewayImport.ts
+++ b/convex/gatewayImport.ts
@@ -13,9 +13,13 @@ import {
   MAX_REPORTED_INVALID_LINES,
   normalizeGatewayLog,
   parseGatewayJsonl,
+  parseSidecar,
   summarizeTraces,
 } from "./traceAdapters/cloudflareAiGateway";
-import type { TraceAggregate } from "./traceAdapters/cloudflareAiGateway";
+import type {
+  SidecarMap,
+  TraceAggregate,
+} from "./traceAdapters/cloudflareAiGateway";
 import { materializeEvalCase } from "./traceAdapters/materializeEvalCase";
 
 const SOURCE = "cloudflare_ai_gateway" as const;
@@ -33,6 +37,14 @@ type ImportGatewayLogsResult = {
   invalid: number;
   invalidLines: number[];
   truncated: boolean;
+  /**
+   * Present only when a `sidecarJson` arg was supplied. `entries` = valid
+   * sidecar entries parsed; `matched` = imported (non-duplicate) log records
+   * that had a sidecar entry merged into their metadata. An invalid/over-limit
+   * sidecar yields `{ entries: 0, matched: 0 }` and never fails the import.
+   * Management-safe: counts only, never sidecar content.
+   */
+  sidecar?: { entries: number; matched: number };
 } & TraceAggregate;
 
 /**
@@ -119,6 +131,7 @@ export const importGatewayLogs = action({
   args: {
     projectId: v.id("projects"),
     jsonl: v.string(),
+    sidecarJson: v.optional(v.string()),
   },
   handler: async (ctx, args): Promise<ImportGatewayLogsResult> => {
     // UTF-16 char length, not exact bytes — a cheap upper-bound guard before
@@ -129,9 +142,21 @@ export const importGatewayLogs = action({
       );
     }
 
-    const { traces, invalidLines, truncated } = parseGatewayJsonl(
+    // Optional metadata sidecar. Never fails the import: a malformed or
+    // over-limit sidecar is dropped (management-safe, counted as 0 entries) and
+    // the import proceeds without it.
+    let sidecarMap: SidecarMap | undefined;
+    let sidecarEntries = 0;
+    if (args.sidecarJson !== undefined) {
+      const parsed = parseSidecar(args.sidecarJson);
+      sidecarMap = parsed.sidecar;
+      sidecarEntries = parsed.entries;
+    }
+
+    const { traces, invalidLines, truncated, sidecarMerged } = parseGatewayJsonl(
       args.jsonl,
       DEFAULT_LIMITS,
+      sidecarMap,
     );
 
     const { imported, deduped, newRows }: InsertImportRowsResult =
@@ -145,11 +170,15 @@ export const importGatewayLogs = action({
     // for dedup hits. Sequential keeps it simple and bounded by maxLines.
     const updates: { importId: Id<"traceImports">; storageId: Id<"_storage"> }[] =
       [];
+    // Count sidecar matches over the imported subset only — the stored blob for
+    // each new row already carries the merged metadata.
+    let sidecarMatched = 0;
     for (const { importId, index } of newRows) {
       const storageId = await ctx.storage.store(
         new Blob([traces[index]!.rawPayloadJson], { type: "application/json" }),
       );
       updates.push({ importId, storageId });
+      if (sidecarMerged[index]) sidecarMatched++;
     }
     if (updates.length > 0) {
       await ctx.runMutation(internal.gatewayImport.attachRawPayloads, {
@@ -158,7 +187,7 @@ export const importGatewayLogs = action({
     }
 
     const agg = summarizeTraces(traces);
-    return {
+    const result: ImportGatewayLogsResult = {
       imported,
       deduped,
       parsed: traces.length,
@@ -167,6 +196,10 @@ export const importGatewayLogs = action({
       truncated,
       ...agg,
     };
+    if (args.sidecarJson !== undefined) {
+      result.sidecar = { entries: sidecarEntries, matched: sidecarMatched };
+    }
+    return result;
   },
 });
 

--- a/convex/traceAdapters/cloudflareAiGateway.test.ts
+++ b/convex/traceAdapters/cloudflareAiGateway.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
+  DEFAULT_SIDECAR_LIMITS,
   normalizeGatewayLog,
   parseGatewayJsonl,
+  parseSidecar,
   summarizeTraces,
 } from "./cloudflareAiGateway";
 
@@ -112,5 +114,117 @@ describe("convex cloudflare gateway parser", () => {
     expect(s.latest).toBe("2026-06-23T12:01:00Z");
     // summary carries no message/output text
     expect(JSON.stringify(s)).not.toContain("payoff");
+  });
+});
+
+describe("convex gateway metadata sidecar", () => {
+  // Record whose ground-truth metadata carries a trace_id (survives the 5-key
+  // cap) plus an inline `product` the sidecar must not override.
+  const withTrace = {
+    ...chat,
+    log_id: "log_TRACE_001",
+    metadata: { trace_id: "tr_abc", product: "support-assistant" },
+  };
+
+  it("merges a sidecar entry by metadata.trace_id, into rawPayloadJson", () => {
+    const { sidecar } = parseSidecar(
+      JSON.stringify({ tr_abc: { release: "2026.7.0", environment: "prod" } }),
+    );
+    const { traces, sidecarMerged } = parseGatewayJsonl(
+      JSON.stringify(withTrace),
+      undefined,
+      sidecar,
+    );
+    expect(sidecarMerged).toEqual([true]);
+    // The merged metadata is in the stored blob (rawPayloadJson), so
+    // materialization/readProduct picks it up for free.
+    const stored = JSON.parse(traces[0]!.rawPayloadJson);
+    expect(stored.metadata.release).toBe("2026.7.0");
+    expect(stored.metadata.environment).toBe("prod");
+  });
+
+  it("falls back to the log id when there is no metadata.trace_id", () => {
+    const { sidecar } = parseSidecar(
+      JSON.stringify({ log_TEST_001: { release: "fallback-rel" } }),
+    );
+    // `chat` has log_id but no metadata.trace_id.
+    const { traces, sidecarMerged } = parseGatewayJsonl(
+      JSON.stringify(chat),
+      undefined,
+      sidecar,
+    );
+    expect(sidecarMerged).toEqual([true]);
+    expect(JSON.parse(traces[0]!.rawPayloadJson).metadata.release).toBe(
+      "fallback-rel",
+    );
+  });
+
+  it("lets inline record metadata win on key conflicts", () => {
+    const { sidecar } = parseSidecar(
+      JSON.stringify({ tr_abc: { product: "WRONG", release: "r1" } }),
+    );
+    const { traces } = parseGatewayJsonl(
+      JSON.stringify(withTrace),
+      undefined,
+      sidecar,
+    );
+    const meta = JSON.parse(traces[0]!.rawPayloadJson).metadata;
+    // Gateway-logged value is ground truth.
+    expect(meta.product).toBe("support-assistant");
+    expect(meta.release).toBe("r1");
+  });
+
+  it("rejects entries whose values aren't primitives (counted, not thrown)", () => {
+    const { sidecar, entries } = parseSidecar(
+      JSON.stringify({
+        tr_abc: { release: "ok" },
+        tr_bad: { nested: { deep: 1 } },
+      }),
+    );
+    expect(entries).toBe(1); // only the primitive-valued entry counts
+    expect(sidecar).toBeDefined();
+    expect(sidecar!.tr_bad).toBeUndefined();
+    expect(sidecar!.tr_abc).toEqual({ release: "ok" });
+  });
+
+  it("treats an over-limit sidecar as invalid, without throwing", () => {
+    const tooMany = Object.fromEntries(
+      Array.from({ length: DEFAULT_SIDECAR_LIMITS.maxEntries + 1 }, (_, i) => [
+        `tr_${i}`,
+        { release: "r" },
+      ]),
+    );
+    const byEntries = parseSidecar(JSON.stringify(tooMany));
+    expect(byEntries.sidecar).toBeUndefined();
+    expect(byEntries.entries).toBe(0);
+
+    const oversized = "x".repeat(DEFAULT_SIDECAR_LIMITS.maxBytes + 1);
+    const byBytes = parseSidecar(oversized);
+    expect(byBytes.sidecar).toBeUndefined();
+    expect(byBytes.entries).toBe(0);
+  });
+
+  it("treats malformed sidecar JSON as invalid, without throwing", () => {
+    const bad = parseSidecar("{ not json");
+    expect(bad.sidecar).toBeUndefined();
+    expect(bad.entries).toBe(0);
+    const notObject = parseSidecar("[1,2,3]");
+    expect(notObject.sidecar).toBeUndefined();
+    expect(notObject.entries).toBe(0);
+  });
+
+  it("reports no merge for records with no matching sidecar key", () => {
+    const { sidecar } = parseSidecar(JSON.stringify({ tr_other: { a: "b" } }));
+    const { sidecarMerged, traces } = parseGatewayJsonl(
+      JSON.stringify(withTrace),
+      undefined,
+      sidecar,
+    );
+    expect(sidecarMerged).toEqual([false]);
+    // Untouched metadata still has only the inline keys.
+    expect(JSON.parse(traces[0]!.rawPayloadJson).metadata).toEqual({
+      trace_id: "tr_abc",
+      product: "support-assistant",
+    });
   });
 });

--- a/convex/traceAdapters/cloudflareAiGateway.test.ts
+++ b/convex/traceAdapters/cloudflareAiGateway.test.ts
@@ -213,6 +213,69 @@ describe("convex gateway metadata sidecar", () => {
     expect(notObject.entries).toBe(0);
   });
 
+  it("measures the size limit in UTF-8 bytes, not UTF-16 chars", () => {
+    // "€" is 1 UTF-16 char but 3 UTF-8 bytes — a multibyte payload must not
+    // sneak past maxBytes on character count.
+    const overByBytes = "€".repeat(
+      Math.floor(DEFAULT_SIDECAR_LIMITS.maxBytes / 3) + 1,
+    );
+    expect(new TextEncoder().encode(overByBytes).length).toBeGreaterThan(
+      DEFAULT_SIDECAR_LIMITS.maxBytes,
+    );
+    expect(overByBytes.length).toBeLessThan(DEFAULT_SIDECAR_LIMITS.maxBytes);
+    const rejected = parseSidecar(overByBytes);
+    expect(rejected.sidecar).toBeUndefined();
+    expect(rejected.entries).toBe(0);
+
+    // Exactly at the byte limit is allowed (guard is strict >).
+    const atLimitJson = JSON.stringify({ tr_abc: { release: "ok" } });
+    const padding = DEFAULT_SIDECAR_LIMITS.maxBytes - atLimitJson.length;
+    const atLimit = parseSidecar(atLimitJson + " ".repeat(padding));
+    expect(new TextEncoder().encode(atLimitJson + " ".repeat(padding)).length).toBe(
+      DEFAULT_SIDECAR_LIMITS.maxBytes,
+    );
+    expect(atLimit.entries).toBe(1);
+  });
+
+  it("never matches inherited object members as correlation ids", () => {
+    // A record whose trace_id collides with Object.prototype members must not
+    // pick up a phantom sidecar entry.
+    const hostileRecord = {
+      log_id: "log_h1",
+      metadata: { trace_id: "toString", product: "support-assistant" },
+      request: { messages: [{ role: "user", content: "hi" }] },
+      response: { choices: [{ message: { content: "ok" } }] },
+    };
+    const { sidecar } = parseSidecar(JSON.stringify({ tr_other: { a: "b" } }));
+    const { sidecarMerged } = parseGatewayJsonl(
+      JSON.stringify(hostileRecord),
+      undefined,
+      sidecar,
+    );
+    expect(sidecarMerged).toEqual([false]);
+
+    // A "__proto__" sidecar key stays a plain own key: it merges only into the
+    // record that carries that literal trace_id, and pollutes nothing.
+    const proto = parseSidecar(
+      JSON.stringify({ ["__proto__"]: { release: "r9" } }),
+    );
+    expect(proto.entries).toBe(1);
+    expect(({} as Record<string, unknown>).release).toBeUndefined();
+    const protoRecord = {
+      ...hostileRecord,
+      metadata: { trace_id: "__proto__", product: "support-assistant" },
+    };
+    const merged = parseGatewayJsonl(
+      JSON.stringify(protoRecord),
+      undefined,
+      proto.sidecar,
+    );
+    expect(merged.sidecarMerged).toEqual([true]);
+    expect(
+      JSON.parse(merged.traces[0]!.rawPayloadJson).metadata.release,
+    ).toBe("r9");
+  });
+
   it("reports no merge for records with no matching sidecar key", () => {
     const { sidecar } = parseSidecar(JSON.stringify({ tr_other: { a: "b" } }));
     const { sidecarMerged, traces } = parseGatewayJsonl(

--- a/convex/traceAdapters/cloudflareAiGateway.ts
+++ b/convex/traceAdapters/cloudflareAiGateway.ts
@@ -85,7 +85,7 @@ export type SidecarEntry = Record<string, string | number | boolean>;
 export type SidecarMap = Record<string, SidecarEntry>;
 
 export interface SidecarLimits {
-  /** Maximum sidecar text size guard (UTF-16 char length upper bound). */
+  /** Maximum sidecar text size in UTF-8 bytes. */
   maxBytes: number;
   /** Maximum number of correlation-id entries parsed. */
   maxEntries: number;
@@ -119,7 +119,8 @@ export function parseSidecar(
   text: string,
   limits: SidecarLimits = DEFAULT_SIDECAR_LIMITS,
 ): SidecarParseResult {
-  if (text.length > limits.maxBytes) return { sidecar: undefined, entries: 0 };
+  if (new TextEncoder().encode(text).length > limits.maxBytes)
+    return { sidecar: undefined, entries: 0 };
   let parsed: unknown;
   try {
     parsed = JSON.parse(text);
@@ -131,7 +132,9 @@ export function parseSidecar(
   const keys = Object.keys(outer);
   if (keys.length > limits.maxEntries) return { sidecar: undefined, entries: 0 };
 
-  const sidecar: SidecarMap = {};
+  // Prototype-less so hostile correlation ids ("__proto__", "toString") are
+  // plain own keys — lookups can never hit inherited Object.prototype members.
+  const sidecar: SidecarMap = Object.create(null) as SidecarMap;
   let entries = 0;
   for (const key of keys) {
     const inner = asRecord(outer[key]);
@@ -169,9 +172,14 @@ export function mergeSidecarIntoRecord(
   const existing =
     asRecord(get(rec, ["metadata", "request.metadata", "event.metadata"])) ?? {};
 
+  // Own-key lookup only — a plain-object SidecarMap must never match
+  // inherited members (toString, constructor) as correlation ids.
+  const lookup = (id: string): SidecarEntry | undefined =>
+    Object.prototype.hasOwnProperty.call(sidecar, id) ? sidecar[id] : undefined;
+
   let entry: SidecarEntry | undefined;
   const traceId = str(existing.trace_id);
-  if (traceId !== undefined) entry = sidecar[traceId];
+  if (traceId !== undefined) entry = lookup(traceId);
   if (entry === undefined) {
     const logId = getStr(rec, [
       "log_id",
@@ -182,7 +190,7 @@ export function mergeSidecarIntoRecord(
       "cf.ray_id",
       "ray_id",
     ]);
-    if (logId !== undefined) entry = sidecar[logId];
+    if (logId !== undefined) entry = lookup(logId);
   }
   if (entry === undefined) return false;
 

--- a/convex/traceAdapters/cloudflareAiGateway.ts
+++ b/convex/traceAdapters/cloudflareAiGateway.ts
@@ -59,6 +59,137 @@ export interface ParseResult {
   invalidLines: number[];
   /** True when the import hit `maxLines` and stopped early. */
   truncated: boolean;
+  /**
+   * Parallel to `traces`: whether a sidecar entry was merged into that trace's
+   * record before `rawPayloadJson` was produced. Populated only when a sidecar
+   * is supplied; empty/all-false otherwise. The importer counts matches over
+   * the subset of traces it actually imported (non-duplicates).
+   */
+  sidecarMerged: boolean[];
+}
+
+// ---- metadata sidecar --------------------------------------------------
+//
+// Cloudflare AI Gateway stores at most 5 custom-metadata keys per request and
+// silently drops the rest, so grouping keys that overflow the cap don't survive
+// on the log. The sidecar is an out-of-band JSON map — keyed by correlation id
+// (a `metadata.trace_id`, our documented convention, or a gateway log id) —
+// whose entries are merged back into a log record's metadata at import time,
+// BEFORE `rawPayloadJson` is produced. That way the stored blob and everything
+// downstream (materializeEvalCase.readProduct) see the merged metadata for
+// free. Mirrors `metadataSidecar` in `src/lib/evals/cloudflareAiGateway.ts`.
+
+/** A sidecar entry: extra metadata, primitive values only. */
+export type SidecarEntry = Record<string, string | number | boolean>;
+/** Outer key = correlation id (trace_id / log id); inner = extra metadata. */
+export type SidecarMap = Record<string, SidecarEntry>;
+
+export interface SidecarLimits {
+  /** Maximum sidecar text size guard (UTF-16 char length upper bound). */
+  maxBytes: number;
+  /** Maximum number of correlation-id entries parsed. */
+  maxEntries: number;
+}
+
+export const DEFAULT_SIDECAR_LIMITS: SidecarLimits = {
+  maxBytes: 2 * 1024 * 1024,
+  maxEntries: 5000,
+};
+
+export interface SidecarParseResult {
+  /** Parsed map, or `undefined` when the whole sidecar was rejected. */
+  sidecar?: SidecarMap;
+  /** Count of valid entries kept (entries with a non-primitive value dropped). */
+  entries: number;
+}
+
+const isPrimitive = (v: unknown): v is string | number | boolean =>
+  typeof v === "string" ||
+  (typeof v === "number" && Number.isFinite(v)) ||
+  typeof v === "boolean";
+
+/**
+ * Parse sidecar JSON text into a validated `SidecarMap`. Management-safe: over
+ * a size/entry limit, non-object shape, malformed JSON, or a non-object entry
+ * are treated as invalid and counted — never thrown, never echoed. Entries
+ * whose values aren't all primitives are dropped (the gateway-logged value is
+ * ground truth; a structured sidecar override is rejected rather than merged).
+ */
+export function parseSidecar(
+  text: string,
+  limits: SidecarLimits = DEFAULT_SIDECAR_LIMITS,
+): SidecarParseResult {
+  if (text.length > limits.maxBytes) return { sidecar: undefined, entries: 0 };
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return { sidecar: undefined, entries: 0 };
+  }
+  const outer = asRecord(parsed);
+  if (!outer) return { sidecar: undefined, entries: 0 };
+  const keys = Object.keys(outer);
+  if (keys.length > limits.maxEntries) return { sidecar: undefined, entries: 0 };
+
+  const sidecar: SidecarMap = {};
+  let entries = 0;
+  for (const key of keys) {
+    const inner = asRecord(outer[key]);
+    if (!inner) continue; // non-object entry -> reject (counted by omission)
+    const clean: SidecarEntry = {};
+    let ok = true;
+    for (const [k, val] of Object.entries(inner)) {
+      if (!isPrimitive(val)) {
+        ok = false; // reject the whole entry, don't partially merge
+        break;
+      }
+      clean[k] = val;
+    }
+    if (!ok) continue;
+    sidecar[key] = clean;
+    entries++;
+  }
+  return { sidecar, entries };
+}
+
+/**
+ * Merge a matching sidecar entry into a raw record's `metadata` IN PLACE, so a
+ * subsequently-produced `rawPayloadJson` (and downstream materialization) sees
+ * it. Correlation: the record's `metadata.trace_id` first (our convention —
+ * it survives the 5-key cap), else the record's log-id fields (same paths the
+ * adapter uses for the dedup id). The record's own inline metadata wins on key
+ * conflicts. Returns true when an entry was merged.
+ */
+export function mergeSidecarIntoRecord(
+  record: unknown,
+  sidecar: SidecarMap,
+): boolean {
+  const rec = asRecord(record);
+  if (!rec) return false;
+  const existing =
+    asRecord(get(rec, ["metadata", "request.metadata", "event.metadata"])) ?? {};
+
+  let entry: SidecarEntry | undefined;
+  const traceId = str(existing.trace_id);
+  if (traceId !== undefined) entry = sidecar[traceId];
+  if (entry === undefined) {
+    const logId = getStr(rec, [
+      "log_id",
+      "id",
+      "log.id",
+      "event_id",
+      "event.id",
+      "cf.ray_id",
+      "ray_id",
+    ]);
+    if (logId !== undefined) entry = sidecar[logId];
+  }
+  if (entry === undefined) return false;
+
+  // Inline metadata wins: sidecar first, then existing over the top. Written to
+  // the canonical `metadata` path, which readProduct resolves first.
+  rec.metadata = { ...entry, ...existing };
+  return true;
 }
 
 // ---- tiny readers (ported, zod-free) -----------------------------------
@@ -216,9 +347,11 @@ export function normalizeGatewayLog(record: unknown): NormalizedGatewayTrace {
 export function parseGatewayJsonl(
   text: string,
   limits: GatewayLimits = DEFAULT_LIMITS,
+  sidecar?: SidecarMap,
 ): ParseResult {
   const traces: NormalizedGatewayTrace[] = [];
   const invalidLines: number[] = [];
+  const sidecarMerged: boolean[] = [];
   const lines = text.split(/\r?\n/);
   let processed = 0;
   let truncated = false;
@@ -238,14 +371,17 @@ export function parseGatewayJsonl(
       invalidLines.push(i + 1);
       continue;
     }
+    // Merge BEFORE normalize so the merged metadata lands in rawPayloadJson.
+    const merged = sidecar ? mergeSidecarIntoRecord(obj, sidecar) : false;
     try {
       traces.push(normalizeGatewayLog(obj));
+      sidecarMerged.push(merged);
     } catch {
       invalidLines.push(i + 1);
     }
   }
 
-  return { traces, invalidLines, truncated };
+  return { traces, invalidLines, truncated, sidecarMerged };
 }
 
 export interface TraceAggregate {

--- a/docs/cloudflare-gateway-live-import.md
+++ b/docs/cloudflare-gateway-live-import.md
@@ -29,6 +29,14 @@ gateway (not a global key). See the in-app *Gateway onboarding* page for the
 metadata conventions (`product`, `module`, `prompt_version`, …) that make
 imported logs groupable.
 
+> **Prerequisite — enable payload logging.** Cloudflare only stores
+> request/response bodies when **Log payloads is enabled on the gateway**
+> (**AI Gateway → your gateway → Settings → payload logging** toggle). Without
+> it, exported logs carry metadata but no prompt/output text, so imported
+> traces have no output to score, materialized eval cases can't be scored, and
+> the scorecard reports them as skipped. It is not retroactive — enable it
+> before generating the traffic you onboard.
+
 The parser reads common field shapes opportunistically:
 
 | Field | Source paths tried |
@@ -52,6 +60,30 @@ The importer returns a management-safe summary: imported / deduped / parsed
 counts, invalid line numbers, missing-request / missing-response counts, the
 set of models and providers seen, and the earliest/latest timestamp.
 
+### Metadata sidecar
+
+Cloudflare stores at most 5 custom-metadata keys per request and silently drops
+the rest, so grouping keys that overflow the cap don't survive on the log. The
+importer accepts an **optional sidecar** — pass it to `importGatewayLogs` as the
+`sidecarJson` string argument — to merge those overflow keys back at import
+time:
+
+- **Format:** a JSON object `{ "<correlation-id>": { "<key>": <primitive>, … }, … }`.
+  Outer key is the correlation id; inner values must be primitives (string /
+  number / boolean). An entry with a non-primitive value is dropped and counted.
+- **Matching:** each record is correlated by its `metadata.trace_id` first (the
+  documented convention that survives the 5-key cap), falling back to the log id
+  fields (`log_id` / `id` / `event_id` / …). A matched entry is merged into the
+  record's metadata **before** the raw payload is stored, so downstream
+  materialization sees it. The record's own inline metadata **wins** on key
+  conflicts (the gateway-logged value is ground truth).
+- **Limits:** sidecar text ≤ **2 MB** and ≤ **5,000 entries**. Over either limit
+  (or malformed JSON) the sidecar is dropped and the import proceeds without it —
+  it never fails the import.
+- **Summary:** when a `sidecarJson` is supplied the result carries
+  `sidecar: { entries, matched }` (valid entries parsed / imported records
+  merged), counts only — sidecar content is never echoed.
+
 ## 3. Data boundary
 
 - **Import identity** is persisted: `(projectId, source, sourceTraceId)` rows
@@ -73,6 +105,8 @@ set of models and providers seen, and the earliest/latest timestamp.
 | Lines per import | 5,000 | Stops early, `truncated: true` in summary |
 | Payload size | 8 MB | Importer rejects with a "split into batches" error |
 | Invalid lines reported | 50 | Remainder counted but line numbers omitted |
+| Sidecar text | 2 MB | Sidecar dropped, import proceeds (`sidecar.entries: 0`) |
+| Sidecar entries | 5,000 | Sidecar dropped, import proceeds (`sidecar.entries: 0`) |
 
 Defaults live in `convex/traceAdapters/cloudflareAiGateway.ts`
 (`DEFAULT_LIMITS`).
@@ -105,6 +139,3 @@ No external state is created, so rollback needs no Cloudflare-side action.
 
 - **Materialization:** turn imported traces into prompt versions / completed
   run outputs (`setMaterialized` already exists) to drive baseline evals.
-- **Sidecar metadata merge:** the local adapter supports a `trace_id`-keyed
-  sidecar for fields too large for Gateway custom metadata; the Convex importer
-  does not yet accept one.

--- a/docs/gateway-onboarding.md
+++ b/docs/gateway-onboarding.md
@@ -17,6 +17,14 @@ production logs stay `prod_sensitive` and customer-scoped inside the workspace �
 never commit them to the repo. The repo and any demo use **synthetic or redacted
 samples only**.
 
+> **⚠️ Enable payload logging on the gateway first.** Cloudflare only stores
+> request/response bodies when **Log payloads is enabled on the gateway**
+> (**AI Gateway → your gateway → Settings → payload logging** toggle). Without
+> it, exported logs carry metadata but **no prompt/output text** — imported
+> traces then have no output to score, materialized eval cases can't be scored,
+> and the baseline scorecard reports them as **skipped**. Turn it on *before*
+> generating the traffic you plan to onboard; it is not retroactive.
+
 ---
 
 ## Onboarding checklist
@@ -45,12 +53,12 @@ only at step 7.
    product / time window, then import it (step 1's path). Each new, non-duplicate
    trace is stored as a deduplicated `traceImports` row; the importer returns a
    summary (imported / deduped / parsed / invalid counts, models, providers, and
-   the time window). **Manual/planned:** turning imported traces into runnable
-   eval cases uses `setMaterialized` in the backend, but the Convex importer does
-   not yet expose materialization in the UI (see
-   `cloudflare-gateway-live-import.md` "Follow-up"). Today the local path
-   (`normalizeCloudflareAiGatewayLog → convertTraceToEvalCase`) is how a trace
-   becomes an eval case.
+   the time window). Then click **Materialize into eval cases** on the same
+   page — imported traces become runnable eval cases in-app (idempotent;
+   re-run to drain backlogs larger than one 500-row batch), and the per-org
+   **Quality scorecard** page grades them. The local CLI path
+   (`normalizeCloudflareAiGatewayLog → convertTraceToEvalCase`) remains for
+   offline work.
 5. **Run a baseline eval.** Score the current production prompt against the pack
    to establish the baseline scorecard. The runner is
    `src/lib/evals/modelComparison.ts` (`npm run compare:demo`), and the
@@ -125,10 +133,28 @@ priority is `trace_id, tenant, product, prompt_version, variant`
 (`SMOKE_METADATA_KEYS` in `src/lib/evals/fireworksGatewaySmoke.ts`). Values must
 also stay short. Anything larger — full prompt text, long ids, structured
 context, and any keys that didn't make the cut — goes in a **sidecar record
-keyed by `trace_id`**, not inline in Gateway metadata. Note that the Convex
-importer does **not yet accept a sidecar** (the local exported-JSONL adapter
-does — see `cloudflare-gateway-live-import.md` "Follow-up"), so for now keep
-everything you need for grouping inside your 5 metadata keys.
+keyed by `trace_id`**, not inline in Gateway metadata.
+
+**The Convex importer now accepts a sidecar** (as does the local exported-JSONL
+adapter). Pass it to `importGatewayLogs` as the optional `sidecarJson` string
+argument. Format and rules:
+
+- **Shape:** a JSON object `{ "<correlation-id>": { "<key>": <primitive>, … }, … }`
+  — outer key is the correlation id, inner object is the extra metadata.
+  Values must be primitives (string / number / boolean); an entry with a
+  non-primitive value is dropped and counted, never merged.
+- **Matching:** each log record is correlated by its `metadata.trace_id` first
+  (the convention that survives the 5-key cap), falling back to the record's log
+  id fields (`log_id` / `id` / `event_id` / …). A matched entry is merged into
+  the record's metadata **before** the raw payload is stored, so materialized
+  eval cases (which read `product` and friends from the stored record) pick it
+  up for free. The record's own inline metadata **wins** on key conflicts — the
+  gateway-logged value is ground truth.
+- **Limits:** sidecar text ≤ **2 MB** and ≤ **5,000 entries**; over either
+  limit (or malformed JSON) the sidecar is dropped and the import proceeds
+  without it. The import summary reports `sidecar: { entries, matched }`
+  (valid entries parsed / imported records merged), counts only — never sidecar
+  content.
 
 Metadata travels two ways on a request: in the request body's `metadata` field
 and in a `cf-aig-metadata` header

--- a/src/routes/orgs/GatewayImport.tsx
+++ b/src/routes/orgs/GatewayImport.tsx
@@ -34,6 +34,7 @@ export function GatewayImport() {
 
   const [projectId, setProjectId] = useState<string>("");
   const [jsonl, setJsonl] = useState("");
+  const [sidecarJson, setSidecarJson] = useState("");
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState("");
   const [summary, setSummary] = useState<ImportSummary | null>(null);
@@ -45,9 +46,11 @@ export function GatewayImport() {
     setError("");
     setSummary(null);
     try {
+      const trimmedSidecar = sidecarJson.trim();
       const result = await importLogs({
         projectId: projectId as Id<"projects">,
         jsonl,
+        ...(trimmedSidecar ? { sidecarJson: trimmedSidecar } : {}),
       });
       setSummary(result);
     } catch (err) {
@@ -143,6 +146,31 @@ export function GatewayImport() {
           </p>
         </div>
 
+        <details className="rounded-lg border bg-muted/30 px-4 py-3">
+          <summary className="cursor-pointer text-sm font-medium">
+            Metadata sidecar (optional)
+          </summary>
+          <div className="mt-3 space-y-1.5">
+            <Label htmlFor="gw-sidecar">Sidecar JSON</Label>
+            <Textarea
+              id="gw-sidecar"
+              value={sidecarJson}
+              onChange={(e) => setSidecarJson(e.target.value)}
+              placeholder={'{ "<trace_id>": { "module": "...", "release": "..." } }'}
+              rows={6}
+              spellCheck={false}
+              className="font-mono text-xs"
+            />
+            <p className="text-xs text-muted-foreground">
+              Cloudflare keeps only 5 metadata keys per request. Paste a JSON
+              object keyed by trace_id to restore the rest:{" "}
+              <code className="text-foreground">
+                {'{ "<trace_id>": { "module": "...", "release": "..." } }'}
+              </code>
+            </p>
+          </div>
+        </details>
+
         {error && (
           <p className="text-sm text-destructive" role="alert">
             {error}
@@ -186,12 +214,42 @@ function ImportSummaryCard({ summary }: { summary: ImportSummary }) {
     { label: "Missing request", value: String(summary.redactedRequest) },
     { label: "Missing response", value: String(summary.redactedResponse) },
   ];
+
+  // "Log payloads" is off when nearly every imported row lands with no response
+  // body — those outputs can never be scored. Amber, not red (color-blind rule).
+  const processed = summary.imported + summary.deduped;
+  const payloadsLikelyOff =
+    processed > 0 && summary.redactedResponse >= processed * 0.9;
+
   return (
     <Card className="mt-6">
       <CardHeader>
         <CardTitle className="text-base">Import summary</CardTitle>
       </CardHeader>
       <CardContent className="space-y-3 text-sm">
+        {payloadsLikelyOff && (
+          <div className="rounded-lg border border-amber-500/40 bg-amber-500/5 p-3">
+            <div className="flex items-start gap-2">
+              <ShieldAlert
+                aria-hidden="true"
+                className="mt-0.5 h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400"
+              />
+              <div className="space-y-1">
+                <p className="font-semibold">
+                  This gateway isn’t storing payloads
+                </p>
+                <p className="text-muted-foreground">
+                  Nearly every imported row has no response body, so these
+                  outputs can’t be scored. Enable{" "}
+                  <strong className="text-foreground">Log payloads</strong> in
+                  Cloudflare (AI Gateway → your gateway → Settings), then
+                  re-generate traffic and re-import.
+                </p>
+              </div>
+            </div>
+          </div>
+        )}
+
         <dl className="grid grid-cols-2 gap-3 sm:grid-cols-3">
           {stats.map((s) => (
             <div key={s.label}>
@@ -222,6 +280,13 @@ function ImportSummaryCard({ summary }: { summary: ImportSummary }) {
         {(summary.earliest || summary.latest) && (
           <p className="text-xs text-muted-foreground">
             Window: {summary.earliest ?? "?"} → {summary.latest ?? "?"}
+          </p>
+        )}
+
+        {summary.sidecar && (
+          <p className="text-xs text-muted-foreground">
+            Sidecar: {summary.sidecar.entries} entries,{" "}
+            {summary.sidecar.matched} traces enriched
           </p>
         )}
       </CardContent>

--- a/src/routes/orgs/GatewayImport.tsx
+++ b/src/routes/orgs/GatewayImport.tsx
@@ -285,7 +285,8 @@ function ImportSummaryCard({ summary }: { summary: ImportSummary }) {
 
         {summary.sidecar && (
           <p className="text-xs text-muted-foreground">
-            Sidecar: {summary.sidecar.entries} entries,{" "}
+            Sidecar: {summary.sidecar.entries}{" "}
+            {summary.sidecar.entries === 1 ? "entry" : "entries"},{" "}
             {summary.sidecar.matched} newly imported{" "}
             {summary.sidecar.matched === 1 ? "trace" : "traces"} enriched
             (previously imported duplicates keep their original metadata)

--- a/src/routes/orgs/GatewayImport.tsx
+++ b/src/routes/orgs/GatewayImport.tsx
@@ -286,7 +286,9 @@ function ImportSummaryCard({ summary }: { summary: ImportSummary }) {
         {summary.sidecar && (
           <p className="text-xs text-muted-foreground">
             Sidecar: {summary.sidecar.entries} entries,{" "}
-            {summary.sidecar.matched} traces enriched
+            {summary.sidecar.matched} newly imported{" "}
+            {summary.sidecar.matched === 1 ? "trace" : "traces"} enriched
+            (previously imported duplicates keep their original metadata)
           </p>
         )}
       </CardContent>

--- a/src/routes/orgs/GatewayOnboarding.tsx
+++ b/src/routes/orgs/GatewayOnboarding.tsx
@@ -174,8 +174,8 @@ export function GatewayOnboarding() {
                 <strong className="text-foreground">Log payloads</strong> for
                 the gateway (AI Gateway → your gateway → Settings) before
                 exporting. Without it, logs carry no request/response bodies —
-                imported traces have no output text, and nothing downstream can
-                be materialized or scored.
+                imported traces have no output text, so the eval cases built
+                from them cannot be scored.
               </p>
             </div>
           </div>

--- a/src/routes/orgs/GatewayOnboarding.tsx
+++ b/src/routes/orgs/GatewayOnboarding.tsx
@@ -161,6 +161,25 @@ export function GatewayOnboarding() {
         <h2 id="checklist-heading" className="text-lg font-semibold">
           Onboarding checklist
         </h2>
+        <div className="mt-3 rounded-lg border border-amber-500/40 bg-amber-500/5 p-4">
+          <div className="flex items-start gap-2 text-sm">
+            <ShieldAlert
+              aria-hidden="true"
+              className="mt-0.5 h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400"
+            />
+            <div className="space-y-1">
+              <p className="font-semibold">Enable payload logging first</p>
+              <p className="text-muted-foreground">
+                Turn on{" "}
+                <strong className="text-foreground">Log payloads</strong> for
+                the gateway (AI Gateway → your gateway → Settings) before
+                exporting. Without it, logs carry no request/response bodies —
+                imported traces have no output text, and nothing downstream can
+                be materialized or scored.
+              </p>
+            </div>
+          </div>
+        </div>
         <ol className="mt-3 space-y-3">
           {STEPS.map((step, i) => (
             <li

--- a/src/routes/orgs/Scorecard.tsx
+++ b/src/routes/orgs/Scorecard.tsx
@@ -274,6 +274,45 @@ function CompletedScorecard({ latest }: { latest: Latest }) {
   const hardFailFindings = latest.hardFailFindings ?? [];
   const blocked = (summary?.hardFailed ?? 0) > 0;
 
+  // Every materialized case was skipped for want of a captured output — the
+  // scorecard graded nothing. Make that the headline instead of an empty grid.
+  const nothingScored =
+    !!summary && summary.cases === 0 && summary.skippedNoOutput > 0;
+
+  if (nothingScored) {
+    return (
+      <div className="space-y-8">
+        <p className="text-xs text-muted-foreground">
+          as of {formatTimestamp(latest.completedAt ?? latest.startedAt)}
+        </p>
+        <Card className="border-amber-500/40 bg-amber-500/5">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-base">
+              <FileWarning
+                aria-hidden="true"
+                className="h-4 w-4 text-amber-600 dark:text-amber-400"
+              />
+              No cases could be scored
+            </CardTitle>
+            <CardDescription>
+              All {summary.skippedNoOutput} materialized case
+              {summary.skippedNoOutput === 1 ? "" : "s"} had no captured output
+              to score — usually payload logging is off on the gateway. Enable{" "}
+              <strong className="text-foreground">Log payloads</strong> in
+              Cloudflare (AI Gateway → your gateway → Settings), re-generate
+              traffic, and re-import.
+            </CardDescription>
+          </CardHeader>
+        </Card>
+        <Separator />
+        <p className="text-xs text-muted-foreground">
+          This surface shows only case IDs, product labels, scorer keys, and
+          aggregate counts — never prompts, model outputs, or scorer reasons.
+        </p>
+      </div>
+    );
+  }
+
   return (
     <div className="space-y-8">
       <p className="text-xs text-muted-foreground">
@@ -355,13 +394,19 @@ function CompletedScorecard({ latest }: { latest: Latest }) {
             />
           </div>
           {summary.skippedNoOutput > 0 && (
-            <div className="mt-3">
+            <div className="mt-3 space-y-2">
               <MetricCard
                 icon={FileWarning}
                 label="Skipped — no output"
                 value={String(summary.skippedNoOutput)}
                 detail="Imported traces with no captured output to grade"
               />
+              <p className="text-xs text-muted-foreground">
+                {summary.skippedNoOutput} case
+                {summary.skippedNoOutput === 1 ? "" : "s"} had no captured
+                output to score — usually payload logging is off on the gateway.
+                Enable Log payloads in Cloudflare and re-import.
+              </p>
             </div>
           )}
         </section>


### PR DESCRIPTION
Two refinements from the live Gateway work, per explicit scoping decision (scorer configurability filed separately as #261).

## 1. Payload-logging guidance (the first wall a real customer hits)

Cloudflare only stores request/response bodies when **Log payloads** is enabled on the gateway — our own live smoke came back with redacted bodies. Without it, imported traces have no output text and the scorecard silently skips everything. Now surfaced at every stage:

- **Gateway onboarding:** amber "Enable payload logging first" prerequisite callout with the CF dashboard path.
- **Gateway import:** amber warning when ~all imported rows (≥90%) lack response bodies, with the fix spelled out.
- **Scorecard:** skipped-cases footnote explaining the likely cause; when *nothing* could be scored, a dominant "No cases could be scored" state replaces the empty-looking metric grid.

## 2. Metadata sidecar in the Convex importer

CF caps custom metadata at 5 keys and silently drops the rest (verified live, PR #257), so grouping keys like `module`/`release`/`environment` rarely survive. The local CLI adapter already supported a sidecar; the in-app importer now does too:

- `importGatewayLogs` accepts optional `sidecarJson`: a JSON map `{ "<trace_id>": { "module": "...", ... } }` (primitive values only).
- Entries merge into each record's metadata **before** the raw payload blob is stored, so materialization (#260) picks restored keys up for free. Matched by `metadata.trace_id` first, log-id fields fallback; the gateway-logged inline metadata wins conflicts.
- Limits: 2 MB (UTF-8 bytes) / 5,000 entries; malformed sidecar never fails the import; result reports counts only (`sidecar: { entries, matched }`), content never echoed.
- Import UI: collapsed "Metadata sidecar (optional)" textarea + enrichment counts in the summary.
- Docs updated (format, matching rule, limits, payload prerequisite); also corrected the stale "materialization not in UI" paragraph left over from before #260.

## Review & verification

- Codex round 1: 4 findings (UTF-16 vs UTF-8 size-limit bypass, prototype-pollution-able sidecar lookups, two copy issues) — all fixed.
- Codex round 2: fixes verified correct (including confirming TextEncoder in the Convex runtime); remaining asks were edge-case tests + a pluralization nit, both done: multibyte at/over-limit, hostile `toString` trace_id, `__proto__` sidecar key merging without pollution.
- **239/239 tests pass** (9 new); esbuild parses all touched Convex modules; 6 pre-existing `convex/_generated` file-level failures unchanged (Vercel CI authoritative, deploys Convex in-build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)