### PR TITLE
docs: agent trace strategy + M31 Trajectory Spine plan

### DIFF
--- a/docs/handoffs/2026-07-07-m31-trajectory-spine.md
+++ b/docs/handoffs/2026-07-07-m31-trajectory-spine.md
@@ -1,0 +1,42 @@
+# Handoff: M31 Trajectory Spine kickoff (2026-07-07)
+
+## Goal
+Implement M31 per `project-docs/Blind Bench - Agent Trace Strategy.md`
+(approved by Noah 2026-07-07) — issues #264–#268, starting with #264.
+
+## State
+- Done + verified: strategy doc, Build Plan M31 section, Positioning addendum
+  committed as `4840c98` on local main; M31 milestone + issues #264–#268
+  created; #130/#131/#133/#136/#209/#219 closed; #263/#261/#53 re-scoped via
+  comments (verified via `gh issue list`).
+- Not started: all implementation. Order: #264 (spine schema — gates the
+  rest) → #265 (CC JSONL importer) ∥ #268 (Harbor spike) → #266 → #267.
+- **Unpushed:** `4840c98` is local-only. Issue comments link the strategy doc
+  path on GitHub — push first or the links 404.
+
+## Next action
+Push `4840c98` (Noah runs `git push origin main`, or via PR branch), then
+`gh issue edit 264 --add-label "in-progress"` and start the schema on a
+branch per CLAUDE.md workflow.
+
+## Landmines
+- Auto-mode permission classifier blocks: subagents closing GH issues,
+  closing issues after a user "hold" without fresh explicit confirmation, and
+  pushing to main. Ask Noah directly (AskUserQuestion) rather than retrying.
+- Noah kept **#55 open** (deprioritized, not closed) — don't re-close it.
+- #264 constraints: full trace must NEVER be one Convex doc (~1MiB cap);
+  step bodies → file storage (`rawPayloadStorageId` pattern); paginated
+  queries only. `src/lib/evals/agentTrace.ts` is the type source but is
+  duplicated-by-design vs `convex/*` (zod-free runtime) — resolve for this
+  module, see header comments in `convex/lib/scorecardScoring.ts`.
+- Blind projection must be precomputed + enforced at the function boundary;
+  copy frames trace blinding as bias reduction, NOT anonymity (Codex review,
+  recorded in strategy doc).
+- Noah's standing prefs: subagents on Opus for delegated work; Reviewr pane
+  for manual review before handoff (a pane may still be open from this
+  session, w5:p4).
+
+## Verify
+- `git log --oneline -1` → `4840c98 docs: agent trace strategy…` (passes)
+- `gh issue list --milestone "M31 — Trajectory Spine"` → #264–#268 (passes)
+- `git status --short` → clean except this handoff file

