### PR TITLE
M31.6 (#271): wire blind-reviewer access to the trace review surface

### DIFF
--- a/convex/agentTraceReview.ts
+++ b/convex/agentTraceReview.ts
@@ -226,8 +226,10 @@ export const getMatchup = query({
     const matchup = await ctx.db.get(args.matchupId);
     if (!matchup) return null;
     await requireProjectRole(ctx, matchup.projectId, [...REVIEW_ROLES]);
+    const project = await ctx.db.get(matchup.projectId);
     return {
       _id: matchup._id,
+      projectName: project?.name ?? "Project",
       leftTraceId: matchup.leftTraceId,
       rightTraceId: matchup.rightTraceId,
       divergenceStepIndex: matchup.divergenceStepIndex,

--- a/convex/agentTraces.ts
+++ b/convex/agentTraces.ts
@@ -24,7 +24,7 @@ import { paginationOptsValidator } from "convex/server";
 import { action, internalMutation, internalQuery, query } from "./_generated/server";
 import { internal } from "./_generated/api";
 import type { Id } from "./_generated/dataModel";
-import { requireProjectRole, isBlindReviewer } from "./lib/auth";
+import { requireAuth, requireProjectRole, isBlindReviewer } from "./lib/auth";
 import type { AgentRunTrace } from "./lib/agentTrace";
 import { redactValue } from "./lib/agentTrace";
 import { splitStep } from "./lib/agentTraceStorage";
@@ -301,11 +301,15 @@ export const getTrace = query({
     if (!trace) return null;
     await requireProjectRole(ctx, trace.projectId, ["owner", "editor", "evaluator"]);
     const blind = await isBlindReviewer(ctx, trace.projectId);
+    const project = await ctx.db.get(trace.projectId);
     const finalAnswerId = blind
       ? trace.finalAnswerBlindStorageId
       : trace.finalAnswerStorageId;
     const view = {
       _id: trace._id as string,
+      // Eval project name (not harness/model provenance) — powers the
+      // "Evaluation — {project}" document title on the blind surface.
+      projectName: project?.name ?? "Project",
       traceId: trace.traceId,
       product: trace.product,
       module: trace.module,
@@ -407,6 +411,56 @@ export const listTraces = query({
       harnessName: blind ? undefined : r.harnessName,
       model: blind ? undefined : r.model,
     }));
+  },
+});
+
+/**
+ * Traces the caller can review across ALL projects they collaborate on — the
+ * discovery list for the blind eval surface (`/eval/traces`), where the reviewer
+ * has no project context. Blind-projected per project (a reviewer can be blind
+ * on one project, not another). Only `ready` traces; newest first, capped.
+ */
+export const listReviewableTraces = query({
+  args: {},
+  handler: async (ctx) => {
+    const userId = await requireAuth(ctx);
+    const collabs = await ctx.db
+      .query("projectCollaborators")
+      .withIndex("by_user", (q) => q.eq("userId", userId))
+      .collect();
+    const out: Array<{
+      _id: Id<"agentTraces">;
+      projectName: string;
+      status: string;
+      stepCount: number;
+      createdAt: number;
+      product?: string;
+      harnessName?: string;
+      model?: string;
+    }> = [];
+    for (const c of collabs) {
+      const blind = await isBlindReviewer(ctx, c.projectId);
+      const project = await ctx.db.get(c.projectId);
+      const traces = await ctx.db
+        .query("agentTraces")
+        .withIndex("by_project", (q) => q.eq("projectId", c.projectId))
+        .order("desc")
+        .take(100);
+      for (const tr of traces) {
+        if (tr.status !== "ready") continue;
+        out.push({
+          _id: tr._id,
+          projectName: project?.name ?? "Project",
+          status: tr.status,
+          stepCount: tr.stepCount,
+          createdAt: tr._creationTime,
+          product: blind ? undefined : tr.product,
+          harnessName: blind ? undefined : tr.harnessName,
+          model: blind ? undefined : tr.model,
+        });
+      }
+    }
+    return out.sort((a, b) => b.createdAt - a.createdAt).slice(0, 200);
   },
 });
 

--- a/convex/lib/blindProjection.ts
+++ b/convex/lib/blindProjection.ts
@@ -86,6 +86,7 @@ export function blindStepView(item: StepView): StepView {
 
 export interface TraceView {
   _id: string;
+  projectName: string;
   traceId?: string;
   product?: string;
   module?: string;
@@ -109,6 +110,7 @@ export interface TraceView {
 export function blindTraceView(trace: TraceView): TraceView {
   return {
     _id: trace._id,
+    projectName: trace.projectName,
     traceId: undefined,
     product: undefined,
     module: undefined,

--- a/convex/tests/agentTraceReview.test.ts
+++ b/convex/tests/agentTraceReview.test.ts
@@ -107,6 +107,21 @@ describe("#267 step-level trace review", () => {
     expect(count).toBe(1);
   });
 
+  test("blind reviewer discovers reviewable traces across their projects, blinded", async () => {
+    const t = convexTest(schema);
+    const { ids, asOwner, asBlind } = await seed(t);
+    await persist(asOwner, ids.projectId, baseRun);
+
+    const list = await asBlind.query(api.agentTraces.listReviewableTraces, {});
+    expect(list).toHaveLength(1);
+    expect(list[0]?.projectName).toBe("P");
+    expect(list[0]?.stepCount).toBeGreaterThan(0);
+    // Blinded: no harness/model/product for the evaluator.
+    expect(list[0]?.harnessName).toBeUndefined();
+    expect(list[0]?.model).toBeUndefined();
+    expect(JSON.stringify(list)).not.toContain("jeeves_clog");
+  });
+
   test("step-level pairwise: owner sets up, blind reviewer picks the winner", async () => {
     const t = convexTest(schema);
     const { ids, asOwner, asBlind } = await seed(t);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -53,6 +53,9 @@ const EvaluatePage = lazy(() => import("./routes/orgs/projects/EvaluatePage").th
 const TraceList = lazy(() => import("./routes/traces/TraceList").then(m => ({ default: m.TraceList })));
 const TraceViewer = lazy(() => import("./routes/traces/TraceViewer").then(m => ({ default: m.TraceViewer })));
 const TraceMatchup = lazy(() => import("./routes/traces/TraceMatchup").then(m => ({ default: m.TraceMatchup })));
+const TraceReviewList = lazy(() => import("./routes/traces/TraceReviewList").then(m => ({ default: m.TraceReviewList })));
+const TraceReview = lazy(() => import("./routes/traces/TraceReview").then(m => ({ default: m.TraceReview })));
+const TraceMatchupReview = lazy(() => import("./routes/traces/TraceMatchupReview").then(m => ({ default: m.TraceMatchupReview })));
 const HistoryPage = lazy(() => import("./routes/orgs/projects/HistoryPage").then(m => ({ default: m.HistoryPage })));
 const Terms = lazy(() => import("./routes/legal/Terms").then(m => ({ default: m.Terms })));
 const Privacy = lazy(() => import("./routes/legal/Privacy").then(m => ({ default: m.Privacy })));
@@ -138,6 +141,9 @@ export function App() {
           </Route>
           <Route path="/eval" element={<EvalLayout />}>
             <Route index element={<InvitesInbox />} />
+            <Route path="traces" element={<TraceReviewList />} />
+            <Route path="traces/:agentTraceId" element={<TraceReview />} />
+            <Route path="matchups/:matchupId" element={<TraceMatchupReview />} />
           </Route>
           <Route path="/denied" element={<Denied />} />
           <Route path="*" element={<NotFound />} />

--- a/src/routes/invite/InvitesInbox.tsx
+++ b/src/routes/invite/InvitesInbox.tsx
@@ -4,7 +4,7 @@ import { api } from "../../../convex/_generated/api";
 import { EmptyState } from "@/components/EmptyState";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
-import { ClipboardCheck, FolderOpen, Inbox, Users } from "lucide-react";
+import { ClipboardCheck, FolderOpen, Inbox, Route, Users } from "lucide-react";
 
 function formatRelativeTime(ts: number): string {
   const diff = Date.now() - ts;
@@ -29,9 +29,33 @@ function labelForScope(scope: "org" | "project" | "cycle"): string {
   return "review";
 }
 
+function TraceReviewCard({ count }: { count: number }) {
+  return (
+    <Link
+      to="/eval/traces"
+      className="block rounded-lg border border-primary/30 bg-primary/5 p-4 transition-colors hover:bg-primary/10"
+    >
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-3 min-w-0">
+          <Route className="h-4 w-4 shrink-0 text-primary" />
+          <p className="text-sm font-medium">
+            {count} {count === 1 ? "trajectory" : "trajectories"} to review
+          </p>
+        </div>
+        <span aria-hidden="true" className="text-primary">
+          →
+        </span>
+      </div>
+    </Link>
+  );
+}
+
 export function InvitesInbox() {
   const invites = useQuery(api.invitations.listMine);
+  const traces = useQuery(api.agentTraces.listReviewableTraces, {});
   const navigate = useNavigate();
+
+  const traceCount = traces?.length ?? 0;
 
   if (invites === undefined) {
     return (
@@ -44,6 +68,22 @@ export function InvitesInbox() {
   }
 
   if (invites.length === 0) {
+    if (traceCount > 0) {
+      return (
+        <div className="max-w-2xl mx-auto p-6 space-y-6">
+          <TraceReviewCard count={traceCount} />
+          <EmptyState
+            icon={Inbox}
+            heading="You're all caught up"
+            description="No pending invitations. Trajectories shared with you are above."
+            action={{
+              label: "Back to dashboard",
+              onClick: () => navigate("/"),
+            }}
+          />
+        </div>
+      );
+    }
     return (
       <div className="flex flex-1 items-center justify-center p-6">
         <EmptyState
@@ -61,6 +101,7 @@ export function InvitesInbox() {
 
   return (
     <div className="max-w-2xl mx-auto p-6 space-y-6">
+      {traceCount > 0 && <TraceReviewCard count={traceCount} />}
       <section className="space-y-3">
         <h1 className="text-lg font-medium">Invitations waiting for you</h1>
         <div className="space-y-2">

--- a/src/routes/traces/TraceMatchup.tsx
+++ b/src/routes/traces/TraceMatchup.tsx
@@ -1,32 +1,13 @@
 /**
- * #267 (M31.4): step-level pairwise preference. Two blind-labelled trajectories
- * side by side, sharing the same task up to a divergence point; the reviewer
- * picks whose NEXT move is better. Both sides page steps through the same
- * blind-projected listSteps — no provenance reaches the DOM.
+ * #267 (M31.4): step-level pairwise preference for owners and editors, nested
+ * under ProjectLayout. The matchup surface lives in the shared TraceMatchupBody
+ * (#271) so blind reviewers reach an identical view via /eval/matchups/:matchupId.
+ * This wrapper only supplies the project-scoped back link.
  */
-import { useEffect, useState } from "react";
-import { useQuery, useMutation } from "convex/react";
-import { Link, useParams } from "react-router-dom";
-import { api } from "../../../convex/_generated/api";
+import { useParams } from "react-router-dom";
 import type { Id } from "../../../convex/_generated/dataModel";
 import { useProject } from "@/contexts/ProjectContext";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
-import { Skeleton } from "@/components/ui/skeleton";
-import { buttonVariants } from "@/components/ui/button";
-import { cn } from "@/lib/utils";
-import { friendlyError } from "@/lib/errors";
-import { StepList, COMMENT_TAGS, type CommentTag } from "./traceSteps";
-import { ArrowLeft } from "lucide-react";
-
-const WINNERS = [
-  { value: "left", label: "◀ Left better" },
-  { value: "right", label: "Right better ▶" },
-  { value: "tie", label: "Tie" },
-  { value: "skip", label: "Skip" },
-] as const;
-
-type Winner = (typeof WINNERS)[number]["value"];
+import { TraceMatchupBody } from "./TraceMatchupBody";
 
 export function TraceMatchup() {
   const { projectId } = useProject();
@@ -36,179 +17,13 @@ export function TraceMatchup() {
   }>();
   const id = matchupId as Id<"agentTraceMatchups">;
 
-  const matchup = useQuery(api.agentTraceReview.getMatchup, { matchupId: id });
-  const decide = useMutation(api.agentTraceReview.decideMatchup);
-
-  const [tags, setTags] = useState<CommentTag[]>([]);
-  const [tagsInit, setTagsInit] = useState(false);
-  const [busy, setBusy] = useState(false);
-  const [error, setError] = useState("");
-
-  useEffect(() => {
-    if (!tagsInit && matchup) {
-      setTags(matchup.reasonTags as CommentTag[]);
-      setTagsInit(true);
-    }
-  }, [matchup, tagsInit]);
-
   const projectBase = `/orgs/${orgSlug}/projects/${projectId}`;
 
-  if (matchup === undefined) {
-    return (
-      <div className="mx-auto max-w-5xl space-y-4 p-6">
-        <Skeleton className="h-8 w-64" />
-        <div className="grid gap-4 md:grid-cols-2">
-          <Skeleton className="h-96 w-full" />
-          <Skeleton className="h-96 w-full" />
-        </div>
-      </div>
-    );
-  }
-
-  if (matchup === null) {
-    return (
-      <div className="mx-auto max-w-3xl space-y-3 p-6">
-        <p className="text-sm">
-          This matchup isn’t available. It may have been removed, or you may not
-          have access to it.
-        </p>
-        <Link
-          to={`${projectBase}/traces`}
-          className={buttonVariants({ size: "sm", variant: "outline" })}
-        >
-          <ArrowLeft aria-hidden="true" className="mr-1.5 h-3.5 w-3.5" />
-          Back to trajectories
-        </Link>
-      </div>
-    );
-  }
-
-  function toggleTag(tag: CommentTag) {
-    setTags((prev) =>
-      prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag],
-    );
-  }
-
-  async function submit(winner: Winner) {
-    setBusy(true);
-    setError("");
-    try {
-      await decide({ matchupId: id, winner, reasonTags: tags });
-    } catch (err) {
-      setError(friendlyError(err, "Couldn’t record your pick. Try again."));
-    } finally {
-      setBusy(false);
-    }
-  }
-
   return (
-    <div className="mx-auto max-w-5xl p-6">
-      <Link
-        to={`${projectBase}/traces`}
-        className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
-      >
-        <ArrowLeft aria-hidden="true" className="h-3 w-3" />
-        Trajectories
-      </Link>
-
-      <header className="mt-3">
-        <h1 className="text-2xl font-bold">Which next move is better?</h1>
-        <p className="mt-1 text-sm text-muted-foreground">
-          Given the same task up to this point, which agent’s next move is
-          better?
-        </p>
-      </header>
-
-      <div className="mt-6 grid gap-4 md:grid-cols-2">
-        <MatchupColumn
-          heading={matchup.leftBlindLabel}
-          agentTraceId={matchup.leftTraceId}
-          divergenceStepIndex={matchup.divergenceStepIndex}
-        />
-        <MatchupColumn
-          heading={matchup.rightBlindLabel}
-          agentTraceId={matchup.rightTraceId}
-          divergenceStepIndex={matchup.divergenceStepIndex}
-        />
-      </div>
-
-      <Card className="mt-6">
-        <CardHeader>
-          <CardTitle className="text-base">Your pick</CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-3">
-          <div className="flex flex-wrap gap-2">
-            {WINNERS.map((w) => {
-              const selected = matchup.winner === w.value;
-              return (
-                <Button
-                  key={w.value}
-                  type="button"
-                  variant={selected ? "default" : "outline"}
-                  size="sm"
-                  onClick={() => void submit(w.value)}
-                  disabled={busy}
-                  className={cn(selected && "ring-2 ring-primary/40")}
-                >
-                  {w.label}
-                </Button>
-              );
-            })}
-          </div>
-
-          <div>
-            <p className="mb-1.5 text-xs text-muted-foreground">
-              Reasons (optional)
-            </p>
-            <div className="flex flex-wrap gap-1.5">
-              {COMMENT_TAGS.map((tag) => {
-                const on = tags.includes(tag);
-                return (
-                  <button
-                    key={tag}
-                    type="button"
-                    onClick={() => toggleTag(tag)}
-                    className={cn(
-                      "rounded-full border px-2 py-0.5 text-xs transition-colors",
-                      on
-                        ? "border-primary bg-primary/10 text-primary"
-                        : "border-border text-muted-foreground hover:text-foreground",
-                    )}
-                  >
-                    {tag}
-                  </button>
-                );
-              })}
-            </div>
-          </div>
-
-          {error && (
-            <p className="text-sm text-destructive" role="alert">
-              {error}
-            </p>
-          )}
-        </CardContent>
-      </Card>
-    </div>
-  );
-}
-
-function MatchupColumn({
-  heading,
-  agentTraceId,
-  divergenceStepIndex,
-}: {
-  heading: string;
-  agentTraceId: Id<"agentTraces">;
-  divergenceStepIndex: number;
-}) {
-  return (
-    <div className="min-w-0">
-      <h2 className="mb-3 text-sm font-semibold">{heading}</h2>
-      <StepList
-        agentTraceId={agentTraceId}
-        divergenceStepIndex={divergenceStepIndex}
-      />
-    </div>
+    <TraceMatchupBody
+      matchupId={id}
+      backTo={`${projectBase}/traces`}
+      backLabel="Trajectories"
+    />
   );
 }

--- a/src/routes/traces/TraceMatchupBody.tsx
+++ b/src/routes/traces/TraceMatchupBody.tsx
@@ -1,0 +1,216 @@
+/**
+ * #271 (M31): shared step-level pairwise-preference body. Extracted from
+ * TraceMatchup so both the owner/editor route (under ProjectLayout) and the
+ * blind-reviewer route (under EvalLayout) render an identical matchup surface.
+ * Reads `getMatchup` by `matchupId` — no org/project context. Two blind-labelled
+ * trajectories share the same task up to a divergence point; the reviewer picks
+ * whose NEXT move is better. No provenance reaches the DOM.
+ */
+import { useEffect, useState } from "react";
+import { useQuery, useMutation } from "convex/react";
+import { Link } from "react-router-dom";
+import { api } from "../../../convex/_generated/api";
+import type { Id } from "../../../convex/_generated/dataModel";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { buttonVariants } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { friendlyError } from "@/lib/errors";
+import { StepList, COMMENT_TAGS, type CommentTag } from "./traceSteps";
+import { ArrowLeft } from "lucide-react";
+
+const WINNERS = [
+  { value: "left", label: "◀ Left better" },
+  { value: "right", label: "Right better ▶" },
+  { value: "tie", label: "Tie" },
+  { value: "skip", label: "Skip" },
+] as const;
+
+type Winner = (typeof WINNERS)[number]["value"];
+
+export function TraceMatchupBody({
+  matchupId,
+  backTo,
+  backLabel,
+}: {
+  matchupId: Id<"agentTraceMatchups">;
+  backTo: string;
+  backLabel: string;
+}) {
+  const matchup = useQuery(api.agentTraceReview.getMatchup, { matchupId });
+  const decide = useMutation(api.agentTraceReview.decideMatchup);
+
+  const [tags, setTags] = useState<CommentTag[]>([]);
+  const [tagsInit, setTagsInit] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    if (!tagsInit && matchup) {
+      setTags(matchup.reasonTags as CommentTag[]);
+      setTagsInit(true);
+    }
+  }, [matchup, tagsInit]);
+
+  if (matchup === undefined) {
+    return (
+      <div className="mx-auto max-w-5xl space-y-4 p-6">
+        <Skeleton className="h-8 w-64" />
+        <div className="grid gap-4 md:grid-cols-2">
+          <Skeleton className="h-96 w-full" />
+          <Skeleton className="h-96 w-full" />
+        </div>
+      </div>
+    );
+  }
+
+  if (matchup === null) {
+    return (
+      <div className="mx-auto max-w-3xl space-y-3 p-6">
+        <p className="text-sm">
+          This matchup isn’t available. It may have been removed, or you may not
+          have access to it.
+        </p>
+        <Link
+          to={backTo}
+          className={buttonVariants({ size: "sm", variant: "outline" })}
+        >
+          <ArrowLeft aria-hidden="true" className="mr-1.5 h-3.5 w-3.5" />
+          Back to {backLabel.toLowerCase()}
+        </Link>
+      </div>
+    );
+  }
+
+  const resolved = matchup;
+
+  function toggleTag(tag: CommentTag) {
+    setTags((prev) =>
+      prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag],
+    );
+  }
+
+  async function submit(winner: Winner) {
+    setBusy(true);
+    setError("");
+    try {
+      await decide({ matchupId, winner, reasonTags: tags });
+    } catch (err) {
+      setError(friendlyError(err, "Couldn’t record your pick. Try again."));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="mx-auto max-w-5xl p-6">
+      <Link
+        to={backTo}
+        className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+      >
+        <ArrowLeft aria-hidden="true" className="h-3 w-3" />
+        {backLabel}
+      </Link>
+
+      <header className="mt-3">
+        <h1 className="text-2xl font-bold">Which next move is better?</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Given the same task up to this point, which agent’s next move is
+          better?
+        </p>
+      </header>
+
+      <div className="mt-6 grid gap-4 md:grid-cols-2">
+        <MatchupColumn
+          heading={resolved.leftBlindLabel}
+          agentTraceId={resolved.leftTraceId}
+          divergenceStepIndex={resolved.divergenceStepIndex}
+        />
+        <MatchupColumn
+          heading={resolved.rightBlindLabel}
+          agentTraceId={resolved.rightTraceId}
+          divergenceStepIndex={resolved.divergenceStepIndex}
+        />
+      </div>
+
+      <Card className="mt-6">
+        <CardHeader>
+          <CardTitle className="text-base">Your pick</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div className="flex flex-wrap gap-2">
+            {WINNERS.map((w) => {
+              const selected = resolved.winner === w.value;
+              return (
+                <Button
+                  key={w.value}
+                  type="button"
+                  variant={selected ? "default" : "outline"}
+                  size="sm"
+                  onClick={() => void submit(w.value)}
+                  disabled={busy}
+                  className={cn(selected && "ring-2 ring-primary/40")}
+                >
+                  {w.label}
+                </Button>
+              );
+            })}
+          </div>
+
+          <div>
+            <p className="mb-1.5 text-xs text-muted-foreground">
+              Reasons (optional)
+            </p>
+            <div className="flex flex-wrap gap-1.5">
+              {COMMENT_TAGS.map((tag) => {
+                const on = tags.includes(tag);
+                return (
+                  <button
+                    key={tag}
+                    type="button"
+                    onClick={() => toggleTag(tag)}
+                    className={cn(
+                      "rounded-full border px-2 py-0.5 text-xs transition-colors",
+                      on
+                        ? "border-primary bg-primary/10 text-primary"
+                        : "border-border text-muted-foreground hover:text-foreground",
+                    )}
+                  >
+                    {tag}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          {error && (
+            <p className="text-sm text-destructive" role="alert">
+              {error}
+            </p>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function MatchupColumn({
+  heading,
+  agentTraceId,
+  divergenceStepIndex,
+}: {
+  heading: string;
+  agentTraceId: Id<"agentTraces">;
+  divergenceStepIndex: number;
+}) {
+  return (
+    <div className="min-w-0">
+      <h2 className="mb-3 text-sm font-semibold">{heading}</h2>
+      <StepList
+        agentTraceId={agentTraceId}
+        divergenceStepIndex={divergenceStepIndex}
+      />
+    </div>
+  );
+}

--- a/src/routes/traces/TraceMatchupReview.tsx
+++ b/src/routes/traces/TraceMatchupReview.tsx
@@ -1,0 +1,39 @@
+/**
+ * #271 (M31): blind reviewer's step-level pairwise-preference page. Rendered
+ * under EvalLayout at /eval/matchups/:matchupId — no org/project context. The
+ * matchup surface is the shared TraceMatchupBody; this wrapper only reads the
+ * :matchupId param and sets the blind-eval document title (Rule 3).
+ */
+import { useEffect } from "react";
+import { useQuery } from "convex/react";
+import { useParams } from "react-router-dom";
+import { api } from "../../../convex/_generated/api";
+import type { Id } from "../../../convex/_generated/dataModel";
+import { TraceMatchupBody } from "./TraceMatchupBody";
+
+export function TraceMatchupReview() {
+  const { matchupId } = useParams<{ matchupId: string }>();
+  const id = matchupId as Id<"agentTraceMatchups">;
+
+  const matchup = useQuery(api.agentTraceReview.getMatchup, { matchupId: id });
+
+  // Rule 3: evaluators see "Evaluation — {project name}" and nothing else.
+  useEffect(() => {
+    if (!matchup) return;
+    const previous = document.title;
+    document.title = matchup.projectName
+      ? `Evaluation — ${matchup.projectName}`
+      : "Evaluation";
+    return () => {
+      document.title = previous;
+    };
+  }, [matchup]);
+
+  return (
+    <TraceMatchupBody
+      matchupId={id}
+      backTo="/eval/traces"
+      backLabel="Trajectories to review"
+    />
+  );
+}

--- a/src/routes/traces/TraceReview.tsx
+++ b/src/routes/traces/TraceReview.tsx
@@ -1,0 +1,39 @@
+/**
+ * #271 (M31): blind reviewer's single-trajectory review page. Rendered under
+ * EvalLayout at /eval/traces/:agentTraceId — no org/project context. The review
+ * surface itself is the shared TraceReviewBody; this wrapper only reads the
+ * :agentTraceId param and sets the blind-eval document title (Rule 3).
+ */
+import { useEffect } from "react";
+import { useQuery } from "convex/react";
+import { useParams } from "react-router-dom";
+import { api } from "../../../convex/_generated/api";
+import type { Id } from "../../../convex/_generated/dataModel";
+import { TraceReviewBody } from "./TraceReviewBody";
+
+export function TraceReview() {
+  const { agentTraceId } = useParams<{ agentTraceId: string }>();
+  const traceId = agentTraceId as Id<"agentTraces">;
+
+  const trace = useQuery(api.agentTraces.getTrace, { agentTraceId: traceId });
+
+  // Rule 3: evaluators see "Evaluation — {project name}" and nothing else.
+  useEffect(() => {
+    if (!trace) return;
+    const previous = document.title;
+    document.title = trace.projectName
+      ? `Evaluation — ${trace.projectName}`
+      : "Evaluation";
+    return () => {
+      document.title = previous;
+    };
+  }, [trace]);
+
+  return (
+    <TraceReviewBody
+      agentTraceId={traceId}
+      backTo="/eval/traces"
+      backLabel="Trajectories to review"
+    />
+  );
+}

--- a/src/routes/traces/TraceReviewBody.tsx
+++ b/src/routes/traces/TraceReviewBody.tsx
@@ -1,0 +1,263 @@
+/**
+ * #271 (M31): shared step-level review body for a single agent trajectory.
+ * Extracted from TraceViewer so both the owner/editor route (under
+ * ProjectLayout) and the blind-reviewer route (under EvalLayout) render the
+ * exact same review surface. Reads everything from `getTrace`/`listComments`
+ * by `agentTraceId` — no org/project context, no `useProject`/`useParams`.
+ *
+ * For blind reviewers the backend strips harness/model/product; when that
+ * provenance is absent we show the bias-reduction framing instead. No real ids
+ * or provenance attributes are rendered into the DOM.
+ */
+import { useEffect, useState } from "react";
+import { useQuery, useMutation } from "convex/react";
+import { Link } from "react-router-dom";
+import { api } from "../../../convex/_generated/api";
+import type { Id } from "../../../convex/_generated/dataModel";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { Skeleton } from "@/components/ui/skeleton";
+import { buttonVariants } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { friendlyError } from "@/lib/errors";
+import { StepList, StepBody } from "./traceSteps";
+import { ArrowLeft, EyeOff, Route } from "lucide-react";
+
+const RATINGS = [
+  { value: "best", label: "Best" },
+  { value: "acceptable", label: "Acceptable" },
+  { value: "weak", label: "Weak" },
+] as const;
+
+type Rating = (typeof RATINGS)[number]["value"];
+
+export function TraceReviewBody({
+  agentTraceId,
+  backTo,
+  backLabel,
+}: {
+  agentTraceId: Id<"agentTraces">;
+  backTo: string;
+  backLabel: string;
+}) {
+  const trace = useQuery(api.agentTraces.getTrace, { agentTraceId });
+  const comments = useQuery(api.agentTraceReview.listComments, {
+    agentTraceId,
+  });
+
+  if (trace === undefined) {
+    return (
+      <div className="mx-auto max-w-3xl space-y-4 p-6">
+        <Skeleton className="h-8 w-56" />
+        <Skeleton className="h-24 w-full" />
+        <Skeleton className="h-64 w-full" />
+      </div>
+    );
+  }
+
+  if (trace === null) {
+    return (
+      <div className="mx-auto max-w-3xl space-y-3 p-6">
+        <p className="text-sm">
+          This trajectory isn’t available. It may have been removed, or you may
+          not have access to it.
+        </p>
+        <Link
+          to={backTo}
+          className={buttonVariants({ size: "sm", variant: "outline" })}
+        >
+          <ArrowLeft aria-hidden="true" className="mr-1.5 h-3.5 w-3.5" />
+          Back to {backLabel.toLowerCase()}
+        </Link>
+      </div>
+    );
+  }
+
+  const blind = !trace.harnessName && !trace.product && !trace.model;
+  const provenance = [trace.product, trace.harnessName, trace.model].filter(
+    Boolean,
+  );
+
+  const usageBits: string[] = [];
+  if (trace.usage.totalTokens !== undefined) {
+    usageBits.push(`${trace.usage.totalTokens.toLocaleString()} tokens`);
+  }
+  if (trace.usage.costUsd !== undefined) {
+    usageBits.push(`$${trace.usage.costUsd.toFixed(4)}`);
+  }
+  if (trace.usage.durationMs !== undefined) {
+    usageBits.push(
+      trace.usage.durationMs >= 1000
+        ? `${(trace.usage.durationMs / 1000).toFixed(1)}s`
+        : `${trace.usage.durationMs}ms`,
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-3xl p-6">
+      <Link
+        to={backTo}
+        className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+      >
+        <ArrowLeft aria-hidden="true" className="h-3 w-3" />
+        {backLabel}
+      </Link>
+
+      <header className="mt-3">
+        <div className="flex items-center gap-2">
+          <Route aria-hidden="true" className="h-5 w-5 text-primary" />
+          <h1 className="text-2xl font-bold">
+            {provenance.length > 0 ? provenance.join(" · ") : "Trajectory"}
+          </h1>
+        </div>
+        <p className="mt-1 text-sm text-muted-foreground">
+          {trace.stepCount} {trace.stepCount === 1 ? "step" : "steps"}
+          {usageBits.length > 0 && <> · {usageBits.join(" · ")}</>}
+        </p>
+      </header>
+
+      {trace.status === "failed" && (
+        <p className="mt-4 text-sm text-destructive" role="alert">
+          This import failed while processing. Re-import the session to try
+          again.
+        </p>
+      )}
+
+      {blind && (
+        <Card className="mt-4 border-primary/30 bg-primary/5">
+          <CardContent className="flex items-start gap-2 pt-0 text-sm text-muted-foreground">
+            <EyeOff
+              aria-hidden="true"
+              className="mt-0.5 h-4 w-4 shrink-0 text-primary"
+            />
+            <p>
+              <span className="font-medium text-foreground">Blind review</span>{" "}
+              — provenance hidden. Blinding reduces bias; it is not anonymity.
+            </p>
+          </CardContent>
+        </Card>
+      )}
+
+      <VerdictControl agentTraceId={agentTraceId} />
+
+      {trace.hasFinalAnswer && (
+        <Card className="mt-6">
+          <CardHeader>
+            <CardTitle className="text-base">Final answer</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <StepBody agentTraceId={agentTraceId} field="text" />
+          </CardContent>
+        </Card>
+      )}
+
+      <section className="mt-6">
+        <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+          Steps
+        </h2>
+        <StepList agentTraceId={agentTraceId} comments={comments} />
+      </section>
+    </div>
+  );
+}
+
+function VerdictControl({ agentTraceId }: { agentTraceId: Id<"agentTraces"> }) {
+  const verdict = useQuery(api.agentTraceReview.myVerdict, { agentTraceId });
+  const setVerdict = useMutation(api.agentTraceReview.setVerdict);
+
+  const [note, setNote] = useState("");
+  const [noteInit, setNoteInit] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState("");
+  const [saved, setSaved] = useState(false);
+
+  useEffect(() => {
+    if (!noteInit && verdict !== undefined) {
+      setNote(verdict?.note ?? "");
+      setNoteInit(true);
+    }
+  }, [verdict, noteInit]);
+
+  const current = verdict?.rating;
+
+  async function submit(rating: Rating) {
+    setBusy(true);
+    setError("");
+    setSaved(false);
+    try {
+      await setVerdict({
+        agentTraceId,
+        rating,
+        note: note.trim() ? note.trim() : undefined,
+      });
+      setSaved(true);
+    } catch (err) {
+      setError(friendlyError(err, "Couldn’t save your verdict. Try again."));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <Card className="mt-4">
+      <CardHeader>
+        <CardTitle className="text-base">Your verdict</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <p className="text-sm text-muted-foreground">
+          How did this agent handle the task overall?
+        </p>
+        <div className="flex flex-wrap gap-2">
+          {RATINGS.map((r) => {
+            const selected = current === r.value;
+            return (
+              <Button
+                key={r.value}
+                type="button"
+                variant={selected ? "default" : "outline"}
+                size="sm"
+                onClick={() => void submit(r.value)}
+                disabled={busy}
+                className={cn(selected && "ring-2 ring-primary/40")}
+              >
+                {r.label}
+              </Button>
+            );
+          })}
+        </div>
+
+        <Textarea
+          value={note}
+          onChange={(e) => {
+            setNote(e.target.value);
+            setSaved(false);
+          }}
+          placeholder="Optional: why? (saved with your verdict)"
+          rows={2}
+          className="text-sm"
+        />
+        {current && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => void submit(current)}
+            disabled={busy}
+          >
+            {busy ? "Saving…" : "Save note"}
+          </Button>
+        )}
+
+        {error && (
+          <p className="text-sm text-destructive" role="alert">
+            {error}
+          </p>
+        )}
+        {saved && !error && (
+          <p className="text-xs text-muted-foreground">Saved.</p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/routes/traces/TraceReviewList.tsx
+++ b/src/routes/traces/TraceReviewList.tsx
@@ -1,0 +1,97 @@
+/**
+ * #271 (M31): blind reviewer's cross-project discovery list of trajectories to
+ * review. Rendered under EvalLayout at /eval/traces — no org/project context.
+ * Reads everything from `listReviewableTraces`; for blind reviewers the backend
+ * strips product/harness/model, so those rows show only the project name and
+ * step count. No real ids or provenance attributes reach the DOM.
+ */
+import { useQuery } from "convex/react";
+import { Link } from "react-router-dom";
+import { api } from "../../../convex/_generated/api";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Badge } from "@/components/ui/badge";
+import { Route, ArrowRight } from "lucide-react";
+
+type TraceStatus = "pending" | "ready" | "failed";
+
+function StatusBadge({ status }: { status: string }) {
+  const s = status as TraceStatus;
+  if (s === "failed") {
+    return <Badge variant="destructive">Failed</Badge>;
+  }
+  if (s === "pending") {
+    return <Badge variant="outline">Processing</Badge>;
+  }
+  return <Badge variant="secondary">Ready</Badge>;
+}
+
+export function TraceReviewList() {
+  const traces = useQuery(api.agentTraces.listReviewableTraces, {});
+
+  return (
+    <div className="mx-auto max-w-3xl p-6">
+      <header>
+        <div className="flex items-center gap-2">
+          <Route aria-hidden="true" className="h-5 w-5 text-primary" />
+          <h1 className="text-2xl font-bold">Trajectories to review</h1>
+        </div>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Review each imported agent run step by step — every message, tool
+          call, and result in order.
+        </p>
+      </header>
+
+      <div className="mt-6">
+        {traces === undefined ? (
+          <div className="space-y-2">
+            {[0, 1, 2, 3].map((i) => (
+              <Skeleton key={i} className="h-16 w-full" />
+            ))}
+          </div>
+        ) : traces.length === 0 ? (
+          <div className="max-w-lg space-y-3 rounded-lg border border-dashed p-6">
+            <p className="text-sm">
+              No trajectories assigned to review yet. When a teammate shares an
+              agent run with you, it will show up here.
+            </p>
+          </div>
+        ) : (
+          <ul className="space-y-2">
+            {traces.map((t) => {
+              const provenance = [t.product, t.harnessName, t.model].filter(
+                Boolean,
+              );
+              return (
+                <li key={t._id}>
+                  <Link
+                    to={`/eval/traces/${t._id}`}
+                    className="flex items-center justify-between gap-4 rounded-lg border bg-card px-4 py-3 transition-colors hover:bg-muted/50"
+                  >
+                    <div className="min-w-0">
+                      <p className="truncate text-sm font-medium">
+                        {t.projectName}
+                      </p>
+                      <p className="mt-0.5 text-xs text-muted-foreground">
+                        {provenance.length > 0 && (
+                          <>{provenance.join(" · ")} · </>
+                        )}
+                        {t.stepCount} {t.stepCount === 1 ? "step" : "steps"}
+                      </p>
+                    </div>
+                    <div className="flex shrink-0 items-center gap-3">
+                      <StatusBadge status={t.status} />
+                      <ArrowRight
+                        aria-hidden="true"
+                        className="h-4 w-4 text-muted-foreground"
+                      />
+                    </div>
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/routes/traces/TraceViewer.tsx
+++ b/src/routes/traces/TraceViewer.tsx
@@ -1,34 +1,14 @@
 /**
- * #267 (M31.4): step-level review of a single agent trajectory. Header metadata
- * + a whole-trajectory verdict + the paginated step list with per-step comments.
- *
- * For blind reviewers the backend strips harness/model/product; when that
- * provenance is absent we show the bias-reduction framing instead. No real ids
- * or provenance attributes are rendered into the DOM.
+ * #267 (M31.4): step-level review of a single agent trajectory for owners and
+ * editors, nested under ProjectLayout. The actual review surface lives in the
+ * shared TraceReviewBody (#271) so blind reviewers reach an identical view via
+ * /eval/traces/:agentTraceId. This wrapper only supplies the project-scoped
+ * back link.
  */
-import { useEffect, useState } from "react";
-import { useQuery, useMutation } from "convex/react";
-import { Link, useParams } from "react-router-dom";
-import { api } from "../../../convex/_generated/api";
+import { useParams } from "react-router-dom";
 import type { Id } from "../../../convex/_generated/dataModel";
 import { useProject } from "@/contexts/ProjectContext";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
-import { Textarea } from "@/components/ui/textarea";
-import { Skeleton } from "@/components/ui/skeleton";
-import { buttonVariants } from "@/components/ui/button";
-import { cn } from "@/lib/utils";
-import { friendlyError } from "@/lib/errors";
-import { StepList, StepBody } from "./traceSteps";
-import { ArrowLeft, EyeOff, Route } from "lucide-react";
-
-const RATINGS = [
-  { value: "best", label: "Best" },
-  { value: "acceptable", label: "Acceptable" },
-  { value: "weak", label: "Weak" },
-] as const;
-
-type Rating = (typeof RATINGS)[number]["value"];
+import { TraceReviewBody } from "./TraceReviewBody";
 
 export function TraceViewer() {
   const { projectId } = useProject();
@@ -38,225 +18,13 @@ export function TraceViewer() {
   }>();
   const traceId = agentTraceId as Id<"agentTraces">;
 
-  const trace = useQuery(api.agentTraces.getTrace, { agentTraceId: traceId });
-  const comments = useQuery(api.agentTraceReview.listComments, {
-    agentTraceId: traceId,
-  });
-
   const projectBase = `/orgs/${orgSlug}/projects/${projectId}`;
 
-  if (trace === undefined) {
-    return (
-      <div className="mx-auto max-w-3xl space-y-4 p-6">
-        <Skeleton className="h-8 w-56" />
-        <Skeleton className="h-24 w-full" />
-        <Skeleton className="h-64 w-full" />
-      </div>
-    );
-  }
-
-  if (trace === null) {
-    return (
-      <div className="mx-auto max-w-3xl space-y-3 p-6">
-        <p className="text-sm">
-          This trajectory isn’t available. It may have been removed, or you may
-          not have access to it.
-        </p>
-        <Link
-          to={`${projectBase}/traces`}
-          className={buttonVariants({ size: "sm", variant: "outline" })}
-        >
-          <ArrowLeft aria-hidden="true" className="mr-1.5 h-3.5 w-3.5" />
-          Back to trajectories
-        </Link>
-      </div>
-    );
-  }
-
-  const blind = !trace.harnessName && !trace.product && !trace.model;
-  const provenance = [trace.product, trace.harnessName, trace.model].filter(
-    Boolean,
-  );
-
-  const usageBits: string[] = [];
-  if (trace.usage.totalTokens !== undefined) {
-    usageBits.push(`${trace.usage.totalTokens.toLocaleString()} tokens`);
-  }
-  if (trace.usage.costUsd !== undefined) {
-    usageBits.push(`$${trace.usage.costUsd.toFixed(4)}`);
-  }
-  if (trace.usage.durationMs !== undefined) {
-    usageBits.push(
-      trace.usage.durationMs >= 1000
-        ? `${(trace.usage.durationMs / 1000).toFixed(1)}s`
-        : `${trace.usage.durationMs}ms`,
-    );
-  }
-
   return (
-    <div className="mx-auto max-w-3xl p-6">
-      <Link
-        to={`${projectBase}/traces`}
-        className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
-      >
-        <ArrowLeft aria-hidden="true" className="h-3 w-3" />
-        Trajectories
-      </Link>
-
-      <header className="mt-3">
-        <div className="flex items-center gap-2">
-          <Route aria-hidden="true" className="h-5 w-5 text-primary" />
-          <h1 className="text-2xl font-bold">
-            {provenance.length > 0 ? provenance.join(" · ") : "Trajectory"}
-          </h1>
-        </div>
-        <p className="mt-1 text-sm text-muted-foreground">
-          {trace.stepCount} {trace.stepCount === 1 ? "step" : "steps"}
-          {usageBits.length > 0 && <> · {usageBits.join(" · ")}</>}
-        </p>
-      </header>
-
-      {trace.status === "failed" && (
-        <p className="mt-4 text-sm text-destructive" role="alert">
-          This import failed while processing. Re-import the session to try
-          again.
-        </p>
-      )}
-
-      {blind && (
-        <Card className="mt-4 border-primary/30 bg-primary/5">
-          <CardContent className="flex items-start gap-2 pt-0 text-sm text-muted-foreground">
-            <EyeOff
-              aria-hidden="true"
-              className="mt-0.5 h-4 w-4 shrink-0 text-primary"
-            />
-            <p>
-              <span className="font-medium text-foreground">Blind review</span>{" "}
-              — provenance hidden. Blinding reduces bias; it is not anonymity.
-            </p>
-          </CardContent>
-        </Card>
-      )}
-
-      <VerdictControl agentTraceId={traceId} />
-
-      {trace.hasFinalAnswer && (
-        <Card className="mt-6">
-          <CardHeader>
-            <CardTitle className="text-base">Final answer</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <StepBody agentTraceId={traceId} field="text" />
-          </CardContent>
-        </Card>
-      )}
-
-      <section className="mt-6">
-        <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
-          Steps
-        </h2>
-        <StepList agentTraceId={traceId} comments={comments} />
-      </section>
-    </div>
-  );
-}
-
-function VerdictControl({ agentTraceId }: { agentTraceId: Id<"agentTraces"> }) {
-  const verdict = useQuery(api.agentTraceReview.myVerdict, { agentTraceId });
-  const setVerdict = useMutation(api.agentTraceReview.setVerdict);
-
-  const [note, setNote] = useState("");
-  const [noteInit, setNoteInit] = useState(false);
-  const [busy, setBusy] = useState(false);
-  const [error, setError] = useState("");
-  const [saved, setSaved] = useState(false);
-
-  useEffect(() => {
-    if (!noteInit && verdict !== undefined) {
-      setNote(verdict?.note ?? "");
-      setNoteInit(true);
-    }
-  }, [verdict, noteInit]);
-
-  const current = verdict?.rating;
-
-  async function submit(rating: Rating) {
-    setBusy(true);
-    setError("");
-    setSaved(false);
-    try {
-      await setVerdict({
-        agentTraceId,
-        rating,
-        note: note.trim() ? note.trim() : undefined,
-      });
-      setSaved(true);
-    } catch (err) {
-      setError(friendlyError(err, "Couldn’t save your verdict. Try again."));
-    } finally {
-      setBusy(false);
-    }
-  }
-
-  return (
-    <Card className="mt-4">
-      <CardHeader>
-        <CardTitle className="text-base">Your verdict</CardTitle>
-      </CardHeader>
-      <CardContent className="space-y-3">
-        <p className="text-sm text-muted-foreground">
-          How did this agent handle the task overall?
-        </p>
-        <div className="flex flex-wrap gap-2">
-          {RATINGS.map((r) => {
-            const selected = current === r.value;
-            return (
-              <Button
-                key={r.value}
-                type="button"
-                variant={selected ? "default" : "outline"}
-                size="sm"
-                onClick={() => void submit(r.value)}
-                disabled={busy}
-                className={cn(selected && "ring-2 ring-primary/40")}
-              >
-                {r.label}
-              </Button>
-            );
-          })}
-        </div>
-
-        <Textarea
-          value={note}
-          onChange={(e) => {
-            setNote(e.target.value);
-            setSaved(false);
-          }}
-          placeholder="Optional: why? (saved with your verdict)"
-          rows={2}
-          className="text-sm"
-        />
-        {current && (
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            onClick={() => void submit(current)}
-            disabled={busy}
-          >
-            {busy ? "Saving…" : "Save note"}
-          </Button>
-        )}
-
-        {error && (
-          <p className="text-sm text-destructive" role="alert">
-            {error}
-          </p>
-        )}
-        {saved && !error && (
-          <p className="text-xs text-muted-foreground">Saved.</p>
-        )}
-      </CardContent>
-    </Card>
+    <TraceReviewBody
+      agentTraceId={traceId}
+      backTo={`${projectBase}/traces`}
+      backLabel="Trajectories"
+    />
   );
 }

--- a/src/routes/traces/__smoke__/convexReactMock.tsx
+++ b/src/routes/traces/__smoke__/convexReactMock.tsx
@@ -4,6 +4,8 @@
  * lazy-expand against deterministic fixture data — no backend, no auth. Only the
  * hooks the trace components import are stubbed.
  */
+import { getFunctionName } from "convex/server";
+
 export const FIXTURE_STEPS = [
   { stepIndex: 0, kind: "message", role: "assistant", hasBody: true },
   {
@@ -51,6 +53,59 @@ export function useMutation() {
   return noopMutation;
 }
 
-export function useQuery() {
+// Fixture rows for the blind reviewer's discovery list (listReviewableTraces).
+export const FIXTURE_REVIEWABLE = [
+  {
+    _id: "trace_review_1",
+    projectName: "Support Router",
+    status: "ready",
+    stepCount: 12,
+    createdAt: 2,
+  },
+  {
+    _id: "trace_review_2",
+    projectName: "Refund Agent",
+    status: "ready",
+    stepCount: 3,
+    createdAt: 1,
+  },
+];
+
+// A blind reviewer's getTrace payload — provenance stripped by the backend
+// (harness/model/product undefined), projectName + usage retained.
+export const FIXTURE_BLIND_TRACE = {
+  _id: "trace_review_1",
+  projectName: "Support Router",
+  traceId: undefined,
+  product: undefined,
+  module: undefined,
+  environment: undefined,
+  status: "ready",
+  stepCount: 4,
+  privacyClass: "internal",
+  model: undefined,
+  harnessName: undefined,
+  harnessVersion: undefined,
+  usage: { totalTokens: 900 },
+  hasFinalAnswer: true,
+};
+
+// Branch by function name so each query gets the right fixture; anything
+// unmapped stays undefined (loading), keeping specs independent.
+export function useQuery(query: unknown) {
+  try {
+    switch (getFunctionName(query as never)) {
+      case "agentTraces:listReviewableTraces":
+        return FIXTURE_REVIEWABLE;
+      case "agentTraces:getTrace":
+        return FIXTURE_BLIND_TRACE;
+      case "agentTraceReview:myVerdict":
+        return null;
+      case "agentTraceReview:listComments":
+        return [];
+    }
+  } catch {
+    // Not a resolvable function reference — treat as loading.
+  }
   return undefined;
 }

--- a/src/routes/traces/traceReviewBody.ct.spec.tsx
+++ b/src/routes/traces/traceReviewBody.ct.spec.tsx
@@ -1,0 +1,26 @@
+import { test, expect } from "@playwright/experimental-ct-react";
+import { MemoryRouter } from "react-router-dom";
+import type { Id } from "../../../convex/_generated/dataModel";
+import { TraceReviewBody } from "./TraceReviewBody";
+
+// #271 render smoke for the BLIND reviewer's review page: the getTrace payload
+// has provenance stripped, so the surface must show "Trajectory" (no harness/
+// model), the bias-reduction framing, the verdict control, and the steps.
+test("blind review page: no provenance, bias framing, verdict, and steps render", async ({
+  mount,
+}) => {
+  const cmp = await mount(
+    <MemoryRouter>
+      <TraceReviewBody
+        agentTraceId={"t" as Id<"agentTraces">}
+        backTo="/eval/traces"
+        backLabel="Trajectories to review"
+      />
+    </MemoryRouter>,
+  );
+  await expect(cmp).toContainText("Trajectory"); // header, no provenance
+  await expect(cmp).toContainText("Blinding reduces bias; it is not anonymity");
+  await expect(cmp).toContainText("Your verdict");
+  await expect(cmp).toContainText("Acceptable");
+  await expect(cmp).toContainText("run_command"); // steps render via StepList
+});

--- a/src/routes/traces/traceReviewList.ct.spec.tsx
+++ b/src/routes/traces/traceReviewList.ct.spec.tsx
@@ -1,0 +1,18 @@
+import { test, expect } from "@playwright/experimental-ct-react";
+import { MemoryRouter } from "react-router-dom";
+import { TraceReviewList } from "./TraceReviewList";
+
+// Render smoke for the blind reviewer's discovery list (#271): does
+// listReviewableTraces render a row per trajectory with the project name and
+// step count? Convex is mocked; useQuery returns FIXTURE_REVIEWABLE.
+test("renders reviewable trajectory rows", async ({ mount }) => {
+  const cmp = await mount(
+    <MemoryRouter>
+      <TraceReviewList />
+    </MemoryRouter>,
+  );
+  await expect(cmp).toContainText("Support Router");
+  await expect(cmp).toContainText("Refund Agent");
+  await expect(cmp).toContainText("12 steps");
+  await expect(cmp).toContainText("3 steps");
+});


### PR DESCRIPTION
Closes #271. Makes the M31.4 trace review usable by the reviewer it's for: the **domain-expert (blind) reviewer**, who couldn't reach it before.

## The problem
The trace review UI (#267) lived under `ProjectLayout` at `/orgs/:slug/projects/:id/traces/...`, but `ProjectLayout` redirects blind evaluators to `/eval`. So the person whose blind judgment is the entire M31 thesis could never open a trace. The blind projection backend (#266) was enforced + tested, but unreachable.

## The fix (mirrors the prompt-output blind surface, `SessionDeck`)
The trace **backend already authorizes evaluators** (`requireProjectRole` + `isBlindReviewer`) — the gap was a reachable route + discovery + context-free pages.

**Backend** (no auth changes):
- `listReviewableTraces` — traces across every project the caller collaborates on, blind-projected per project, ready-only. The discovery list for `/eval`, which has no project context.
- `getTrace`/`getMatchup` now return `projectName` (the eval project name — not harness/model provenance) for the "Evaluation — {project}" title (blind-eval Rule 3).

**Frontend**:
- Extracted `TraceReviewBody` / `TraceMatchupBody` — shared, context-free bodies. Owner routes (under `ProjectLayout`) and the new blind routes render the **same** surface; only the wrappers differ (`useProject` vs none).
- New pages under `/eval` (`EvalLayout`, no project context): `TraceReviewList`, `TraceReview` (`:agentTraceId`), `TraceMatchupReview` (`:matchupId`).
- `InvitesInbox` (the `/eval` landing) shows a "N trajectories to review →" card when there's work.

## Blind-safety
For a blind reviewer the header reads "Trajectory" (no harness/model/product), the "Blinding reduces bias; it is not anonymity" card shows, title is "Evaluation — {project}", no `data-*` provenance, blue/purple only.

## Verification
- `npm run build` clean · `npm run test:convex` **196 passed** (new `listReviewableTraces` test) · `npm run test:ct` **4 passed** — including a new **blind review-page render smoke** (asserts no provenance, bias framing, verdict control, and steps all render) + the reviewable-list render.

## Still a human step
An actual authed browser clickthrough of the full blind flow (invite an evaluator → they land on `/eval` → open a trace → comment/rate/A-B) — the CT guards render, not the live auth+session path (impractical to automate here: Convex Auth + the powerless Anonymous provider). Recommended manual QA before/after merge: sign in as a blind evaluator on a project with an imported session and walk the flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)