### PR TITLE
M31.7 (#53): training-data export bridge — DPO/SFT for trajectories + output preferences

### DIFF
--- a/convex/exports.ts
+++ b/convex/exports.ts
@@ -1,0 +1,417 @@
+/**
+ * #53: training-data export bridge. One engine, two sources
+ * (output_preference | trajectory), feeding the #53 serializers + data-boundary
+ * gate (convex/lib/trainingExport.ts).
+ *
+ * Split (actions have no ctx.db; trajectory bodies live in storage):
+ *  - `gatherOutputPrefRows` (internalQuery): output-preference rows are complete
+ *    (outputContent is inline text) — returns ClassifiedRow[] ready to gate.
+ *  - `gatherTrajectoryPlan` (internalQuery): trajectory bodies are in storage, so
+ *    it returns a PLAN (step metadata + fullBodyStorageId refs); the action reads
+ *    the blobs and assembles the rows.
+ *  - `generateExport` (action): gather → (trajectory: read bodies) → gate →
+ *    toJsonl → store blob → record row. Auth is owner/editor ONLY (export is
+ *    privileged + un-blinded — never evaluators).
+ *
+ * Anonymization is by CONSTRUCTION: rows are built from an allowlist (resolved
+ * prompt, output/step text, blind labels, counts) — never raw docs, org names,
+ * emails, or user ids. `gateRows` is the backstop.
+ */
+import { v } from "convex/values";
+import { action, internalMutation, internalQuery, query } from "./_generated/server";
+import { internal } from "./_generated/api";
+import type { Doc, Id } from "./_generated/dataModel";
+import { requireProjectRole } from "./lib/auth";
+import { readMessages } from "./lib/messages";
+import {
+  gateRows,
+  toJsonl,
+  renderStep,
+  renderTranscript,
+  moreSensitive,
+  type ClassifiedRow,
+  type ExportFormat,
+  type PrivacyClass,
+  type StepMeta,
+} from "./lib/trainingExport";
+
+const SOURCE = v.union(v.literal("trajectory"), v.literal("output_preference"));
+const FORMAT = v.union(v.literal("dpo"), v.literal("annotated"), v.literal("sft"));
+
+const DOWNLOAD_TTL_MS = 60 * 60 * 1000; // AC6: download expires after 1 hour
+const MAX_PAIRS_PER_RUN = 20; // cap best×weak explosion per run
+
+// {{word}} substitution — mirrors convex/runsActions.ts substituteVariables.
+const substitute = (t: string, vars: Record<string, string>): string =>
+  t.replace(/\{\{(\w+)\}\}/g, (m, n: string) => vars[n] ?? m);
+
+const metaOf = (s: Doc<"agentTraceSteps">): StepMeta => ({
+  kind: s.kind,
+  role: s.role,
+  toolName: s.toolName,
+  label: s.label,
+  policy: s.policy,
+  action: s.action,
+  reason: s.reason,
+});
+
+// --- output-preference source (complete rows, no storage) --------------------
+
+export const gatherOutputPrefRows = internalQuery({
+  args: { projectId: v.id("projects"), format: FORMAT },
+  handler: async (ctx, args): Promise<ClassifiedRow[]> => {
+    await requireProjectRole(ctx, args.projectId, ["owner", "editor"]);
+    const rows: ClassifiedRow[] = [];
+    const runs = await ctx.db
+      .query("promptRuns")
+      .withIndex("by_project_and_status", (q) =>
+        q.eq("projectId", args.projectId).eq("status", "completed"),
+      )
+      .collect();
+
+    for (const run of runs) {
+      const outputs = await ctx.db
+        .query("runOutputs")
+        .withIndex("by_run", (q) => q.eq("runId", run._id))
+        .collect();
+      if (outputs.length === 0) continue;
+      const prefs = await ctx.db
+        .query("outputPreferences")
+        .withIndex("by_run", (q) => q.eq("runId", run._id))
+        .collect();
+      if (prefs.length === 0) continue;
+
+      // Tally ratings per output; classify best (≥1 best, 0 weak) vs weak (≥1 weak).
+      const tally = new Map<string, { best: number; weak: number }>();
+      for (const p of prefs) {
+        const t = tally.get(p.outputId) ?? { best: 0, weak: 0 };
+        if (p.rating === "best") t.best++;
+        else if (p.rating === "weak") t.weak++;
+        tally.set(p.outputId, t);
+      }
+      const best = outputs.filter((o) => {
+        const t = tally.get(o._id);
+        return t && t.best > 0 && t.weak === 0;
+      });
+      const weak = outputs.filter((o) => {
+        const t = tally.get(o._id);
+        return t && t.weak > 0;
+      });
+      if (best.length === 0) continue;
+
+      // Resolve the prompt (variables substituted) from the run's version.
+      const version = await ctx.db.get(run.promptVersionId);
+      let vars: Record<string, string> | undefined = run.inputSnapshot?.text;
+      if (!vars && run.testCaseId) {
+        const tc = await ctx.db.get(run.testCaseId);
+        vars = tc?.variableValues ?? undefined;
+      }
+      vars = vars ?? run.inlineVariables ?? {};
+      const messages = version
+        ? readMessages(version).map((m) => ({ role: m.role, content: substitute(m.content ?? "", vars!) }))
+        : [];
+      const promptText = messages.map((m) => `${m.role}: ${m.content}`).join("\n");
+      const evaluatorCount = new Set(prefs.map((p) => p.userId)).size;
+
+      if (args.format === "dpo") {
+        let made = 0;
+        for (const b of best) {
+          for (const w of weak) {
+            if (made >= MAX_PAIRS_PER_RUN) break;
+            rows.push({
+              privacyClass: "internal",
+              row: {
+                kind: "dpo",
+                prompt: promptText,
+                chosen: b.outputContent,
+                rejected: w.outputContent,
+                metadata: {
+                  blind_labels: [b.blindLabel, w.blindLabel],
+                  evaluator_count: evaluatorCount,
+                },
+              },
+            });
+            made++;
+          }
+        }
+      } else if (args.format === "sft") {
+        for (const b of best) {
+          rows.push({
+            privacyClass: "internal",
+            row: {
+              kind: "sft",
+              messages: [...messages, { role: "assistant", content: b.outputContent }],
+              metadata: { preference: "best" },
+            },
+          });
+        }
+      }
+    }
+    return rows;
+  },
+});
+
+// --- trajectory source (plan → action reads storage) -------------------------
+
+interface StepRef {
+  meta: StepMeta;
+  storageId?: Id<"_storage">;
+}
+interface TrajectoryPlanRow {
+  privacyClass: PrivacyClass;
+  metadata: Record<string, unknown>;
+  prefix?: StepRef[];
+  chosen?: StepRef;
+  rejected?: StepRef;
+  messages?: StepRef[];
+  finalAnswer?: Id<"_storage">;
+}
+
+export const gatherTrajectoryPlan = internalQuery({
+  args: { projectId: v.id("projects"), format: FORMAT },
+  handler: async (ctx, args): Promise<TrajectoryPlanRow[]> => {
+    await requireProjectRole(ctx, args.projectId, ["owner", "editor"]);
+    const stepsOf = (traceId: Id<"agentTraces">) =>
+      ctx.db
+        .query("agentTraceSteps")
+        .withIndex("by_trace_and_index", (q) => q.eq("agentTraceId", traceId))
+        .collect();
+
+    const plan: TrajectoryPlanRow[] = [];
+
+    if (args.format === "dpo") {
+      const matchups = await ctx.db
+        .query("agentTraceMatchups")
+        .withIndex("by_project", (q) => q.eq("projectId", args.projectId))
+        .collect();
+      for (const m of matchups) {
+        if (m.winner !== "left" && m.winner !== "right") continue;
+        const winnerId = m.winner === "left" ? m.leftTraceId : m.rightTraceId;
+        const loserId = m.winner === "left" ? m.rightTraceId : m.leftTraceId;
+        const [wt, lt] = [await ctx.db.get(winnerId), await ctx.db.get(loserId)];
+        if (!wt || !lt) continue;
+        const wSteps = await stepsOf(winnerId);
+        const lSteps = await stepsOf(loserId);
+        const chosen = wSteps.find((s) => s.stepIndex === m.divergenceStepIndex);
+        const rejected = lSteps.find((s) => s.stepIndex === m.divergenceStepIndex);
+        if (!chosen || !rejected) continue;
+        plan.push({
+          privacyClass: moreSensitive(wt.privacyClass, lt.privacyClass),
+          metadata: { reason_tags: m.reasonTags },
+          prefix: wSteps
+            .filter((s) => s.stepIndex < m.divergenceStepIndex)
+            .map((s) => ({ meta: metaOf(s), storageId: s.fullBodyStorageId })),
+          chosen: { meta: metaOf(chosen), storageId: chosen.fullBodyStorageId },
+          rejected: { meta: metaOf(rejected), storageId: rejected.fullBodyStorageId },
+        });
+      }
+    } else if (args.format === "sft") {
+      const traces = await ctx.db
+        .query("agentTraces")
+        .withIndex("by_project", (q) => q.eq("projectId", args.projectId))
+        .collect();
+      for (const tr of traces) {
+        if (tr.status !== "ready") continue;
+        const verdicts = await ctx.db
+          .query("agentTraceVerdicts")
+          .withIndex("by_trace", (q) => q.eq("agentTraceId", tr._id))
+          .collect();
+        if (!verdicts.some((vd) => vd.rating === "best")) continue;
+        const steps = await stepsOf(tr._id);
+        plan.push({
+          privacyClass: tr.privacyClass,
+          metadata: { verdict: "best" },
+          messages: steps
+            .filter((s) => s.kind === "message")
+            .map((s) => ({ meta: metaOf(s), storageId: s.fullBodyStorageId })),
+          finalAnswer: tr.finalAnswerStorageId,
+        });
+      }
+    }
+    return plan;
+  },
+});
+
+// --- record + list -----------------------------------------------------------
+
+export const recordExport = internalMutation({
+  args: {
+    projectId: v.id("projects"),
+    source: SOURCE,
+    format: FORMAT,
+    storageId: v.id("_storage"),
+    rowCount: v.number(),
+    excludedCount: v.number(),
+    createdById: v.id("users"),
+    createdAt: v.number(),
+  },
+  handler: async (ctx, args): Promise<Id<"trainingExports">> =>
+    await ctx.db.insert("trainingExports", args),
+});
+
+export const listExports = query({
+  args: { projectId: v.id("projects") },
+  handler: async (ctx, args) => {
+    await requireProjectRole(ctx, args.projectId, ["owner", "editor"]);
+    const rows = await ctx.db
+      .query("trainingExports")
+      .withIndex("by_project", (q) => q.eq("projectId", args.projectId))
+      .order("desc")
+      .take(50);
+    return rows.map((r) => ({
+      _id: r._id,
+      source: r.source,
+      format: r.format,
+      rowCount: r.rowCount,
+      excludedCount: r.excludedCount,
+      createdAt: r.createdAt,
+      expired: Date.now() - r.createdAt > DOWNLOAD_TTL_MS,
+    }));
+  },
+});
+
+// --- the export action -------------------------------------------------------
+
+export const generateExport = action({
+  args: {
+    projectId: v.id("projects"),
+    source: SOURCE,
+    format: FORMAT,
+    // Explicit consent to include prod-sensitive (confidential/pii/phi) rows.
+    allowSensitive: v.optional(v.boolean()),
+  },
+  handler: async (
+    ctx,
+    args,
+  ): Promise<{ exportId: Id<"trainingExports">; rowCount: number; excludedCount: number }> => {
+    if (args.format === "annotated") {
+      throw new Error("Annotated export isn’t available yet — use DPO or SFT.");
+    }
+    const userId = await ctx.runQuery(internal.exports.whoAmIForExport, {
+      projectId: args.projectId,
+    });
+
+    let classified: ClassifiedRow[];
+    if (args.source === "output_preference") {
+      classified = await ctx.runQuery(internal.exports.gatherOutputPrefRows, {
+        projectId: args.projectId,
+        format: args.format,
+      });
+    } else {
+      const plan = await ctx.runQuery(internal.exports.gatherTrajectoryPlan, {
+        projectId: args.projectId,
+        format: args.format,
+      });
+      classified = await hydrateTrajectory(ctx, plan, args.format);
+    }
+
+    const { included, excluded } = gateRows(classified, {
+      allowSensitive: args.allowSensitive,
+    });
+    const jsonl = toJsonl(args.format as ExportFormat, included);
+
+    const storageId = await ctx.storage.store(
+      new Blob([jsonl], { type: "application/jsonl" }),
+    );
+    const exportId = await ctx.runMutation(internal.exports.recordExport, {
+      projectId: args.projectId,
+      source: args.source,
+      format: args.format,
+      storageId,
+      rowCount: included.length,
+      excludedCount: excluded.length,
+      createdById: userId,
+      createdAt: Date.now(),
+    });
+    return { exportId, rowCount: included.length, excludedCount: excluded.length };
+  },
+});
+
+// Read trajectory bodies from storage and assemble ExportRows.
+async function hydrateTrajectory(
+  ctx: { storage: { get: (id: Id<"_storage">) => Promise<Blob | null> } },
+  plan: TrajectoryPlanRow[],
+  format: "dpo" | "sft" | "annotated",
+): Promise<ClassifiedRow[]> {
+  const cache = new Map<string, unknown>();
+  const read = async (id?: Id<"_storage">): Promise<unknown> => {
+    if (!id) return undefined;
+    if (cache.has(id)) return cache.get(id);
+    const blob = await ctx.storage.get(id);
+    let body: unknown = undefined;
+    if (blob) {
+      try {
+        body = JSON.parse(await blob.text());
+      } catch {
+        body = undefined;
+      }
+    }
+    cache.set(id, body);
+    return body;
+  };
+
+  const out: ClassifiedRow[] = [];
+  for (const r of plan) {
+    if (format === "dpo" && r.chosen && r.rejected) {
+      const prefix = await Promise.all(
+        (r.prefix ?? []).map(async (s) => ({ meta: s.meta, body: await read(s.storageId) })),
+      );
+      const chosen = renderStep(r.chosen.meta, await read(r.chosen.storageId));
+      const rejected = renderStep(r.rejected.meta, await read(r.rejected.storageId));
+      out.push({
+        privacyClass: r.privacyClass,
+        row: { kind: "dpo", prompt: renderTranscript(prefix), chosen, rejected, metadata: r.metadata },
+      });
+    } else if (format === "sft" && r.messages) {
+      const msgs = await Promise.all(
+        r.messages.map(async (s) => ({
+          role: s.meta.role ?? "assistant",
+          content: String(((await read(s.storageId)) as Record<string, unknown> | undefined)?.content ?? ""),
+        })),
+      );
+      const finalBody = (await read(r.finalAnswer)) as Record<string, unknown> | undefined;
+      if (finalBody?.text) msgs.push({ role: "assistant", content: String(finalBody.text) });
+      out.push({ privacyClass: r.privacyClass, row: { kind: "sft", messages: msgs, metadata: r.metadata } });
+    }
+  }
+  return out;
+}
+
+// Actions have no ctx.db; resolve the owner/editor caller via an internal query.
+export const whoAmIForExport = internalQuery({
+  args: { projectId: v.id("projects") },
+  handler: async (ctx, args): Promise<Id<"users">> => {
+    const { userId } = await requireProjectRole(ctx, args.projectId, ["owner", "editor"]);
+    return userId;
+  },
+});
+
+// --- download (1-hour gate) --------------------------------------------------
+
+export const downloadExport = action({
+  args: { exportId: v.id("trainingExports") },
+  handler: async (ctx, args): Promise<{ url: string }> => {
+    const meta = await ctx.runQuery(internal.exports.exportForDownload, {
+      exportId: args.exportId,
+    });
+    if (Date.now() - meta.createdAt > DOWNLOAD_TTL_MS) {
+      throw new Error("This export link has expired. Generate a fresh export.");
+    }
+    const url = await ctx.storage.getUrl(meta.storageId);
+    if (!url) throw new Error("Export file is no longer available.");
+    return { url };
+  },
+});
+
+export const exportForDownload = internalQuery({
+  args: { exportId: v.id("trainingExports") },
+  handler: async (
+    ctx,
+    args,
+  ): Promise<{ storageId: Id<"_storage">; createdAt: number }> => {
+    const row = await ctx.db.get(args.exportId);
+    if (!row) throw new Error("Export not found.");
+    await requireProjectRole(ctx, row.projectId, ["owner", "editor"]);
+    return { storageId: row.storageId, createdAt: row.createdAt };
+  },
+});

--- a/convex/lib/trainingExport.ts
+++ b/convex/lib/trainingExport.ts
@@ -140,6 +140,55 @@ export function gateRows(
   return { included, excluded };
 }
 
+// --- trajectory rendering (steps → readable text for DPO prompt/answers) -----
+
+export interface StepMeta {
+  kind: "message" | "tool_call" | "tool_result" | "state" | "policy_event";
+  role?: string;
+  toolName?: string;
+  label?: string;
+  policy?: string;
+  action?: string;
+  reason?: string;
+}
+
+const asStr = (v: unknown): string =>
+  typeof v === "string" ? v : v === undefined ? "" : JSON.stringify(v);
+
+/** One step (metadata + its parsed body) → a single readable transcript line. */
+export function renderStep(meta: StepMeta, body: unknown): string {
+  const b = (body ?? {}) as Record<string, unknown>;
+  switch (meta.kind) {
+    case "message":
+      return `${meta.role ?? "assistant"}: ${asStr(b.content)}`;
+    case "tool_call":
+      return `${meta.role ?? "assistant"} → ${meta.toolName ?? "tool"}(${asStr(b.args)})`;
+    case "tool_result":
+      return `tool ${meta.toolName ?? ""} result: ${asStr(b.result)}`;
+    case "state":
+      return `[state ${meta.label ?? ""}] ${asStr(b.snapshot)}`;
+    case "policy_event":
+      return `[policy ${meta.policy ?? ""}/${meta.action ?? ""}${meta.reason ? `: ${meta.reason}` : ""}]`;
+  }
+}
+
+/** Ordered (meta, body) pairs → a transcript string (DPO prefix / SFT turns). */
+export function renderTranscript(steps: Array<{ meta: StepMeta; body: unknown }>): string {
+  return steps.map((s) => renderStep(s.meta, s.body)).join("\n");
+}
+
+/** The more-sensitive of two privacy classes (for a matchup spanning two traces). */
+const CLASS_RANK: Record<PrivacyClass, number> = {
+  public: 0,
+  internal: 1,
+  confidential: 2,
+  pii: 3,
+  phi: 4,
+};
+export function moreSensitive(a: PrivacyClass, b: PrivacyClass): PrivacyClass {
+  return CLASS_RANK[a] >= CLASS_RANK[b] ? a : b;
+}
+
 const jsonl = (objs: unknown[]): string => objs.map((o) => JSON.stringify(o)).join("\n");
 
 /** Serialize gated rows to JSONL for the given format. Rows must match `format`. */

--- a/convex/lib/trainingExport.ts
+++ b/convex/lib/trainingExport.ts
@@ -1,0 +1,175 @@
+/**
+ * #53 (export bridge): Convex-safe serializers for training-data export.
+ *
+ * Pure, zero-dep (no node, no zod) so it runs in the Convex export action and in
+ * plain vitest. This module owns only the TARGET JSONL shapes (fixed by #53) and
+ * the data-boundary gate applied at serialization time; the per-source mapping
+ * (output preferences / trajectory matchups → these rows) lives in the export
+ * action. Formats:
+ *
+ *   DPO:       {prompt, chosen, rejected, metadata}
+ *   Annotated: {prompt, output, annotations:[{from,to,text,comment,tags}], preference, metadata}
+ *   SFT:       {messages:[{role,content}], metadata?}
+ *
+ * Data-boundary contract (mirrors src/lib/evals/trainingDataset.ts / #228):
+ *  - Default-deny by privacy class: only `public`/`internal` rows export; any
+ *    `confidential`/`pii`/`phi` (prod-sensitive) row is EXCLUDED unless the
+ *    caller passes an explicit consent flag.
+ *  - Excluded rows are reported with a reason, never dropped silently.
+ *  - Defense-in-depth: a row whose serialized text still contains an email or an
+ *    api-key-looking token is excluded (`pii_leak`) even if its class allowed it.
+ *  Anonymization is by CONSTRUCTION in the action (allowlisted fields only); this
+ *  gate is the backstop.
+ */
+
+export type ExportFormat = "dpo" | "annotated" | "sft";
+export type PrivacyClass = "public" | "internal" | "confidential" | "pii" | "phi";
+
+export interface Annotation {
+  from: number;
+  to: number;
+  text: string;
+  comment: string;
+  tags: string[];
+}
+
+export interface DpoPair {
+  prompt: string;
+  chosen: string;
+  rejected: string;
+  metadata: Record<string, unknown>;
+}
+
+export interface AnnotatedRow {
+  prompt: string;
+  output: string;
+  annotations: Annotation[];
+  preference: string;
+  metadata: Record<string, unknown>;
+}
+
+export interface SftMessage {
+  role: string;
+  content: string;
+}
+
+export interface SftRow {
+  messages: SftMessage[];
+  metadata?: Record<string, unknown>;
+}
+
+export type ExportRow =
+  | ({ kind: "dpo" } & DpoPair)
+  | ({ kind: "annotated" } & AnnotatedRow)
+  | ({ kind: "sft" } & SftRow);
+
+/** Every export row carries its privacy class so the gate can decide. */
+export interface ClassifiedRow {
+  row: ExportRow;
+  privacyClass: PrivacyClass;
+}
+
+export interface ExcludedRow {
+  reason: "prod_sensitive" | "pii_leak" | "empty";
+  privacyClass: PrivacyClass;
+}
+
+export interface GateResult {
+  included: ExportRow[];
+  excluded: ExcludedRow[];
+}
+
+const SENSITIVE_CLASSES: ReadonlySet<PrivacyClass> = new Set([
+  "confidential",
+  "pii",
+  "phi",
+]);
+
+// Belt-and-suspenders leak scan: email + common secret-key prefixes.
+const EMAIL = /[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}/i;
+const API_KEY = /\b(sk-[a-z0-9]{16,}|xox[baprs]-[a-z0-9-]{10,}|AKIA[0-9A-Z]{12,}|ghp_[a-z0-9]{20,})\b/i;
+
+const rowText = (row: ExportRow): string => {
+  switch (row.kind) {
+    case "dpo":
+      return `${row.prompt}\n${row.chosen}\n${row.rejected}`;
+    case "annotated":
+      return `${row.prompt}\n${row.output}\n${row.annotations.map((a) => `${a.text} ${a.comment}`).join("\n")}`;
+    case "sft":
+      return row.messages.map((m) => m.content).join("\n");
+  }
+};
+
+const isEmptyRow = (row: ExportRow): boolean => {
+  switch (row.kind) {
+    case "dpo":
+      return !row.prompt.trim() || !row.chosen.trim() || !row.rejected.trim();
+    case "annotated":
+      return !row.prompt.trim() || !row.output.trim();
+    case "sft":
+      return row.messages.length === 0 || row.messages.every((m) => !m.content.trim());
+  }
+};
+
+/**
+ * Apply the data-boundary gate. `allowSensitive` opts sensitive-class rows in
+ * (explicit consent); the pii-leak scan and empty-row drop always apply.
+ */
+export function gateRows(
+  rows: ClassifiedRow[],
+  opts: { allowSensitive?: boolean } = {},
+): GateResult {
+  const included: ExportRow[] = [];
+  const excluded: ExcludedRow[] = [];
+  for (const { row, privacyClass } of rows) {
+    if (isEmptyRow(row)) {
+      excluded.push({ reason: "empty", privacyClass });
+      continue;
+    }
+    if (SENSITIVE_CLASSES.has(privacyClass) && !opts.allowSensitive) {
+      excluded.push({ reason: "prod_sensitive", privacyClass });
+      continue;
+    }
+    const text = rowText(row);
+    if (EMAIL.test(text) || API_KEY.test(text)) {
+      excluded.push({ reason: "pii_leak", privacyClass });
+      continue;
+    }
+    included.push(row);
+  }
+  return { included, excluded };
+}
+
+const jsonl = (objs: unknown[]): string => objs.map((o) => JSON.stringify(o)).join("\n");
+
+/** Serialize gated rows to JSONL for the given format. Rows must match `format`. */
+export function toJsonl(format: ExportFormat, rows: ExportRow[]): string {
+  if (format === "dpo") {
+    return jsonl(
+      rows.map((r) => {
+        const p = r as DpoPair;
+        return { prompt: p.prompt, chosen: p.chosen, rejected: p.rejected, metadata: p.metadata };
+      }),
+    );
+  }
+  if (format === "annotated") {
+    return jsonl(
+      rows.map((r) => {
+        const a = r as AnnotatedRow;
+        return {
+          prompt: a.prompt,
+          output: a.output,
+          annotations: a.annotations,
+          preference: a.preference,
+          metadata: a.metadata,
+        };
+      }),
+    );
+  }
+  return jsonl(
+    rows.map((r) => {
+      const s = r as SftRow;
+      return s.metadata ? { messages: s.messages, metadata: s.metadata } : { messages: s.messages };
+    }),
+  );
+}

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -888,6 +888,28 @@ const schema = defineSchema({
     .index("by_project", ["projectId"])
     .index("by_left", ["leftTraceId"]),
 
+  // #53 (export bridge): a generated training-data export. The JSONL is in
+  // storage; this row tracks provenance + counts and gates the download to a
+  // 1-hour window (AC6). `excludedCount` reflects rows dropped by the
+  // data-boundary gate (reported to the user, never silently lost).
+  trainingExports: defineTable({
+    projectId: v.id("projects"),
+    source: v.union(
+      v.literal("trajectory"),
+      v.literal("output_preference"),
+    ),
+    format: v.union(
+      v.literal("dpo"),
+      v.literal("annotated"),
+      v.literal("sft"),
+    ),
+    storageId: v.id("_storage"),
+    rowCount: v.number(),
+    excludedCount: v.number(),
+    createdById: v.id("users"),
+    createdAt: v.number(),
+  }).index("by_project", ["projectId"]),
+
   // #259: per-org scorecard runs. Grades every org eval case that has a
   // captured production output against its assigned deterministic scorers.
   // `summary` and `errorMessage` are sanitized — counts + generic strings only,

--- a/convex/tests/exports.test.ts
+++ b/convex/tests/exports.test.ts
@@ -1,0 +1,168 @@
+/// <reference types="vite/client" />
+import { convexTest } from "convex-test";
+import { describe, expect, test } from "vitest";
+import { api } from "../_generated/api";
+import type { Id } from "../_generated/dataModel";
+import schema from "../schema";
+import {
+  normalizeJeevesClogRun,
+  type JeevesClogRunExport,
+  type AgentRunTrace,
+} from "../lib/agentTrace";
+
+const asJson = <T>(v: T): T => JSON.parse(JSON.stringify(v)) as T;
+type Ident = ReturnType<ReturnType<typeof convexTest>["withIdentity"]>;
+
+// Two trajectories that share a 2-step prefix then diverge at step 2.
+const runWith = (run_id: string, divergingTool: string): JeevesClogRunExport => ({
+  run_id,
+  product: "acme",
+  harness: { name: "jeeves_clog", version: "v1", sdk: "clog" },
+  model: "claude-sonnet-4-0",
+  messages: [{ role: "user", content: "Handle the account." }],
+  steps: [
+    { type: "message", role: "assistant", content: "Looking it up." },
+    { type: "tool_call", id: "t1", name: "lookup_account", args: { id: "ACCT-TEST-1" } },
+    { type: "tool_call", id: "t2", name: divergingTool, args: { note: "x" } },
+  ],
+  final_answer: "Done.",
+  usage: { cost_usd: 0.01, duration_ms: 1000, total_tokens: 500 },
+});
+
+async function seed(t: ReturnType<typeof convexTest>) {
+  const ids = await t.run(async (ctx) => {
+    const ownerUserId = await ctx.db.insert("users", { name: "Owner", email: "owner@test.com" });
+    const evalUserId = await ctx.db.insert("users", { name: "Rev", email: "rev@test.com" });
+    const orgId = await ctx.db.insert("organizations", { name: "Org", slug: "org", createdById: ownerUserId });
+    await ctx.db.insert("organizationMembers", { organizationId: orgId, userId: ownerUserId, role: "owner" });
+    const projectId = await ctx.db.insert("projects", { organizationId: orgId, name: "P", createdById: ownerUserId });
+    await ctx.db.insert("projectCollaborators", { projectId, userId: ownerUserId, role: "owner", invitedById: ownerUserId, invitedAt: Date.now() });
+    await ctx.db.insert("projectCollaborators", { projectId, userId: evalUserId, role: "evaluator", invitedById: ownerUserId, invitedAt: Date.now() });
+    return { ownerUserId, evalUserId, projectId };
+  });
+  return {
+    ids,
+    asOwner: t.withIdentity({ subject: `${ids.ownerUserId}|s`, tokenIdentifier: `test|${ids.ownerUserId}` }),
+    asEval: t.withIdentity({ subject: `${ids.evalUserId}|s`, tokenIdentifier: `test|${ids.evalUserId}` }),
+  };
+}
+
+const persist = async (as: Ident, projectId: Id<"projects">, run: JeevesClogRunExport) => {
+  const res = await as.action(api.agentTraces.persistTrace, {
+    projectId,
+    trace: asJson(normalizeJeevesClogRun(run)) as unknown as AgentRunTrace,
+  });
+  return res.agentTraceId;
+};
+
+const readExport = async (t: ReturnType<typeof convexTest>, exportId: Id<"trainingExports">) =>
+  await t.run(async (ctx) => {
+    const row = await ctx.db.get(exportId);
+    const blob = row ? await ctx.storage.get(row.storageId) : null;
+    return blob ? await blob.text() : "";
+  });
+
+describe("#53 training export", () => {
+  test("trajectory DPO: winner's divergence step is chosen, loser's rejected, prefix is the prompt", async () => {
+    const t = convexTest(schema);
+    const { ids, asOwner } = await seed(t);
+    const left = await persist(asOwner, ids.projectId, runWith("A", "create_escalation"));
+    const right = await persist(asOwner, ids.projectId, runWith("B", "close_ticket"));
+    const matchupId = await asOwner.mutation(api.agentTraceReview.createMatchup, {
+      leftTraceId: left, rightTraceId: right, divergenceStepIndex: 2,
+      leftBlindLabel: "A", rightBlindLabel: "B",
+    });
+    await asOwner.mutation(api.agentTraceReview.decideMatchup, { matchupId, winner: "left", reasonTags: ["accuracy"] });
+
+    const res = await asOwner.action(api.exports.generateExport, {
+      projectId: ids.projectId, source: "trajectory", format: "dpo",
+    });
+    expect(res.rowCount).toBe(1);
+    const line = JSON.parse(await readExport(t, res.exportId));
+    expect(line.chosen).toContain("create_escalation"); // winner (left) next action
+    expect(line.rejected).toContain("close_ticket"); // loser (right) next action
+    expect(line.prompt).toContain("lookup_account"); // shared prefix
+    expect(line.prompt).not.toContain("create_escalation"); // prefix stops before divergence
+  });
+
+  test("output-preference DPO: best vs weak with the resolved prompt", async () => {
+    const t = convexTest(schema);
+    const { ids, asOwner } = await seed(t);
+    await t.run(async (ctx) => {
+      const versionId = await ctx.db.insert("promptVersions", {
+        projectId: ids.projectId, versionNumber: 1,
+        // messages[] is canonical (readMessages prefers it); userMessageTemplate
+        // is the still-required legacy field.
+        messages: [{ id: "m1", role: "user", content: "Handle {{topic}} for the customer." }],
+        userMessageTemplate: "Handle {{topic}} for the customer.",
+        status: "current",
+        createdById: ids.ownerUserId,
+      });
+      const runId = await ctx.db.insert("promptRuns", {
+        projectId: ids.projectId, promptVersionId: versionId,
+        inlineVariables: { topic: "a refund" },
+        model: "m", temperature: 0, status: "completed", triggeredById: ids.ownerUserId,
+      });
+      const good = await ctx.db.insert("runOutputs", { runId, blindLabel: "A", outputContent: "Happy to refund you." });
+      const bad = await ctx.db.insert("runOutputs", { runId, blindLabel: "B", outputContent: "No refunds." });
+      await ctx.db.insert("outputPreferences", { runId, outputId: good, userId: ids.ownerUserId, rating: "best" });
+      await ctx.db.insert("outputPreferences", { runId, outputId: bad, userId: ids.ownerUserId, rating: "weak" });
+    });
+
+    const res = await asOwner.action(api.exports.generateExport, {
+      projectId: ids.projectId, source: "output_preference", format: "dpo",
+    });
+    expect(res.rowCount).toBe(1);
+    const line = JSON.parse(await readExport(t, res.exportId));
+    expect(line.prompt).toContain("Handle a refund for the customer."); // {{topic}} substituted
+    expect(line.chosen).toBe("Happy to refund you.");
+    expect(line.rejected).toBe("No refunds.");
+  });
+
+  test("consent gate: a pii-classed trajectory is excluded unless allowSensitive", async () => {
+    const t = convexTest(schema);
+    const { ids, asOwner } = await seed(t);
+    // ssn in args → normalizer marks the trace privacy pii.
+    const piiRun = (id: string, tool: string): JeevesClogRunExport => ({
+      ...runWith(id, tool),
+      steps: [
+        { type: "tool_call", id: "t1", name: "lookup", args: { ssn: "123-45-6789" } },
+        { type: "tool_call", id: "t2", name: tool, args: {} },
+      ],
+    });
+    const left = await persist(asOwner, ids.projectId, piiRun("A", "escalate"));
+    const right = await persist(asOwner, ids.projectId, piiRun("B", "close"));
+    const matchupId = await asOwner.mutation(api.agentTraceReview.createMatchup, {
+      leftTraceId: left, rightTraceId: right, divergenceStepIndex: 1, leftBlindLabel: "A", rightBlindLabel: "B",
+    });
+    await asOwner.mutation(api.agentTraceReview.decideMatchup, { matchupId, winner: "left", reasonTags: [] });
+
+    const denied = await asOwner.action(api.exports.generateExport, { projectId: ids.projectId, source: "trajectory", format: "dpo" });
+    expect(denied.rowCount).toBe(0);
+    expect(denied.excludedCount).toBe(1);
+
+    const consented = await asOwner.action(api.exports.generateExport, { projectId: ids.projectId, source: "trajectory", format: "dpo", allowSensitive: true });
+    expect(consented.rowCount).toBe(1);
+  });
+
+  test("export is owner/editor only — an evaluator is denied", async () => {
+    const t = convexTest(schema);
+    const { ids, asEval } = await seed(t);
+    await expect(
+      asEval.action(api.exports.generateExport, { projectId: ids.projectId, source: "output_preference", format: "sft" }),
+    ).rejects.toThrow(/Permission denied/);
+  });
+
+  test("download link expires after 1 hour", async () => {
+    const t = convexTest(schema);
+    const { ids, asOwner } = await seed(t);
+    const res = await asOwner.action(api.exports.generateExport, { projectId: ids.projectId, source: "output_preference", format: "dpo" });
+    // Fresh download works.
+    await expect(asOwner.action(api.exports.downloadExport, { exportId: res.exportId })).resolves.toBeTruthy();
+    // Age the row past the TTL.
+    await t.run(async (ctx) => {
+      await ctx.db.patch(res.exportId, { createdAt: Date.now() - 2 * 60 * 60 * 1000 });
+    });
+    await expect(asOwner.action(api.exports.downloadExport, { exportId: res.exportId })).rejects.toThrow(/expired/);
+  });
+});

--- a/convex/tests/trainingExport.test.ts
+++ b/convex/tests/trainingExport.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "vitest";
+import {
+  gateRows,
+  toJsonl,
+  type ClassifiedRow,
+  type ExportRow,
+} from "../lib/trainingExport";
+
+const dpo = (over: Partial<Record<string, string>> = {}): ExportRow => ({
+  kind: "dpo",
+  prompt: over.prompt ?? "resolve the ticket",
+  chosen: over.chosen ?? "escalated appropriately",
+  rejected: over.rejected ?? "ignored the request",
+  metadata: { evaluator_count: 2 },
+});
+
+describe("#53 training-export data-boundary gate", () => {
+  test("sensitive classes are excluded by default, admitted only with explicit consent", () => {
+    const rows: ClassifiedRow[] = [
+      { row: dpo(), privacyClass: "internal" },
+      { row: dpo(), privacyClass: "pii" },
+      { row: dpo(), privacyClass: "phi" },
+    ];
+    const denied = gateRows(rows);
+    expect(denied.included).toHaveLength(1);
+    expect(denied.excluded.map((e) => e.reason)).toEqual(["prod_sensitive", "prod_sensitive"]);
+
+    const consented = gateRows(rows, { allowSensitive: true });
+    expect(consented.included).toHaveLength(3);
+  });
+
+  test("pii-leak scan excludes rows whose text leaks email or api keys, even if class-allowed", () => {
+    const rows: ClassifiedRow[] = [
+      { row: dpo({ rejected: "contact me at agent@example.com" }), privacyClass: "public" },
+      { row: dpo({ chosen: "the key is sk-abcdef0123456789ABCDEF" }), privacyClass: "public" },
+      { row: dpo(), privacyClass: "public" },
+    ];
+    const { included, excluded } = gateRows(rows);
+    expect(included).toHaveLength(1);
+    expect(excluded.every((e) => e.reason === "pii_leak")).toBe(true);
+  });
+
+  test("empty rows are excluded with a reason, never silently dropped", () => {
+    const rows: ClassifiedRow[] = [
+      { row: dpo({ chosen: "   " }), privacyClass: "public" },
+    ];
+    const { included, excluded } = gateRows(rows);
+    expect(included).toHaveLength(0);
+    expect(excluded[0]?.reason).toBe("empty");
+  });
+});
+
+describe("#53 JSONL serializers produce valid, parseable output", () => {
+  test("dpo", () => {
+    const out = toJsonl("dpo", [dpo()]);
+    const parsed = JSON.parse(out);
+    expect(parsed).toMatchObject({ prompt: expect.any(String), chosen: expect.any(String), rejected: expect.any(String), metadata: expect.any(Object) });
+    expect(Object.keys(parsed).sort()).toEqual(["chosen", "metadata", "prompt", "rejected"]);
+  });
+
+  test("annotated", () => {
+    const row: ExportRow = {
+      kind: "annotated",
+      prompt: "p",
+      output: "o",
+      annotations: [{ from: 0, to: 3, text: "abc", comment: "off tone", tags: ["tone"] }],
+      preference: "weak",
+      metadata: {},
+    };
+    const parsed = JSON.parse(toJsonl("annotated", [row]));
+    expect(parsed.annotations[0]).toMatchObject({ from: 0, to: 3, comment: "off tone", tags: ["tone"] });
+    expect(parsed.preference).toBe("weak");
+  });
+
+  test("sft omits metadata when absent; multi-row is newline-delimited", () => {
+    const rows: ExportRow[] = [
+      { kind: "sft", messages: [{ role: "user", content: "hi" }, { role: "assistant", content: "hello" }] },
+      { kind: "sft", messages: [{ role: "user", content: "bye" }, { role: "assistant", content: "later" }], metadata: { preference: "best" } },
+    ];
+    const out = toJsonl("sft", rows);
+    const lines = out.split("\n");
+    expect(lines).toHaveLength(2);
+    expect(JSON.parse(lines[0]!)).not.toHaveProperty("metadata");
+    expect(JSON.parse(lines[1]!).metadata).toEqual({ preference: "best" });
+    // valid JSONL: every line parses
+    for (const l of lines) expect(() => JSON.parse(l)).not.toThrow();
+  });
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -50,6 +50,7 @@ const CycleCreator = lazy(() => import("./routes/orgs/projects/cycles/CycleCreat
 const CycleDetail = lazy(() => import("./routes/orgs/projects/cycles/CycleDetail").then(m => ({ default: m.CycleDetail })));
 const VersionDashboard = lazy(() => import("./routes/orgs/projects/cycles/VersionDashboard").then(m => ({ default: m.VersionDashboard })));
 const EvaluatePage = lazy(() => import("./routes/orgs/projects/EvaluatePage").then(m => ({ default: m.EvaluatePage })));
+const ExportTraining = lazy(() => import("./routes/orgs/projects/ExportTraining").then(m => ({ default: m.ExportTraining })));
 const TraceList = lazy(() => import("./routes/traces/TraceList").then(m => ({ default: m.TraceList })));
 const TraceViewer = lazy(() => import("./routes/traces/TraceViewer").then(m => ({ default: m.TraceViewer })));
 const TraceMatchup = lazy(() => import("./routes/traces/TraceMatchup").then(m => ({ default: m.TraceMatchup })));
@@ -122,6 +123,7 @@ export function App() {
                 element={<CycleDetail />}
               />
               <Route path="evaluate" element={<EvaluatePage />} />
+              <Route path="export" element={<ExportTraining />} />
               <Route path="traces" element={<TraceList />} />
               <Route
                 path="traces/:agentTraceId"

--- a/src/components/ProjectTabs.tsx
+++ b/src/components/ProjectTabs.tsx
@@ -8,6 +8,7 @@ const tabs = [
   { label: "Run", path: "run" },
   { label: "Test Cases", path: "test-cases" },
   { label: "Evaluate", path: "evaluate" },
+  { label: "Export", path: "export" },
   { label: "History", path: "history" },
 ];
 
@@ -30,7 +31,8 @@ export function ProjectTabs() {
             (tab.label === "Run" ||
               tab.label === "Editor" ||
               tab.label === "Test Cases" ||
-              tab.label === "Evaluate")
+              tab.label === "Evaluate" ||
+              tab.label === "Export")
           )
             return null;
 

--- a/src/routes/orgs/projects/ExportTraining.tsx
+++ b/src/routes/orgs/projects/ExportTraining.tsx
@@ -1,0 +1,382 @@
+import { useState } from "react";
+import { useAction, useQuery } from "convex/react";
+import type { FunctionReturnType } from "convex/server";
+import { api } from "../../../../convex/_generated/api";
+import type { Id } from "../../../../convex/_generated/dataModel";
+import { useProject } from "@/contexts/ProjectContext";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { friendlyError } from "@/lib/errors";
+import { cn } from "@/lib/utils";
+import { Database, ShieldAlert, Download } from "lucide-react";
+
+type ExportResult = FunctionReturnType<typeof api.exports.generateExport>;
+type ExportRow = FunctionReturnType<typeof api.exports.listExports>[number];
+
+type Source = "trajectory" | "output_preference";
+type Format = "dpo" | "sft";
+
+const SOURCE_LABELS: Record<Source, string> = {
+  trajectory: "Agent trajectories",
+  output_preference: "Prompt outputs",
+};
+const FORMAT_LABELS: Record<Format, string> = {
+  dpo: "DPO",
+  sft: "SFT",
+};
+
+function formatTimestamp(ms: number): string {
+  try {
+    return new Date(ms).toLocaleString(undefined, {
+      dateStyle: "medium",
+      timeStyle: "short",
+    });
+  } catch {
+    return "—";
+  }
+}
+
+export function ExportTraining() {
+  const { projectId } = useProject();
+  const generate = useAction(api.exports.generateExport);
+  const download = useAction(api.exports.downloadExport);
+  const exports = useQuery(api.exports.listExports, { projectId });
+
+  const [source, setSource] = useState<Source>("trajectory");
+  const [format, setFormat] = useState<Format>("dpo");
+  const [allowSensitive, setAllowSensitive] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState("");
+  const [result, setResult] = useState<
+    (ExportResult & { source: Source; format: Format }) | null
+  >(null);
+  const [downloadError, setDownloadError] = useState("");
+
+  async function handleGenerate(e: React.FormEvent) {
+    e.preventDefault();
+    setBusy(true);
+    setError("");
+    setResult(null);
+    setDownloadError("");
+    try {
+      const res = await generate({ projectId, source, format, allowSensitive });
+      setResult({ ...res, source, format });
+    } catch (err) {
+      setError(
+        friendlyError(err, "Export failed. Adjust the source or format and try again."),
+      );
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function openDownload(exportId: Id<"trainingExports">) {
+    try {
+      const { url } = await download({ exportId });
+      window.open(url, "_blank", "noopener,noreferrer");
+    } catch (err) {
+      throw new Error(
+        friendlyError(
+          err,
+          "Could not download this export. Generate a fresh one and try again.",
+        ),
+      );
+    }
+  }
+
+  return (
+    <div className="mx-auto max-w-3xl p-6">
+      <header>
+        <div className="flex items-center gap-2">
+          <Database aria-hidden="true" className="h-5 w-5 text-primary" />
+          <h1 className="text-2xl font-bold">Export training data</h1>
+        </div>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Turn blind evaluations into DPO / SFT fine-tuning datasets.
+        </p>
+      </header>
+
+      <Card className="mt-6 border-amber-500/40 bg-amber-500/5">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-base">
+            <ShieldAlert aria-hidden="true" className="h-4 w-4 text-amber-600 dark:text-amber-400" />
+            Data boundary
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2 text-sm text-muted-foreground">
+          <p>
+            Exports are{" "}
+            <strong className="text-foreground">anonymized by construction</strong> —
+            no org names, emails, or API keys. Rows carry only resolved prompts,
+            model outputs, blind labels, and aggregate counts.
+          </p>
+          <p>
+            Rows marked prod-sensitive (confidential / PII / PHI) are{" "}
+            <strong className="text-foreground">excluded</strong> unless you
+            explicitly consent below.
+          </p>
+        </CardContent>
+      </Card>
+
+      <form onSubmit={handleGenerate} className="mt-6 space-y-4">
+        <div className="space-y-1.5">
+          <Label htmlFor="ex-source">Source</Label>
+          {/* native select dodges the base-ui Select callback gotchas */}
+          <select
+            id="ex-source"
+            value={source}
+            onChange={(e) => setSource(e.target.value as Source)}
+            className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+          >
+            <option value="trajectory">
+              Agent trajectories (step-level preferences)
+            </option>
+            <option value="output_preference">
+              Prompt outputs (best/weak ratings)
+            </option>
+          </select>
+        </div>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="ex-format">Format</Label>
+          <select
+            id="ex-format"
+            value={format}
+            onChange={(e) => setFormat(e.target.value as Format)}
+            className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+          >
+            <option value="dpo">DPO (preference pairs)</option>
+            <option value="sft">SFT (best-only chat)</option>
+            <option value="annotated" disabled>
+              Annotated — coming soon
+            </option>
+          </select>
+        </div>
+
+        <div className="space-y-1.5">
+          <label className="flex items-start gap-2 text-sm">
+            <input
+              type="checkbox"
+              checked={allowSensitive}
+              onChange={(e) => setAllowSensitive(e.target.checked)}
+              className="mt-0.5 h-4 w-4 rounded border-input accent-primary"
+            />
+            <span>Include prod-sensitive rows (confidential/PII/PHI)</span>
+          </label>
+          {allowSensitive && (
+            <p className="pl-6 text-xs text-amber-600 dark:text-amber-400">
+              Only enable if you have consent to export sensitive data.
+            </p>
+          )}
+        </div>
+
+        {error && (
+          <p className="text-sm text-destructive" role="alert">
+            {error}
+          </p>
+        )}
+
+        <Button type="submit" disabled={busy}>
+          {busy ? "Generating…" : "Generate export"}
+        </Button>
+      </form>
+
+      {result && (
+        <ExportSummaryCard
+          result={result}
+          onDownload={openDownload}
+          downloadError={downloadError}
+          setDownloadError={setDownloadError}
+        />
+      )}
+
+      <section className="mt-8">
+        <h2 className="mb-3 text-sm font-medium uppercase tracking-wider text-muted-foreground">
+          Recent exports
+        </h2>
+        <RecentExports exports={exports} onDownload={openDownload} />
+      </section>
+    </div>
+  );
+}
+
+function ExportSummaryCard({
+  result,
+  onDownload,
+  downloadError,
+  setDownloadError,
+}: {
+  result: ExportResult & { source: Source; format: Format };
+  onDownload: (id: Id<"trainingExports">) => Promise<void>;
+  downloadError: string;
+  setDownloadError: (s: string) => void;
+}) {
+  const [busy, setBusy] = useState(false);
+
+  async function handleDownload() {
+    setBusy(true);
+    setDownloadError("");
+    try {
+      await onDownload(result.exportId);
+    } catch (err) {
+      setDownloadError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  if (result.rowCount === 0) {
+    return (
+      <Card className="mt-6 border-amber-500/40 bg-amber-500/5">
+        <CardHeader>
+          <CardTitle className="text-base">No exportable rows yet</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2 text-sm text-muted-foreground">
+          <p>
+            No exportable rows for this source/format yet — e.g. trajectory DPO
+            needs decided A/B matchups; output-preference DPO needs best+weak
+            ratings on the same run.
+          </p>
+          {result.excludedCount > 0 && (
+            <p>
+              {result.excludedCount} row{result.excludedCount === 1 ? "" : "s"} were
+              excluded by the data-boundary gate. Enable prod-sensitive rows above
+              if you have consent to include them.
+            </p>
+          )}
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="mt-6">
+      <CardHeader>
+        <CardTitle className="text-base">Export ready</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4 text-sm">
+        <dl className="grid grid-cols-2 gap-3">
+          <div>
+            <dt className="text-xs text-muted-foreground">Rows exported</dt>
+            <dd className="text-lg font-semibold tabular-nums">
+              {result.rowCount} row{result.rowCount === 1 ? "" : "s"} exported
+            </dd>
+          </div>
+          <div>
+            <dt className="text-xs text-muted-foreground">Excluded</dt>
+            <dd className="text-lg font-semibold tabular-nums">
+              {result.excludedCount} row{result.excludedCount === 1 ? "" : "s"}{" "}
+              excluded by the data-boundary gate
+            </dd>
+          </div>
+        </dl>
+
+        <p className="text-xs text-muted-foreground">
+          {SOURCE_LABELS[result.source]} · {FORMAT_LABELS[result.format]} · download
+          link expires 1 hour after generation.
+        </p>
+
+        {downloadError && (
+          <p className="text-sm text-destructive" role="alert">
+            {downloadError}
+          </p>
+        )}
+
+        <Button onClick={handleDownload} disabled={busy}>
+          <Download aria-hidden="true" className="h-4 w-4" />
+          {busy ? "Preparing…" : "Download JSONL"}
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}
+
+function RecentExports({
+  exports,
+  onDownload,
+}: {
+  exports: ExportRow[] | undefined;
+  onDownload: (id: Id<"trainingExports">) => Promise<void>;
+}) {
+  if (exports === undefined) {
+    return (
+      <div className="space-y-2" role="status" aria-label="Loading exports">
+        {[1, 2, 3].map((i) => (
+          <Skeleton key={i} className="h-12 w-full" />
+        ))}
+        <span className="sr-only">Loading exports…</span>
+      </div>
+    );
+  }
+
+  if (exports.length === 0) {
+    return <p className="text-sm text-muted-foreground">No exports yet.</p>;
+  }
+
+  return (
+    <div className="divide-y rounded-lg border">
+      {exports.map((row) => (
+        <RecentExportRow key={row._id} row={row} onDownload={onDownload} />
+      ))}
+    </div>
+  );
+}
+
+function RecentExportRow({
+  row,
+  onDownload,
+}: {
+  row: ExportRow;
+  onDownload: (id: Id<"trainingExports">) => Promise<void>;
+}) {
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState("");
+
+  async function handleDownload() {
+    setBusy(true);
+    setError("");
+    try {
+      await onDownload(row._id);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const sourceLabel = SOURCE_LABELS[row.source as Source] ?? row.source;
+  const formatLabel = FORMAT_LABELS[row.format as Format] ?? row.format.toUpperCase();
+
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-3 px-4 py-3">
+      <div className="min-w-0 space-y-0.5 text-sm">
+        <p className="font-medium">
+          {sourceLabel} · {formatLabel} ·{" "}
+          <span className="tabular-nums">
+            {row.rowCount} row{row.rowCount === 1 ? "" : "s"}
+          </span>
+        </p>
+        <p className="text-xs text-muted-foreground">
+          {formatTimestamp(row.createdAt)}
+        </p>
+        {error && (
+          <p className="text-xs text-destructive" role="alert">
+            {error}
+          </p>
+        )}
+      </div>
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={handleDownload}
+        disabled={row.expired || busy}
+        className={cn(row.expired && "text-muted-foreground")}
+      >
+        <Download aria-hidden="true" className="h-3.5 w-3.5" />
+        {row.expired ? "Expired" : busy ? "Preparing…" : "Download"}
+      </Button>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #53. Turns blind-evaluation exhaust into fine-tuning datasets — the "paid artifact" the M31 flywheel points at. One engine, two sources, feeding a data-boundary gate.

## Decided with Noah
Build **one engine feeding both sources** (not one or the other): trajectory step-level preferences (the honest DPO signal per the Agent Trace Strategy doc) *and* prompt-output preferences (real M30 pilot data, testable today).

## Backend (`convex/exports.ts`, `convex/lib/trainingExport.ts`)
`exports.generateExport(projectId, source, format, allowSensitive?)` — **owner/editor only** (privileged, un-blinded — never evaluators):
- **output_preference**: `promptRuns`(completed) → `runOutputs`/`outputPreferences` → best-vs-weak **DPO** pairs (capped/run) + best-only **SFT**. Prompt is resolved from the version messages (`{{var}}` substitution with `inputSnapshot`→`testCase`→inline precedence).
- **trajectory**: `agentTraceMatchups`(decided) → step-level **DPO** (winner's divergence step = `chosen`, loser's = `rejected`, shared prefix = `prompt`); `agentTraceVerdicts`(best) → **SFT**. Step bodies read from storage in the action.
- **Data-boundary gate** (mirrors the #228 lab contract): anonymized **by construction** (allowlisted fields — no org/email/keys/user ids), default-deny by privacy class (confidential/pii/phi excluded unless `allowSensitive`), an email/api-key leak backstop, and **every exclusion is reported, never dropped**.
- JSONL → storage → `trainingExports` row. `downloadExport` gates on `createdAt` for a **1-hour** window (Convex `getUrl` doesn't expire, so the gate is explicit). `annotated` throws a clear "coming soon".

## Frontend (`ExportTraining.tsx`, project **Export** tab)
Owner/editor surface: source + format selectors, default-off consent checkbox with an amber warning, data-boundary card, generate → rows-exported/excluded summary → Download JSONL, actionable empty state, recent-exports list with per-row expiry.

## Verification
`npm run test:convex` → **207 passed** (11 new: trajectory + output-pref DPO *content* correct, consent gate excludes pii unless consented, evaluator denied, 1-hour expiry, gate/serializer units) · `npm run build` clean.

## Honest scope notes
- **v1 formats = DPO + SFT** for both sources. **Annotated** (output-preference only, char-range annotations) is deferred — additive, same engine, shown disabled in the UI.
- The **trajectory source produces rows only once reviewers decide A/B matchups** (zero today); the **output-preference source works against real pilot data now**.
- "Expires after 1 hour" is enforced by re-checking `createdAt` on download, not a self-expiring URL (Convex has no expiring storage URL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)