--- a/project-docs/Blind Bench - Agent Trace Strategy.md
+++ b/project-docs/Blind Bench - Agent Trace Strategy.md
@@ -1,0 +1,271 @@
+---
+title: "Blind Bench - Agent Trace Strategy"
+created: 2026-07-07
+modified: 2026-07-07
+type: strategy
+status: draft
+tags:
+  - blind-bench
+  - strategy
+  - agent-traces
+---
+
+# Blind Bench — Agent Trace Strategy
+
+> **DRAFT for Noah.** Synthesized 2026-07-07 from: a codebase capability audit, a
+> GH pipeline audit, market/landscape research (~60 primary sources), and an
+> independent Codex review. Strategy calls are marked **[DECISION: Noah]**.
+> Companion to [[Blind Bench - Positioning]] (2026-04) and
+> [[Blind Bench - AI Quality Bench Spec]] (2026-07, M30).
+
+---
+
+## Aim
+
+Decide what BlindBench builds next, given that the unit of AI work has shifted
+from *a prompt's output* to *an agent's trajectory* (task → tool calls →
+reasoning → outcome, run by a model+harness combo, often in a sandbox) — and
+position BlindBench so the human judgment it collects becomes training data
+that improves models over time (Fireworks SFT / DPO / RFT).
+
+## The thesis in one paragraph
+
+Everyone in the observability space has traces; almost nobody has disciplined
+human judgment attached to them, and **nobody has blind human judgment**.
+Market research (July 2026) confirms the intersection — **blind, step-level
+human review of agent traces with training-ready export** — is empty across
+all eight living observability platforms, both arena products, and the
+labeling vendors. Sandbox execution (Harbor, Daytona, E2B, Modal) and
+fine-tuning targets (Fireworks, OpenAI, Together) are commoditized on both
+sides of it. The empty middle is exactly the human-judgment layer, and
+BlindBench's blind-eval discipline (enforced at the Convex function boundary,
+opaque tokens, no provenance in the DOM) is the one asset none of them have.
+The open question is **demand density, not competitive occupancy**.
+
+## What changed in the world
+
+1. **Agentic harnesses went mainstream.** Claude Code, Codex CLI, OpenHands
+   etc. now do real work — code review, PRs, customer service — as
+   long-running agents in their own environments (local or cloud sandboxes:
+   Modal, Cloudflare, Vercel Sandbox, Daytona, E2B, Fly).
+2. **The harness matters as much as the model.** Harness-Bench (2026) showed
+   the same model across harnesses can vary ~32× in cost for near-identical
+   output. "Model+harness combo" is now a legitimate unit of comparison —
+   and no product lets you compare combos on *your* task with *your* experts.
+3. **Trajectory data has no interchange standard.** OTLP is the wire format;
+   OTel GenAI semconv is still experimental; Claude Code JSONL, OpenAI Agents
+   SDK, SWE-agent `.traj`, OpenHands events are all bespoke. Defining the
+   normalization is an opportunity, not a tax. (We already drafted it:
+   `src/lib/evals/agentTrace.ts`.)
+4. **Fine-tuning demand shifted toward structured expert judgment.** Fireworks
+   RFT went GA; rubric-based reward is the wave. Expert-data vendors (Surge,
+   Mercor, Handshake) are exploding but enterprise-gated. No product offers
+   {self-serve} + {bring your own expert reviewers} + {one-click SFT + DPO
+   export}.
+
+## Where we actually are (honest inventory)
+
+Shipped and wired: CF AI Gateway JSONL import + metadata sidecar + dedup +
+raw-blob storage; eval-case materialization; deterministic scorers; per-org
+scorecard; review cycles with ratings, pairwise matchups (Bradley-Terry),
+inline comments; unified invites incl. no-account guest review; Polar billing
+foundation.
+
+Designed but **unwired** (lab/CLI only): the multi-step `AgentRunTrace` schema
+(tool calls, reasoning, policy events, per-step privacy classes, blind-view
+projection); Fireworks SFT dataset compiler with consent gates; review →
+promotion workflow; live baseline-vs-candidate endpoint comparison.
+
+**Genuinely absent** — and exactly the heart of the new direction:
+
+| Gap | Detail |
+|---|---|
+| Trace-step persistence | No Convex table stores steps. `evalCases` is flat messages+outputText. Convex ~1MB doc limit forces step bodies to file storage with light inline pointers (pattern already exists: `rawPayloadStorageId`). |
+| Step-level annotation | All comment anchors are text ranges in one immutable document, or whole-output notes. No `{kind:"step"}` / `{kind:"tool_call"}` anchor, no per-step render surface. |
+| Sandbox / harness execution | Nothing. Explicit non-goal to date. |
+| Preference → training bridge | Ratings + pairwise matchups are collected in prod; the SFT compiler exists in the lab; **no bridge between them** and no export UI/endpoint. |
+
+## The positioning tension (must resolve)
+
+Three artifacts point three directions:
+
+- **Positioning (April):** non-technical reviewers; developers are the
+  *anti-persona*; "not a tracing platform."
+- **AI Quality Bench spec (July, M30):** CF-Gateway-centric closed loop;
+  technical buyer; reviewer is one step, not the headline.
+- **New direction (this doc):** agent trajectories; the qualified reviewer of
+  a Claude Code trace is usually a senior engineer or domain expert.
+
+**Resolution (recommended):** the through-line was never "non-technical" — it
+was **"the person whose judgment matters, reviewing without bias, without
+living in a dashboard."** For brand voice that's a VP of Marketing; for a
+customer-service agent it's a CX lead; for a coding agent it's a senior
+engineer. The persona generalizes from "non-technical reviewer" to **domain
+expert reviewer**. What survives from April: blind-by-default, shareable-link
+zero-friction review, plain-language reviewer surfaces, feedback that goes
+somewhere. What's retired: "developers are the anti-persona" (they're now a
+first-class *reviewer*, not just buyer-influencer). What stays true: we are
+still not a tracing platform — we are the **judgment layer** that tracing
+platforms, harnesses, and sandboxes feed into.
+
+Fit with the DPO constraint (verified): Fireworks/OpenAI/Together DPO is
+single-turn — preference over the *final assistant message*. Whole-trajectory
+preferences don't map to DPO directly; **step-level preferences do** ("the
+best next action at step k given an identical prefix" is exactly a single-turn
+pair). Whole-run judgments feed trajectory-filtered SFT and RFT rubrics
+instead. The training-data angle *requires* step-level review — the product
+thesis and the export format reinforce each other.
+
+## Options considered
+
+| Option | Why it might work | Risk / friction | First test | Kill signal |
+|---|---|---|---|---|
+| **A. Trajectory spine**: agent-trace storage + step-level blind review UI over *uploaded* traces | The one data-model shift everything else hangs off; wires existing `agentTrace.ts`; whitespace is verified | Blind projection of traces is hard (tool names fingerprint the harness); review UX for long traces is novel | Import a real Claude Code session, have 2 engineers review it step-level, blind | Reviewers won't finish a trace review; step comments add nothing over whole-run verdicts |
+| **B. Ingestion breadth**: Claude Code JSONL importer + OTLP GenAI endpoint (#263) | Every Claude Code user has transcripts on disk today — zero-integration wedge; OTLP is the standard wire format | Format churn (semconv experimental; CC JSONL undocumented) | Ship CC importer, post "get your agent session reviewed by a human, blind" | Nobody uploads |
+| **C. Training export bridge** (#53): preferences/matchups → Fireworks SFT + DPO + RFT rubrics | Turns review exhaust into the paid artifact; converged interchange format; nobody else does it | Needs A for step-level pairs; consent/data-boundary care | Compile one real DPO set from existing cyclePreferences; run a Fireworks job | Fine-tune shows no lift customers care about |
+| **D. Sandbox execution matrix**: run same task across model+harness combos | The full vision; Harness-Bench legitimizes it; demo-able ("watch 4 harnesses race, judge blind") | Biggest build; infra is commoditized (Harbor already runs CC/Codex/OpenHands across Daytona/Modal/E2B) — **integrate, never build**; cost of runs | One manual Harbor run → import 4 trajectories → blind review | A+B show users only care about their own prod traces, not synthetic matrix runs |
+| **E. Finish the Pennie/M30 loop** (billing #236, Fireworks runbook → product step) | Revenue now; hardens the same loop; beachhead reference | Time not spent on the spine; CF-Gateway-specific surface area | Already in flight — SOW milestones | Pilot stalls / churns |
+
+Boring option: E alone (milk the pilot, defer the vision). Wild card: D-first
+as a public spectacle (blind harness races as content marketing).
+
+## Recommendation
+
+**Sequence (as decided by Noah, 2026-07-07): A (spine, with Claude Code
+upload as its test ingestion) + D (sandbox matrix via Harbor/Daytona
+integration — pulled forward per Noah, integrated never built) in parallel →
+C (export bridge) → B (OTLP #263), with E continuing in parallel
+(pilot-driven).**
+
+Rationale for A+D pairing: the matrix produces trajectories; the spine is
+what renders and reviews them. D without A has nothing to show reviewers; A
+gets its best demo content from D ("watch 4 model+harness combos run the
+same task, judge blind"). D remains an *integration* — Harbor already runs
+Claude Code/Codex CLI/OpenHands across Daytona/Modal/E2B; we orchestrate and
+import, we do not build sandbox infra.
+
+1. **A. Trajectory spine first** — tiny `agentTraces` parent row + separate
+   `agentTraceSteps` rows, large step bodies to file storage, precomputed
+   blind projections, pagination (never a reactive subscription over a full
+   trace); wire the existing `agentTrace.ts` normalizer into Convex;
+   step/tool-call comment anchors; blind projection enforced server-side like
+   today's blind mode. **Claude Code JSONL file upload is the spine's first
+   ingestion path** — the cheapest real agent traces in the world, zero
+   integration, and the dogfood loop (we review our own sessions).
+2. **C. Export bridge** — step-level preference pairs → Fireworks DPO;
+   whole-trajectory verdicts → filtered SFT; rubric outcomes → RFT reward
+   spec. Converts review exhaust into the paid artifact. Do not market DPO
+   until the UI actually captures comparable step-level choices.
+3. **B. OTLP GenAI endpoint (#263)** after the review surface exists —
+   Codex's framing is right: before the spine, OTLP is a telemetry intake
+   pipe with no differentiated product.
+4. **E continues** as the revenue/hardening track (Pennie pilot; billing).
+   Codex would put this outright first; see decision point 4.
+5. **D later**, as a thin integration over Harbor or Daytona once A–C prove
+   people will review trajectories at all. Running the matrix ourselves is a
+   service/demo before it is a product feature.
+
+### Pipeline actions (mechanical, once approved)
+
+- Re-scope **#263** (OTLP GenAI ingest) to follow the trajectory spine, not
+  lead it; the spine's first ingestion is Claude Code JSONL file upload.
+- Close as obsolete: **#130, #131, #133** (per-SaaS paste adapters), **#136**
+  (paste-import UI as scoped), **#55** (public prompt benchmarks — pre-pivot
+  framing). Also cleanup: **#209** (test issue), **#219** (mis-filed A2PCheck).
+- Pull forward **#261** (configurable scorers) and **#53** (training export).
+- New issues to write: trajectory spine (schema + storage + normalizer
+  wiring), step-level annotation anchors + trace review UI, blind projection
+  layer, Claude Code JSONL importer, preference→Fireworks bridge, Harbor
+  integration spike.
+- Update **Build Plan** with an M31+ section; update **Positioning** with the
+  "domain expert reviewer" resolution.
+
+## Decision points — **DECIDED by Noah, 2026-07-07**
+
+1. **Persona:** ✅ Generalize to "domain expert reviewer." Engineers become
+   first-class reviewers; "developers are the anti-persona" is retired; blind-
+   by-default, zero-friction links, and plain-language surfaces survive.
+2. **Execution layer:** ✅ **Pull the sandbox matrix forward** as a near-term
+   milestone (the demo-able expression of the vision), but as an
+   *integration* over Harbor/Daytona — not built in-house. Runs in parallel
+   with the spine (see Recommendation).
+3. **First ingestion wedge:** ✅ Claude Code JSONL upload first; OTLP (#263)
+   follows the spine.
+4. **Pennie pilot priority:** ✅ Parallel — the pilot continues as the
+   revenue/hardening track while the spine starts now (this doc's rec over
+   Codex's pilot-first).
+5. **Honest risk accepted:** demand density. The niche is empty partly
+   because it may be small (teams that run agents seriously AND have in-house
+   experts AND want to fine-tune). Mitigation: the spine + CC upload are
+   cheap to test — the kill signals are fast and observable.
+
+> **Pipeline actions approved by Noah 2026-07-07** ("aligned with the plan,
+> continue") — issue cleanup, re-scopes, and the M31 issue set are being
+> executed.
+
+## Risks
+
+- **Blind-eval leakage surface explodes with traces.** Tool names, reasoning
+  style, harness metadata all fingerprint the combo. Mitigate: server-side
+  step-level redaction/projection (`toScorerVisibleAgentRun` pattern), and
+  honesty that blinding traces is *statistical bias reduction*, not perfect
+  anonymity.
+- **Convex doc limits.** Traces must be storage-backed from day one; inline
+  arrays will not survive real Claude Code sessions.
+- **Dual code paths** (`src/lib/evals/*` vs `convex/*`) double every trace
+  feature. Resolve the duplication before the spine grows.
+- **LLM-as-judge encroachment.** Incumbents bet judges replace routine human
+  review. Our wedge is high-stakes/expert domains where judges are untrusted
+  and "where did it go wrong" is step-level. Don't compete on judge tooling.
+- **DPO overpromise.** Never market "human feedback → DPO" naively; the
+  single-turn constraint shapes what we can honestly export.
+
+## Codex second opinion (independent review, 2026-07-07)
+
+Codex reviewed the repo and the pivot unanchored by this doc's recommendation.
+Convergent on the big calls, divergent on sequencing:
+
+- **Coherence:** the direction is coherent *only* as "blind human judgment
+  over AI behavior," not as April's "Google Docs for AI evaluation." It
+  becomes a second product if BlindBench tries to own sandbox execution and
+  model-harness orchestration. "The April doc should stop controlling
+  strategy"; the durable through-line is "domain expert feedback without
+  model/vendor bias."
+- **Sequencing (Codex's ranking):** 1) finish the Pennie/CF Gateway loop —
+  the closest thing to a shipped wedge; get customer evidence before the
+  agent-trace bet consumes the company; 2) step-level trace storage + review
+  UI over *uploaded* traces, kept narrow; 3) preference→Fireworks export
+  bridge (existing reviewer labor → concrete artifact); 4) OTLP (#263) —
+  "useful later, dangerous early; a telemetry intake pipe with no
+  differentiated product" if it precedes the review surface; 5) sandbox
+  execution — "defer hard."
+- **Biggest technical risk (verified):** the trace data model. Convex ~1MiB
+  doc cap; `AgentRunTrace.steps` inline must never become one document; a
+  modest 100-step run at 10KB/step is at the limit. Correct model: tiny
+  `agentTraces` parent row, separate `agentTraceSteps` rows, large bodies in
+  storage blobs, **precomputed blind projections**, pagination, no reactive
+  subscription over a full trace. Second severe risk: blind leakage — the
+  current scorer-visible projection still exposes harness/model/tool names,
+  and reviewers can fingerprint Claude Code vs Codex from tool names, timing,
+  error formats, reasoning style. "Blindness here becomes bias reduction, not
+  true anonymity. The product should say that honestly."
+- **Kill list:** in-house sandbox execution (clearest path to a second
+  product); "developers are the anti-persona"; full-trace inline Convex
+  documents; adapter sprawl / tracing-platform ambitions; DPO promises not
+  backed by the captured data shape; OTLP as the first agent-trace milestone.
+- **Stale-doc catch:** the July spec's "UI materialization not exposed" note
+  is outdated — `GatewayImport.tsx` now exposes materialization.
+
+**Where this doc updated after Codex:** OTLP (#263) demoted from "flagship of
+the ingestion track" to "follows the spine" — the first ingestion path is
+file-upload (Claude Code JSONL), not a streaming endpoint. The export bridge
+moved ahead of OTLP. The remaining genuine disagreement is E-vs-A priority
+(pilot-first vs spine-first) — left to Noah as decision point 4.
+
+## Next action
+
+Noah reads this doc and approves/amends the Pipeline actions. Then: write the
+M31 issue set (trajectory spine + Harbor integration spike + CC JSONL
+importer + step-level annotation + export bridge), update the Build Plan with
+an M31+ section, update Positioning with the "domain expert reviewer"
+resolution, and start the spine schema.

--- a/project-docs/Blind Bench - Build Plan.md
+++ b/project-docs/Blind Bench - Build Plan.md
@@ -18,6 +18,8 @@ This doc expands the architecture doc's 10-bullet Next Steps into demoable miles
 
 The numbering starts at M0 to mirror "milestone zero = setup" conventions. Milestones are strictly sequential on the critical path except where the dependency graph below says otherwise.
 
+> **Milestone coverage note (2026-07-07).** This doc formally covers M0–M7, with a handful of later milestones (M21, M26, M29) retro-inserted where they earned a full spec. Milestones **M8–M30** are tracked in GH issues (the source of truth per `CLAUDE.md`) and the strategy docs; they are not backfilled here. This file resumes at **M31 — Trajectory Spine**, which formalizes the approved [[Blind Bench - Agent Trace Strategy]] (Noah, 2026-07-07).
+
 See also:
 - [[Blind Bench - Architecture#Next Steps]] — the short form of this doc
 - [[Blind Bench - UX Spec]] — what each screen looks like (milestone deliverables reference screen IDs from this spec)
@@ -545,6 +547,70 @@ M0 → M6 is strictly sequential on the critical path. M7 (landing page on a sep
 - Marketing content beyond a tagline and a paragraph.
 - SEO work.
 - Analytics beyond the Vercel default.
+
+---
+
+## M31 — Trajectory Spine (2026-07)
+
+**Goal**: BlindBench can store an agent's trajectory (task → tool calls → reasoning → outcome), render it step by step, and let domain-expert reviewers blind-review it at the step level — with at least one step-level preference pair exportable in Fireworks DPO format. This is the one data-model shift the agent-trace direction hangs off. Formalizes the approved [[Blind Bench - Agent Trace Strategy]] (Noah, 2026-07-07).
+
+> **Sequencing.** Per the strategy doc, the spine (this milestone) and the Harbor sandbox-matrix integration run in parallel: the matrix produces trajectories, the spine renders and reviews them. The spine is the critical path; the matrix is an integration spike here (M31.5), never in-house sandbox infra. Ingestion breadth (OTLP GenAI, #263) and the full training-export bridge (#53) follow this milestone, not part of it.
+
+### Deliverables
+
+**M31.1 — Trace storage schema.**
+- New `agentTraces` parent table: one tiny row per trajectory (`projectId`, `source` ∈ `"claude_code_jsonl" | "harbor_matrix"`, model+harness combo labels, step count, status, timestamps). No inline step array — ever.
+- New `agentTraceSteps` table: one row per step, keyed by `(traceId, stepIndex)`, holding light inline fields (kind ∈ `step | tool_call | reasoning | policy_event | outcome`, ordering, small metadata) plus a `bodyStorageId` pointer to the full step body in file storage (mirrors the existing `rawPayloadStorageId` pattern). Large bodies never live in the document.
+- Wire the existing `src/lib/evals/agentTrace.ts` normalizer into Convex so ingestion writes through it rather than duplicating trajectory-shape logic. Resolve the `src/lib/evals/*` vs `convex/*` dual-path duplication for this surface (single normalizer, called server-side).
+- Queries are paginated (`paginationOpts`) over `agentTraceSteps`; there is **no reactive subscription over a full trace**.
+
+**M31.2 — Claude Code JSONL importer (first ingestion path).**
+- New importer that accepts an uploaded Claude Code session `.jsonl` file, parses it through the `agentTrace.ts` normalizer, and materializes one `agentTraces` row + N `agentTraceSteps` rows with bodies in storage.
+- Dedup on re-upload (same session → no duplicate trace), consistent with the existing Gateway-import dedup discipline.
+- This is the spine's first and only ingestion path in M31 (the cheapest real agent traces in the world; also the dogfood loop — we review our own sessions).
+
+**M31.3 — Server-side blind projections.**
+- A precomputed, server-side blind projection of each step (`toScorerVisibleAgentStep` in the spirit of the existing `toScorerVisibleAgentRun` / blind-mode boundary): strips/normalizes model names, harness metadata, tool-name fingerprints, and reasoning-style tells that identify the model+harness combo.
+- Enforced at the Convex function boundary exactly like today's blind mode — the reviewer-facing query returns only the projected fields; nothing raw is reachable from a reviewer principal.
+- Documented honestly as **bias reduction, not anonymity**: blinding a trajectory is statistical (a determined reviewer can still fingerprint Claude Code vs Codex from tool sequences/timing). The projection reduces the signal; it does not claim to erase it.
+
+**M31.4 — Step-level review UI + preference capture.**
+- A step-level trace review surface that renders steps paginated (never the whole trace reactively), with a per-step render for each step kind.
+- New annotation anchor kinds `{kind:"step"}` and `{kind:"tool_call"}` (extending today's text-range / whole-output anchors), so a reviewer can comment on a specific step or a specific tool call.
+- **Step-level pairwise preference capture**: given two candidate next-actions at step *k* over an identical prefix, the reviewer picks the better one. This is the DPO-compatible unit — Fireworks/OpenAI/Together DPO is single-turn (preference over the next assistant message), so step-level pairs map directly; whole-trajectory preferences do not.
+- One export fixture: at least one captured step-level preference pair serialized in Fireworks DPO format, checked in as a test fixture. (The full preference→Fireworks bridge / export UI, #53, is a later milestone; M31 proves the captured shape is DPO-serializable.)
+
+**M31.5 — Harbor matrix integration spike.**
+- A thin integration that runs one task across a small model+harness matrix on **Harbor** (which already orchestrates Claude Code / Codex CLI / OpenHands across Daytona/Modal/E2B) and imports the resulting trajectories through the M31.2 ingestion path (`source: "harbor_matrix"`).
+- Scoped as a spike: orchestrate + import, produce demo trajectories. **We integrate, we never build sandbox infra.**
+
+### Acceptance criteria
+
+1. Importing a real Claude Code session `.jsonl` creates exactly one `agentTraces` row and N `agentTraceSteps` rows; every step's full body is in file storage (`bodyStorageId` set) and **no** `agentTraceSteps` document exceeds the Convex ~1MiB doc cap — verified on a session of at least 100 steps at ~10KB/step (the case that breaks any inline-array design).
+2. The trace review surface loads a 100+-step trace via pagination; there is no reactive `useQuery` subscription over the full trace (verified by inspecting the query — it takes `paginationOpts` and returns a page, not the whole step set).
+3. Re-uploading the same Claude Code session produces no second trace (dedup holds).
+4. A reviewer principal calling the step query gets **only** projected fields: no raw model name, harness name, or un-normalized tool identifier appears in any response payload — verified by inspecting the raw JSON, the same bar as the M4 blind-eval field check. A reviewer calling any raw trace/step accessor directly (dashboard/devtools) is denied at the function boundary.
+5. The blind-projection module and its docs explicitly state bias-reduction-not-anonymity; there is a test asserting the projection removes the enumerated fingerprint fields, and the limitation is written down (not silently overclaimed).
+6. A reviewer can attach a comment to a specific step (`kind:"step"`) and to a specific tool call (`kind:"tool_call"`); both persist and re-render on the correct step. No `data-trace-id` / `data-step-id` / model-or-harness attribute leaks into the reviewer-view DOM.
+7. Two reviewers independently blind-review the same imported trace at the step level and submit at least one step-level pairwise preference each; the preferences persist keyed to `(traceId, stepIndex)`.
+8. At least one captured step-level preference pair is serialized to Fireworks DPO format and checked in as a fixture; a test loads the fixture and asserts it is valid single-turn DPO (prompt prefix + chosen/rejected next message), demonstrating the captured shape is training-ready.
+9. The Harbor spike runs one task across at least two model+harness combos and imports every resulting trajectory through the M31.2 path with `source: "harbor_matrix"`; the imported traces are reviewable through the same step-level surface as the Claude Code import, with no BlindBench-owned sandbox code in the path.
+10. `src/lib/evals/agentTrace.ts` is the single normalizer for both ingestion paths — there is no second trajectory-shape parser in `convex/*` for these sources.
+
+This milestone is **not done** if any acceptance criterion is "mostly passing": a trace that renders but leaks a model name fails #4; a preference captured but not DPO-serializable fails #8; an importer that works on a toy session but produces an over-cap document on a real 100-step run fails #1.
+
+### Testable demo
+
+> 1. Import a **real Claude Code session** `.jsonl` → one `agentTraces` row + its steps materialize, bodies in storage. 2. Run **one task across a small Harbor matrix** (≥2 model+harness combos) → import the resulting trajectories through the same path. 3. Two reviewers open the imported traces on the step-level review surface, blind, and each leaves at least one step comment and one step-level pairwise preference. 4. Open devtools on a reviewer view → confirm no model/harness/tool-fingerprint field and no `data-trace-id` / `data-step-id` in any payload or in the DOM. 5. Export at least one captured step-level preference pair as a **Fireworks DPO fixture** and run the test that validates it as single-turn DPO.
+
+### Out of scope
+
+- **OTLP GenAI streaming ingest (#263).** Follows the spine; the only M31 ingestion paths are Claude Code JSONL upload and the Harbor spike import.
+- **Full preference→Fireworks export bridge and export UI (#53).** M31 proves the captured shape is DPO-serializable via one fixture; the productized SFT/DPO/RFT export bridge is a later milestone.
+- **In-house sandbox / harness execution.** Harbor is integrated, never rebuilt. No Daytona/Modal/E2B orchestration code owned by BlindBench.
+- **Whole-trajectory preference → DPO.** The single-turn DPO constraint means only step-level pairs export as DPO; whole-run verdicts feed filtered SFT / RFT rubrics in a later milestone, not here.
+- **Perfect trace anonymity.** The projection is bias reduction; achieving cryptographic un-fingerprintability of a trajectory is explicitly not a goal.
+- **Live baseline-vs-candidate endpoint comparison** and the review→promotion workflow for traces — later.
 
 ---
 

--- a/project-docs/Blind Bench - Positioning.md
+++ b/project-docs/Blind Bench - Positioning.md
@@ -3,7 +3,40 @@
 Working doc. Captures the pivot away from developer-tool framing toward
 non-technical buyers. Expand as customer conversations sharpen the thesis.
 
-Last updated: 2026-04-18
+Last updated: 2026-07-07
+
+---
+
+## 2026-07-07 update — persona generalization (supersedes parts of this doc)
+
+Approved by Noah 2026-07-07. Source of truth:
+[[Blind Bench - Agent Trace Strategy]]. The doc below is kept intact as
+history; where it conflicts with this addendum, this addendum wins.
+
+The unit of AI work moved from *a prompt's output* to *an agent's
+trajectory*. The persona moves with it.
+
+**The persona generalizes** from "non-technical reviewer" to **domain expert
+reviewer** — the person whose judgment matters, reviewing without bias,
+without living in a dashboard. It's the GC for legal tone, the CX lead for a
+support agent, the senior engineer for a coding-agent trace. The through-line
+was never "non-technical." It was "the right reviewer, blind, with no
+friction."
+
+**"Developers are the anti-persona" is retired.** For agent traces, the
+qualified reviewer of a Claude Code trajectory is usually a senior engineer or
+domain expert. Technical reviewers are now first-class *reviewers*, not just
+buyer-influencers.
+
+**What survives unchanged:** blind-by-default; zero-friction, shareable-link
+review with no account required; plain-language reviewer surfaces; feedback
+that flows somewhere (into the prompt, into training data), never into a dead
+dashboard.
+
+**What stays true:** we are still NOT a tracing platform. BlindBench is the
+**judgment layer** that tracing platforms, harnesses, and sandboxes feed into.
+The blind-eval discipline — enforced at the Convex function boundary, opaque
+tokens, no provenance in the DOM — is the asset none of them have.
 
 ---
 
@@ -34,6 +67,10 @@ surface** that plugs into whatever tracing platform a team already runs.
 
 Primary: **non-technical reviewers and the leaders who depend on them.**
 
+> [2026-07-07: generalized to **domain expert reviewer** — see the addendum at
+> the top. The persona is the right reviewer for the artifact, not
+> specifically a non-technical one.]
+
 - VP Marketing, Head of Content — signing off on brand voice in AI output
 - General Counsel, compliance — reviewing AI responses for risk
 - Head of CX, support leads — grading agent replies against policy
@@ -45,6 +82,11 @@ feedback from the people above without scheduling a meeting.
 
 Explicit anti-persona: prompt engineers running eval suites against LLM
 judges. That's the tracing platforms' job. Don't rebuild it.
+
+> [2026-07-07: "developers are the anti-persona" is **retired** — see the
+> addendum at the top. For agent traces, senior technical reviewers are often
+> the correct reviewers. The anti-persona is anyone reviewing *biased* or
+> living *in a dashboard*, not developers as such.]
 
 ## Why this matters (the pain)
 


### PR DESCRIPTION
Strategy work approved by Noah 2026-07-07:

- New `project-docs/Blind Bench - Agent Trace Strategy.md` — blind, step-level human review of agent trajectories with training-ready export; synthesized from codebase/pipeline audits, market research (~60 sources), and an independent Codex review; decisions recorded inline.
- Positioning addendum: persona generalizes to "domain expert reviewer"; anti-persona retired.
- Build Plan: M31 — Trajectory Spine section (issues #264–#268) + milestone coverage note.
- Handoff artifact for the implementation session: `docs/handoffs/2026-07-07-m31-trajectory-spine.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)