### PR TITLE
M31.8 (#263): OTLP Gen-AI ingest endpoint — push-based continuous ingestion → trajectory spine

### DIFF
--- a/convex/agentTraces.ts
+++ b/convex/agentTraces.ts
@@ -22,6 +22,7 @@
 import { v } from "convex/values";
 import { paginationOptsValidator } from "convex/server";
 import { action, internalMutation, internalQuery, query } from "./_generated/server";
+import type { ActionCtx } from "./_generated/server";
 import { internal } from "./_generated/api";
 import type { Id } from "./_generated/dataModel";
 import { requireAuth, requireProjectRole, isBlindReviewer } from "./lib/auth";
@@ -142,6 +143,53 @@ export const insertTraceParent = internalMutation({
   },
 });
 
+/**
+ * Parent insert for the OTLP ingest path (#263). Same dedup + insert as
+ * insertTraceParent but token-authed upstream (the HTTP action verified the
+ * ingest token), so it takes `importedById` explicitly instead of resolving a
+ * signed-in user. Only reachable from the verified ingest action (internal).
+ */
+export const insertTraceParentForIngest = internalMutation({
+  args: {
+    projectId: v.id("projects"),
+    importedById: v.id("users"),
+    traceImportId: v.optional(v.id("traceImports")),
+    traceId: v.string(),
+    harnessName: v.string(),
+    harnessVersion: v.optional(v.string()),
+    harnessSdk: v.optional(v.string()),
+    product: v.string(),
+    module: v.optional(v.string()),
+    environment: v.optional(v.string()),
+    model: v.optional(v.string()),
+    runId: v.optional(v.string()),
+    stepCount: v.number(),
+    privacyClass: privacyClassValidator,
+    costUsd: v.optional(v.number()),
+    durationMs: v.optional(v.number()),
+    totalTokens: v.optional(v.number()),
+  },
+  handler: async (
+    ctx,
+    args,
+  ): Promise<{ agentTraceId: Id<"agentTraces">; deduped: boolean }> => {
+    const existing = await ctx.db
+      .query("agentTraces")
+      .withIndex("by_trace_id", (q) => q.eq("traceId", args.traceId))
+      .filter((q) => q.eq(q.field("projectId"), args.projectId))
+      .first();
+    if (existing) return { agentTraceId: existing._id, deduped: true };
+    const { importedById, ...rest } = args;
+    const agentTraceId = await ctx.db.insert("agentTraces", {
+      ...rest,
+      source: "agent_harness",
+      status: "pending",
+      importedById,
+    });
+    return { agentTraceId, deduped: false };
+  },
+});
+
 /** Insert a chunk of step rows for an already-created parent. */
 export const insertSteps = internalMutation({
   args: {
@@ -240,51 +288,60 @@ export const persistTrace = action({
     );
     // Idempotent: an already-imported trace keeps its stored steps untouched.
     if (deduped) return { agentTraceId, deduped: true, stepCount };
-
-    try {
-      // Store per-step body blobs, then insert rows carrying the storage ids.
-      const rows: Array<Record<string, unknown>> = [];
-      for (const step of trace.steps) {
-        const { row, fullBody, blindBody } = splitStep(step);
-        const fullBodyStorageId =
-          fullBody === undefined ? undefined : await storeJson(ctx, fullBody);
-        const blindBodyStorageId =
-          blindBody === undefined ? undefined : await storeJson(ctx, blindBody);
-        rows.push({ ...row, fullBodyStorageId, blindBodyStorageId });
-      }
-      for (let i = 0; i < rows.length; i += STEP_INSERT_CHUNK) {
-        await ctx.runMutation(internal.agentTraces.insertSteps, {
-          agentTraceId,
-          steps: rows.slice(i, i + STEP_INSERT_CHUNK) as never,
-        });
-      }
-
-      // Final answer → storage (full + precomputed blind), keeps parent bounded.
-      let finalAnswerStorageId: Id<"_storage"> | undefined;
-      let finalAnswerBlindStorageId: Id<"_storage"> | undefined;
-      if (trace.final_answer !== undefined) {
-        finalAnswerStorageId = await storeJson(ctx, { text: trace.final_answer });
-        finalAnswerBlindStorageId = await storeJson(ctx, {
-          text: redactValue(trace.final_answer, "blind_view"),
-        });
-      }
-
-      await ctx.runMutation(internal.agentTraces.finalizeTrace, {
-        agentTraceId,
-        finalAnswerStorageId,
-        finalAnswerBlindStorageId,
-      });
-      return { agentTraceId, deduped: false, stepCount };
-    } catch {
-      // Sanitized — never echo trace content.
-      await ctx.runMutation(internal.agentTraces.markTraceFailed, {
-        agentTraceId,
-        message: "Trace import failed while persisting steps.",
-      });
-      throw new Error("Trace import failed while persisting steps.");
-    }
+    await storeTraceSteps(ctx, agentTraceId, trace);
+    return { agentTraceId, deduped: false, stepCount };
   },
 });
+
+/**
+ * Store a trace's step bodies (full + precomputed blind) and step rows, plus the
+ * final answer, then flip the parent to "ready". Shared by persistTrace and the
+ * OTLP ingest path (#263) — the only difference between them is the parent-row
+ * insert (user-auth vs token-auth). On failure the parent is marked failed with
+ * a sanitized message.
+ */
+export async function storeTraceSteps(
+  ctx: ActionCtx,
+  agentTraceId: Id<"agentTraces">,
+  trace: AgentRunTrace,
+): Promise<void> {
+  try {
+    const rows: Array<Record<string, unknown>> = [];
+    for (const step of trace.steps) {
+      const { row, fullBody, blindBody } = splitStep(step);
+      const fullBodyStorageId =
+        fullBody === undefined ? undefined : await storeJson(ctx, fullBody);
+      const blindBodyStorageId =
+        blindBody === undefined ? undefined : await storeJson(ctx, blindBody);
+      rows.push({ ...row, fullBodyStorageId, blindBodyStorageId });
+    }
+    for (let i = 0; i < rows.length; i += STEP_INSERT_CHUNK) {
+      await ctx.runMutation(internal.agentTraces.insertSteps, {
+        agentTraceId,
+        steps: rows.slice(i, i + STEP_INSERT_CHUNK) as never,
+      });
+    }
+    let finalAnswerStorageId: Id<"_storage"> | undefined;
+    let finalAnswerBlindStorageId: Id<"_storage"> | undefined;
+    if (trace.final_answer !== undefined) {
+      finalAnswerStorageId = await storeJson(ctx, { text: trace.final_answer });
+      finalAnswerBlindStorageId = await storeJson(ctx, {
+        text: redactValue(trace.final_answer, "blind_view"),
+      });
+    }
+    await ctx.runMutation(internal.agentTraces.finalizeTrace, {
+      agentTraceId,
+      finalAnswerStorageId,
+      finalAnswerBlindStorageId,
+    });
+  } catch {
+    await ctx.runMutation(internal.agentTraces.markTraceFailed, {
+      agentTraceId,
+      message: "Trace import failed while persisting steps.",
+    });
+    throw new Error("Trace import failed while persisting steps.");
+  }
+}
 
 // --- reads (auth + blind projection at the boundary) ------------------------
 

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -3,6 +3,7 @@ import { httpAction } from "./_generated/server";
 import { internal } from "./_generated/api";
 import { auth } from "./auth";
 import { verifyWebhook } from "./lib/polarSignature";
+import { otlpIngestHandler } from "./otlpIngest";
 
 const http = httpRouter();
 
@@ -155,6 +156,27 @@ http.route({
   method: "OPTIONS",
   handler: httpAction(async () => {
     return new Response(null, { status: 204, headers: corsHeaders });
+  }),
+});
+
+// --- #263: OTLP Gen-AI trace ingest (per-project token auth) ---
+http.route({
+  path: "/otlp/v1/traces",
+  method: "POST",
+  handler: otlpIngestHandler,
+});
+http.route({
+  path: "/otlp/v1/traces",
+  method: "OPTIONS",
+  handler: httpAction(async () => {
+    return new Response(null, {
+      status: 204,
+      headers: {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Methods": "POST, OPTIONS",
+        "Access-Control-Allow-Headers": "Content-Type, Authorization, x-blindbench-ingest-token",
+      },
+    });
   }),
 });
 

--- a/convex/ingestTokens.ts
+++ b/convex/ingestTokens.ts
@@ -1,0 +1,64 @@
+/**
+ * #263: per-project ingest tokens for the OTLP push endpoint. Opaque 128-bit
+ * bearer tokens (generateToken), stored plaintext with a by_token index — the
+ * house pattern (invitations); a bearer token only needs comparison. The full
+ * token is returned ONCE at creation (the customer configures it in their
+ * gateway); the list surface only ever returns a masked prefix. Revoke by
+ * setting `revokedAt`. Owner/editor only.
+ */
+import { v } from "convex/values";
+import { mutation, query } from "./_generated/server";
+import type { Id } from "./_generated/dataModel";
+import { requireProjectRole } from "./lib/auth";
+import { generateToken } from "./lib/crypto";
+
+export const issueIngestToken = mutation({
+  args: { projectId: v.id("projects"), label: v.string() },
+  handler: async (
+    ctx,
+    args,
+  ): Promise<{ tokenId: Id<"ingestTokens">; token: string }> => {
+    const { userId } = await requireProjectRole(ctx, args.projectId, ["owner", "editor"]);
+    const label = args.label.trim() || "Ingest token";
+    const token = generateToken();
+    const tokenId = await ctx.db.insert("ingestTokens", {
+      projectId: args.projectId,
+      token,
+      label,
+      createdById: userId,
+    });
+    // Full token returned ONCE — never surfaced again.
+    return { tokenId, token };
+  },
+});
+
+export const revokeIngestToken = mutation({
+  args: { tokenId: v.id("ingestTokens") },
+  handler: async (ctx, args) => {
+    const row = await ctx.db.get(args.tokenId);
+    if (!row) return;
+    await requireProjectRole(ctx, row.projectId, ["owner", "editor"]);
+    if (!row.revokedAt) await ctx.db.patch(args.tokenId, { revokedAt: Date.now() });
+  },
+});
+
+export const listIngestTokens = query({
+  args: { projectId: v.id("projects") },
+  handler: async (ctx, args) => {
+    await requireProjectRole(ctx, args.projectId, ["owner", "editor"]);
+    const rows = await ctx.db
+      .query("ingestTokens")
+      .withIndex("by_project", (q) => q.eq("projectId", args.projectId))
+      .order("desc")
+      .collect();
+    return rows.map((r) => ({
+      _id: r._id,
+      label: r.label,
+      // Masked — the full token is only ever shown at creation.
+      preview: `${r.token.slice(0, 6)}…${r.token.slice(-4)}`,
+      createdAt: r._creationTime,
+      lastUsedAt: r.lastUsedAt,
+      revoked: r.revokedAt !== undefined,
+    }));
+  },
+});

--- a/convex/lib/otelGenAI.ts
+++ b/convex/lib/otelGenAI.ts
@@ -1,0 +1,256 @@
+/**
+ * #263: map OTLP/HTTP Gen-AI spans → the `AgentRunTrace` interchange type, one
+ * trace per OTel `traceId` (spans grouped and time-ordered → steps). Feeds
+ * persistTrace → the M31 spine (trajectory review / blind / DPO export).
+ *
+ * Pure + defensive (no Convex ctx, no zod): OTLP JSON is partial/varied across
+ * exporters. Reads the attribute shapes emitted by Cloudflare AI Gateway and the
+ * OTel Gen-AI semantic conventions:
+ *   - gen_ai.request.model / gen_ai.response.model, gen_ai.system|provider
+ *   - gen_ai.usage.input_tokens / output_tokens / cost
+ *   - gen_ai.prompt_json / gen_ai.completion_json  (CF: JSON string of messages)
+ *   - gen_ai.prompt.{n}.role / .content            (OTel indexed)
+ *   - gen_ai.prompt / gen_ai.completion            (plain string)
+ * Bodies are optional: a span with no prompt/completion still produces a trace
+ * (requestMissing/responseMissing counted), mirroring the gateway importer.
+ */
+import type { AgentRunTrace, AgentTraceStep, Message } from "./agentTrace";
+import { redactValue } from "./agentTrace";
+
+export interface OtelIngestSummary {
+  traces: number;
+  spans: number;
+  steps: number;
+  requestMissing: number;
+  responseMissing: number;
+  models: string[];
+  invalid: boolean;
+}
+
+export interface OtelMapResult {
+  traces: AgentRunTrace[];
+  summary: OtelIngestSummary;
+}
+
+const rec = (v: unknown): Record<string, unknown> | undefined =>
+  v && typeof v === "object" && !Array.isArray(v) ? (v as Record<string, unknown>) : undefined;
+const arr = (v: unknown): unknown[] => (Array.isArray(v) ? v : []);
+const str = (v: unknown): string | undefined => (typeof v === "string" && v.length ? v : undefined);
+const num = (v: unknown): number | undefined => {
+  if (typeof v === "number" && Number.isFinite(v)) return v;
+  if (typeof v === "string" && v.trim() !== "" && Number.isFinite(Number(v))) return Number(v);
+  return undefined;
+};
+
+/** Unwrap an OTLP AnyValue ({stringValue|intValue|doubleValue|boolValue|...}). */
+function anyValue(v: unknown): unknown {
+  const o = rec(v);
+  if (!o) return v;
+  if ("stringValue" in o) return o.stringValue;
+  if ("intValue" in o) return num(o.intValue);
+  if ("doubleValue" in o) return o.doubleValue;
+  if ("boolValue" in o) return o.boolValue;
+  if ("arrayValue" in o) return arr(rec(o.arrayValue)?.values).map(anyValue);
+  if ("kvlistValue" in o) return flattenAttrs(rec(o.kvlistValue)?.values);
+  return undefined;
+}
+
+/** OTLP attributes ([{key,value}]) → flat record with unwrapped values. */
+function flattenAttrs(attributes: unknown): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const a of arr(attributes)) {
+    const kv = rec(a);
+    const key = str(kv?.key);
+    if (key) out[key] = anyValue(kv?.value);
+  }
+  return out;
+}
+
+const toMessage = (m: unknown): Message | undefined => {
+  const o = rec(m);
+  if (!o) return undefined;
+  const content = o.content;
+  const contentStr =
+    typeof content === "string" ? content : content == null ? "" : JSON.stringify(content);
+  return { role: str(o.role) ?? "user", content: contentStr };
+};
+
+/** Parse the prompt side of a span into ordered messages. */
+function extractPrompt(attrs: Record<string, unknown>): Message[] {
+  const pj = str(attrs["gen_ai.prompt_json"]) ?? str(attrs["gen_ai.prompt.json"]);
+  if (pj) {
+    try {
+      const parsed = JSON.parse(pj);
+      const list = Array.isArray(parsed) ? parsed : rec(parsed)?.messages;
+      const msgs = arr(list).map(toMessage).filter((m): m is Message => !!m);
+      if (msgs.length) return msgs;
+    } catch {
+      /* fall through */
+    }
+  }
+  const indexed: Message[] = [];
+  for (let i = 0; i < 128; i++) {
+    const role = attrs[`gen_ai.prompt.${i}.role`];
+    const content = attrs[`gen_ai.prompt.${i}.content`];
+    if (role === undefined && content === undefined) break;
+    indexed.push({ role: str(role) ?? "user", content: str(content) ?? "" });
+  }
+  if (indexed.length) return indexed;
+  const plain = str(attrs["gen_ai.prompt"]);
+  return plain ? [{ role: "user", content: plain }] : [];
+}
+
+/** Parse the completion side → an assistant message + any tool calls. */
+function extractCompletion(attrs: Record<string, unknown>): {
+  message?: Message;
+  toolCalls: Array<{ id: string; name: string; args: Record<string, unknown> }>;
+} {
+  const toolCalls: Array<{ id: string; name: string; args: Record<string, unknown> }> = [];
+  const cj = str(attrs["gen_ai.completion_json"]) ?? str(attrs["gen_ai.completion.json"]);
+  if (cj) {
+    try {
+      const parsed = JSON.parse(cj);
+      const first = Array.isArray(parsed) ? rec(parsed[0]) : rec(parsed);
+      const msgObj = first?.message ? rec(first.message) : first;
+      for (const tc of arr(msgObj?.tool_calls)) {
+        const t = rec(tc);
+        const fn = rec(t?.function);
+        let parsedArgs: Record<string, unknown> = {};
+        try {
+          parsedArgs = rec(JSON.parse(str(fn?.arguments) ?? "{}")) ?? {};
+        } catch {
+          parsedArgs = { raw: str(fn?.arguments) };
+        }
+        toolCalls.push({
+          id: str(t?.id) ?? `tool-${toolCalls.length}`,
+          name: str(fn?.name) ?? "unknown_tool",
+          args: parsedArgs,
+        });
+      }
+      const content = msgObj?.content;
+      if (content != null && content !== "") {
+        return {
+          message: { role: str(msgObj?.role) ?? "assistant", content: typeof content === "string" ? content : JSON.stringify(content) },
+          toolCalls,
+        };
+      }
+      if (toolCalls.length) return { toolCalls };
+    } catch {
+      /* fall through */
+    }
+  }
+  const plain = str(attrs["gen_ai.completion"]);
+  return plain ? { message: { role: "assistant", content: plain }, toolCalls: [] } : { toolCalls: [] };
+}
+
+const spanTime = (span: Record<string, unknown>): number =>
+  num(span.startTimeUnixNano) ?? num(span.start_time_unix_nano) ?? 0;
+
+export function mapOtlpToTraces(payload: unknown): OtelMapResult {
+  const root = rec(payload);
+  const resourceSpans = arr(root?.resourceSpans);
+  const summary: OtelIngestSummary = {
+    traces: 0,
+    spans: 0,
+    steps: 0,
+    requestMissing: 0,
+    responseMissing: 0,
+    models: [],
+    invalid: resourceSpans.length === 0,
+  };
+
+  // Group spans by traceId.
+  const byTrace = new Map<string, Array<Record<string, unknown>>>();
+  for (const rs of resourceSpans) {
+    for (const ss of arr(rec(rs)?.scopeSpans)) {
+      for (const s of arr(rec(ss)?.spans)) {
+        const span = rec(s);
+        if (!span) continue;
+        summary.spans++;
+        const traceId = str(span.traceId) ?? str(span.trace_id) ?? `otlp-${summary.spans}`;
+        (byTrace.get(traceId) ?? byTrace.set(traceId, []).get(traceId)!).push(span);
+      }
+    }
+  }
+
+  const models = new Set<string>();
+  const traces: AgentRunTrace[] = [];
+
+  for (const [traceId, spans] of byTrace) {
+    spans.sort((a, b) => spanTime(a) - spanTime(b));
+    const steps: AgentTraceStep[] = [];
+    let harness = "otel";
+    let model: string | undefined;
+    let inTok = 0;
+    let outTok = 0;
+    let cost = 0;
+    let sawRequest = false;
+    let sawResponse = false;
+
+    for (const span of spans) {
+      const attrs = flattenAttrs(span.attributes);
+      const m = str(attrs["gen_ai.request.model"]) ?? str(attrs["gen_ai.response.model"]);
+      if (m) {
+        model ??= m;
+        models.add(m);
+      }
+      const sys = str(attrs["gen_ai.system"]) ?? str(attrs["gen_ai.provider"]) ?? str(attrs["gen_ai.model.provider"]);
+      if (sys) harness = sys;
+      inTok += num(attrs["gen_ai.usage.input_tokens"]) ?? 0;
+      outTok += num(attrs["gen_ai.usage.output_tokens"]) ?? 0;
+      cost += num(attrs["gen_ai.usage.cost"]) ?? 0;
+      const ts = str(span.startTimeUnixNano);
+
+      const prompt = extractPrompt(attrs);
+      if (prompt.length) sawRequest = true;
+      else summary.requestMissing++;
+      for (const msg of prompt) {
+        steps.push({ type: "message", index: steps.length, timestamp: ts, message: msg });
+      }
+
+      const { message, toolCalls } = extractCompletion(attrs);
+      if (message || toolCalls.length) sawResponse = true;
+      else summary.responseMissing++;
+      if (message) {
+        steps.push({ type: "message", index: steps.length, timestamp: ts, message });
+      }
+      for (const tc of toolCalls) {
+        steps.push({
+          type: "tool_call",
+          index: steps.length,
+          timestamp: ts,
+          tool_call_id: tc.id,
+          name: tc.name,
+          args: tc.args,
+          redacted_args: (redactValue(tc.args, "blind_view") as Record<string, unknown>) ?? {},
+          privacy_class: JSON.stringify(redactValue(tc.args, "blind_view")).includes("[REDACTED]") ? "pii" : "internal",
+        });
+      }
+    }
+
+    summary.steps += steps.length;
+    summary.traces++;
+    const anyRedacted = steps.some((s) => JSON.stringify(s).includes("[REDACTED]"));
+    traces.push({
+      trace_id: `otlp-${traceId}`,
+      source: "agent_harness",
+      harness: { name: harness, sdk: "otlp" },
+      product: harness,
+      module: "otlp_ingest",
+      model,
+      run_id: traceId,
+      source_ids: { otel_trace_id: traceId },
+      messages: [],
+      steps,
+      usage: { total_tokens: inTok + outTok || undefined, cost_usd: cost || undefined },
+      privacy: {
+        class: anyRedacted ? "pii" : "internal",
+        redaction_notes: anyRedacted ? ["sensitive tool fields redacted for blind/reviewer views"] : [],
+      },
+      metadata: { otel_trace_id: traceId, request_missing: !sawRequest, response_missing: !sawResponse },
+    });
+  }
+
+  summary.models = [...models];
+  return { traces, summary };
+}

--- a/convex/otlpIngest.ts
+++ b/convex/otlpIngest.ts
@@ -1,0 +1,164 @@
+/**
+ * #263: OTLP/HTTP Gen-AI trace ingest. A public endpoint (mounted in http.ts)
+ * authenticated by a per-project ingest token we issue — Blind Bench never holds
+ * the customer's gateway credential; the customer configures our URL + token in
+ * their gateway (BYOK). Spans are grouped by trace_id into AgentRunTraces
+ * (lib/otelGenAI) and persisted through the M31 spine via the shared, token-authed
+ * storeTraceSteps path. Body-optional, dedup by (source "otlp", sourceTraceId),
+ * counts-only response (never echoes trace content).
+ */
+import { v } from "convex/values";
+import { httpAction, internalMutation, internalQuery } from "./_generated/server";
+import { internal } from "./_generated/api";
+import type { Id } from "./_generated/dataModel";
+import { mapOtlpToTraces } from "./lib/otelGenAI";
+import { storeTraceSteps } from "./agentTraces";
+import type { AgentRunTrace } from "./lib/agentTrace";
+
+const MAX_BYTES = 8 * 1024 * 1024;
+
+const json = (body: unknown, status: number): Response =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+
+const readToken = (req: Request): string | undefined => {
+  const auth = req.headers.get("authorization");
+  if (auth?.toLowerCase().startsWith("bearer ")) return auth.slice(7).trim();
+  return req.headers.get("x-blindbench-ingest-token")?.trim() || undefined;
+};
+
+export const resolveIngestToken = internalQuery({
+  args: { token: v.string() },
+  handler: async (
+    ctx,
+    args,
+  ): Promise<{ projectId: Id<"projects">; createdById: Id<"users"> } | null> => {
+    const row = await ctx.db
+      .query("ingestTokens")
+      .withIndex("by_token", (q) => q.eq("token", args.token))
+      .unique();
+    if (!row || row.revokedAt !== undefined) return null;
+    return { projectId: row.projectId, createdById: row.createdById };
+  },
+});
+
+export const touchIngestToken = internalMutation({
+  args: { token: v.string() },
+  handler: async (ctx, args) => {
+    const row = await ctx.db
+      .query("ingestTokens")
+      .withIndex("by_token", (q) => q.eq("token", args.token))
+      .unique();
+    if (row) await ctx.db.patch(row._id, { lastUsedAt: Date.now() });
+  },
+});
+
+/** Dedup + insert an otlp traceImport for provenance/raw retention. */
+export const insertOtlpImport = internalMutation({
+  args: {
+    projectId: v.id("projects"),
+    importedById: v.id("users"),
+    sourceTraceId: v.string(),
+    rawPayloadStorageId: v.optional(v.id("_storage")),
+  },
+  handler: async (
+    ctx,
+    args,
+  ): Promise<{ importId: Id<"traceImports">; deduped: boolean }> => {
+    const existing = await ctx.db
+      .query("traceImports")
+      .withIndex("by_source_trace", (q) =>
+        q.eq("source", "otlp").eq("sourceTraceId", args.sourceTraceId),
+      )
+      .filter((q) => q.eq(q.field("projectId"), args.projectId))
+      .first();
+    if (existing) return { importId: existing._id, deduped: true };
+    const importId = await ctx.db.insert("traceImports", {
+      projectId: args.projectId,
+      source: "otlp",
+      sourceTraceId: args.sourceTraceId,
+      importedById: args.importedById,
+      rawPayloadStorageId: args.rawPayloadStorageId,
+    });
+    return { importId, deduped: false };
+  },
+});
+
+export const otlpIngestHandler = httpAction(async (ctx, req) => {
+  const token = readToken(req);
+  if (!token) return json({ error: "Missing ingest token" }, 401);
+  const resolved = await ctx.runQuery(internal.otlpIngest.resolveIngestToken, { token });
+  if (!resolved) return json({ error: "Invalid or revoked ingest token" }, 401);
+
+  const body = await req.text();
+  if (body.length > MAX_BYTES) return json({ error: "Payload too large" }, 413);
+  let payload: unknown;
+  try {
+    payload = JSON.parse(body);
+  } catch {
+    return json({ error: "Invalid JSON" }, 400);
+  }
+
+  const { traces, summary } = mapOtlpToTraces(payload);
+
+  // Persist the raw request once for provenance / re-parse; link to new imports.
+  let rawStorageId: Id<"_storage"> | undefined;
+  try {
+    rawStorageId = await ctx.storage.store(new Blob([body], { type: "application/json" }));
+  } catch {
+    rawStorageId = undefined;
+  }
+
+  let imported = 0;
+  let deduped = 0;
+  for (const trace of traces as AgentRunTrace[]) {
+    const sourceTraceId = trace.run_id ?? trace.trace_id;
+    const imp = await ctx.runMutation(internal.otlpIngest.insertOtlpImport, {
+      projectId: resolved.projectId,
+      importedById: resolved.createdById,
+      sourceTraceId,
+      rawPayloadStorageId: rawStorageId,
+    });
+    if (imp.deduped) {
+      deduped++;
+      continue;
+    }
+    const parent = await ctx.runMutation(internal.agentTraces.insertTraceParentForIngest, {
+      projectId: resolved.projectId,
+      importedById: resolved.createdById,
+      traceImportId: imp.importId,
+      traceId: trace.trace_id,
+      harnessName: trace.harness.name,
+      harnessSdk: trace.harness.sdk,
+      product: trace.product,
+      module: trace.module,
+      model: trace.model,
+      runId: trace.run_id,
+      stepCount: trace.steps.length,
+      privacyClass: trace.privacy.class,
+      costUsd: trace.usage.cost_usd,
+      totalTokens: trace.usage.total_tokens,
+    });
+    if (parent.deduped) {
+      deduped++;
+      continue;
+    }
+    await storeTraceSteps(ctx, parent.agentTraceId, trace);
+    imported++;
+  }
+
+  await ctx.runMutation(internal.otlpIngest.touchIngestToken, { token });
+  return json(
+    {
+      traces: summary.traces,
+      imported,
+      deduped,
+      steps: summary.steps,
+      requestMissing: summary.requestMissing,
+      responseMissing: summary.responseMissing,
+    },
+    200,
+  );
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -638,6 +638,8 @@ const schema = defineSchema({
       v.literal("cloudflare_ai_gateway"),
       // #265: Claude Code session .jsonl upload — first trajectory ingestion.
       v.literal("claude_code"),
+      // #263: OTLP Gen-AI span push (Cloudflare AI Gateway + any OTel source).
+      v.literal("otlp"),
     ),
     // Provider's stable trace identifier when available — manual_paste imports
     // don't have one. Combined with `source` it forms the dedup key.
@@ -909,6 +911,23 @@ const schema = defineSchema({
     createdById: v.id("users"),
     createdAt: v.number(),
   }).index("by_project", ["projectId"]),
+
+  // #263: per-project ingest tokens for the OTLP push endpoint. Opaque 128-bit
+  // bearer token (generateToken), stored plaintext with a by_token index — the
+  // house pattern (invitations); it only needs comparison, not decryption. The
+  // customer configures it in their gateway/exporter (BYOK — Blind Bench never
+  // holds the customer's Cloudflare/provider credential). Revoke by setting
+  // `revokedAt`; the list surface never returns the full token after creation.
+  ingestTokens: defineTable({
+    projectId: v.id("projects"),
+    token: v.string(),
+    label: v.string(),
+    createdById: v.id("users"),
+    lastUsedAt: v.optional(v.number()),
+    revokedAt: v.optional(v.number()),
+  })
+    .index("by_token", ["token"])
+    .index("by_project", ["projectId"]),
 
   // #259: per-org scorecard runs. Grades every org eval case that has a
   // captured production output against its assigned deterministic scorers.

--- a/convex/tests/otlpIngest.test.ts
+++ b/convex/tests/otlpIngest.test.ts
@@ -1,0 +1,147 @@
+/// <reference types="vite/client" />
+import { convexTest } from "convex-test";
+import { describe, expect, test } from "vitest";
+import { api } from "../_generated/api";
+import schema from "../schema";
+import { mapOtlpToTraces } from "../lib/otelGenAI";
+
+const attr = (key: string, value: Record<string, unknown>) => ({ key, value });
+const span = (traceId: string, spanId: string, t: string, attrs: Array<{ key: string; value: Record<string, unknown> }>) => ({
+  traceId, spanId, startTimeUnixNano: t, attributes: attrs,
+});
+
+// Two gen_ai spans under one trace_id → one trajectory of 4 message steps.
+const otlpPayload = {
+  resourceSpans: [
+    {
+      scopeSpans: [
+        {
+          spans: [
+            span("trace-abc", "s1", "1000", [
+              attr("gen_ai.request.model", { stringValue: "gpt-4" }),
+              attr("gen_ai.system", { stringValue: "openai" }),
+              attr("gen_ai.usage.input_tokens", { intValue: "10" }),
+              attr("gen_ai.usage.output_tokens", { intValue: "5" }),
+              attr("gen_ai.prompt_json", { stringValue: JSON.stringify([{ role: "user", content: "What is 2+2?" }]) }),
+              attr("gen_ai.completion_json", { stringValue: JSON.stringify({ role: "assistant", content: "4" }) }),
+            ]),
+            span("trace-abc", "s2", "2000", [
+              attr("gen_ai.request.model", { stringValue: "gpt-4" }),
+              attr("gen_ai.prompt", { stringValue: "and 3+3?" }),
+              attr("gen_ai.completion", { stringValue: "6" }),
+            ]),
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+async function seed(t: ReturnType<typeof convexTest>) {
+  const ids = await t.run(async (ctx) => {
+    const ownerUserId = await ctx.db.insert("users", { name: "Owner", email: "o@test.com" });
+    const orgId = await ctx.db.insert("organizations", { name: "Org", slug: "org", createdById: ownerUserId });
+    await ctx.db.insert("organizationMembers", { organizationId: orgId, userId: ownerUserId, role: "owner" });
+    const projectId = await ctx.db.insert("projects", { organizationId: orgId, name: "P", createdById: ownerUserId });
+    await ctx.db.insert("projectCollaborators", { projectId, userId: ownerUserId, role: "owner", invitedById: ownerUserId, invitedAt: Date.now() });
+    return { ownerUserId, projectId };
+  });
+  return { ids, asOwner: t.withIdentity({ subject: `${ids.ownerUserId}|s`, tokenIdentifier: `test|${ids.ownerUserId}` }) };
+}
+
+describe("#263 OTLP → AgentRunTrace mapper (pure)", () => {
+  test("groups spans by trace_id into one trajectory; reads gen_ai attributes", () => {
+    const { traces, summary } = mapOtlpToTraces(otlpPayload);
+    expect(summary.traces).toBe(1);
+    expect(summary.spans).toBe(2);
+    const trace = traces[0]!;
+    expect(trace.trace_id).toBe("otlp-trace-abc");
+    expect(trace.model).toBe("gpt-4");
+    expect(trace.harness.name).toBe("openai");
+    expect(trace.usage.total_tokens).toBe(15);
+    // span1: user + assistant; span2: user + assistant → 4 message steps
+    expect(trace.steps.map((s) => s.type)).toEqual(["message", "message", "message", "message"]);
+    const contents = trace.steps.flatMap((s) => (s.type === "message" ? [s.message.content] : []));
+    expect(contents).toEqual(["What is 2+2?", "4", "and 3+3?", "6"]);
+  });
+
+  test("body-optional: a span with no prompt/completion still yields a trace, counted", () => {
+    const bare = { resourceSpans: [{ scopeSpans: [{ spans: [span("t2", "s1", "1", [attr("gen_ai.request.model", { stringValue: "m" })])] }] }] };
+    const { traces, summary } = mapOtlpToTraces(bare);
+    expect(traces).toHaveLength(1);
+    expect(summary.requestMissing).toBe(1);
+    expect(summary.responseMissing).toBe(1);
+  });
+});
+
+describe("#263 ingest tokens", () => {
+  test("issue returns the full token once; list masks it; revoke disables it", async () => {
+    const t = convexTest(schema);
+    const { ids, asOwner } = await seed(t);
+    const { token } = await asOwner.mutation(api.ingestTokens.issueIngestToken, { projectId: ids.projectId, label: "CF gateway" });
+    expect(token).toMatch(/^[0-9a-f]{32}$/);
+
+    const list = await asOwner.query(api.ingestTokens.listIngestTokens, { projectId: ids.projectId });
+    expect(list).toHaveLength(1);
+    expect(list[0]?.label).toBe("CF gateway");
+    expect(list[0]?.preview).not.toBe(token); // masked
+    expect(JSON.stringify(list)).not.toContain(token);
+
+    await asOwner.mutation(api.ingestTokens.revokeIngestToken, { tokenId: list[0]!._id });
+    expect((await asOwner.query(api.ingestTokens.listIngestTokens, { projectId: ids.projectId }))[0]?.revoked).toBe(true);
+  });
+});
+
+describe("#263 OTLP HTTP ingest end-to-end", () => {
+  test("token-authed POST persists a trajectory through the spine; re-POST dedups", async () => {
+    const t = convexTest(schema);
+    const { ids, asOwner } = await seed(t);
+    const { token } = await asOwner.mutation(api.ingestTokens.issueIngestToken, { projectId: ids.projectId, label: "t" });
+
+    const post = () =>
+      t.fetch("/otlp/v1/traces", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+        body: JSON.stringify(otlpPayload),
+      });
+
+    const res = await post();
+    expect(res.status).toBe(200);
+    const summary = await res.json();
+    expect(summary.imported).toBe(1);
+    expect(summary.steps).toBe(4);
+
+    // Persisted as an agentTrace with steps, source otlp import linked.
+    const persisted = await t.run(async (ctx) => {
+      const trace = await ctx.db.query("agentTraces").first();
+      const steps = trace
+        ? await ctx.db.query("agentTraceSteps").withIndex("by_trace_and_index", (q) => q.eq("agentTraceId", trace._id)).collect()
+        : [];
+      const imp = trace?.traceImportId ? await ctx.db.get(trace.traceImportId) : null;
+      return { status: trace?.status, stepCount: steps.length, source: imp?.source };
+    });
+    expect(persisted.status).toBe("ready");
+    expect(persisted.stepCount).toBe(4);
+    expect(persisted.source).toBe("otlp");
+
+    // Idempotent re-POST.
+    const again = await (await post()).json();
+    expect(again.imported).toBe(0);
+    expect(again.deduped).toBe(1);
+    const traceCount = await t.run(async (ctx) => (await ctx.db.query("agentTraces").collect()).length);
+    expect(traceCount).toBe(1);
+  });
+
+  test("missing or invalid token is rejected 401", async () => {
+    const t = convexTest(schema);
+    await seed(t);
+    const noToken = await t.fetch("/otlp/v1/traces", { method: "POST", body: "{}" });
+    expect(noToken.status).toBe(401);
+    const badToken = await t.fetch("/otlp/v1/traces", {
+      method: "POST",
+      headers: { Authorization: "Bearer deadbeef" },
+      body: "{}",
+    });
+    expect(badToken.status).toBe(401);
+  });
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -51,6 +51,7 @@ const CycleDetail = lazy(() => import("./routes/orgs/projects/cycles/CycleDetail
 const VersionDashboard = lazy(() => import("./routes/orgs/projects/cycles/VersionDashboard").then(m => ({ default: m.VersionDashboard })));
 const EvaluatePage = lazy(() => import("./routes/orgs/projects/EvaluatePage").then(m => ({ default: m.EvaluatePage })));
 const ExportTraining = lazy(() => import("./routes/orgs/projects/ExportTraining").then(m => ({ default: m.ExportTraining })));
+const IngestEndpoint = lazy(() => import("./routes/orgs/projects/IngestEndpoint").then(m => ({ default: m.IngestEndpoint })));
 const TraceList = lazy(() => import("./routes/traces/TraceList").then(m => ({ default: m.TraceList })));
 const TraceViewer = lazy(() => import("./routes/traces/TraceViewer").then(m => ({ default: m.TraceViewer })));
 const TraceMatchup = lazy(() => import("./routes/traces/TraceMatchup").then(m => ({ default: m.TraceMatchup })));
@@ -124,6 +125,7 @@ export function App() {
               />
               <Route path="evaluate" element={<EvaluatePage />} />
               <Route path="export" element={<ExportTraining />} />
+              <Route path="ingest" element={<IngestEndpoint />} />
               <Route path="traces" element={<TraceList />} />
               <Route
                 path="traces/:agentTraceId"

--- a/src/components/ProjectTabs.tsx
+++ b/src/components/ProjectTabs.tsx
@@ -9,6 +9,7 @@ const tabs = [
   { label: "Test Cases", path: "test-cases" },
   { label: "Evaluate", path: "evaluate" },
   { label: "Export", path: "export" },
+  { label: "Ingest", path: "ingest" },
   { label: "History", path: "history" },
 ];
 
@@ -32,7 +33,8 @@ export function ProjectTabs() {
               tab.label === "Editor" ||
               tab.label === "Test Cases" ||
               tab.label === "Evaluate" ||
-              tab.label === "Export")
+              tab.label === "Export" ||
+              tab.label === "Ingest")
           )
             return null;
 

--- a/src/routes/orgs/projects/IngestEndpoint.tsx
+++ b/src/routes/orgs/projects/IngestEndpoint.tsx
@@ -1,0 +1,369 @@
+import { useState } from "react";
+import { useMutation, useQuery } from "convex/react";
+import type { FunctionReturnType } from "convex/server";
+import { api } from "../../../../convex/_generated/api";
+import { useProject } from "@/contexts/ProjectContext";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { CopyButton } from "@/components/ui/copy-button";
+import { friendlyError } from "@/lib/errors";
+import { cn } from "@/lib/utils";
+import { Radio, ShieldAlert, KeyRound, Settings2 } from "lucide-react";
+
+type IngestToken = FunctionReturnType<
+  typeof api.ingestTokens.listIngestTokens
+>[number];
+
+type IssueResult = FunctionReturnType<typeof api.ingestTokens.issueIngestToken>;
+
+/** {CONVEX_SITE_URL}/otlp/v1/traces — httpActions serve on .convex.site, not .cloud. */
+function deriveIngestUrl(): string {
+  const raw = (import.meta.env.VITE_CONVEX_URL ?? "").trim();
+  const siteUrl = raw.replace(".convex.cloud", ".convex.site");
+  return siteUrl
+    ? `${siteUrl}/otlp/v1/traces`
+    : "https://<your-deployment>.convex.site/otlp/v1/traces";
+}
+
+function formatTimestamp(ms: number): string {
+  try {
+    return new Date(ms).toLocaleString(undefined, {
+      dateStyle: "medium",
+      timeStyle: "short",
+    });
+  } catch {
+    return "—";
+  }
+}
+
+export function IngestEndpoint() {
+  const { projectId } = useProject();
+  const tokens = useQuery(api.ingestTokens.listIngestTokens, { projectId });
+  const issueToken = useMutation(api.ingestTokens.issueIngestToken);
+
+  const ingestUrl = deriveIngestUrl();
+
+  const [label, setLabel] = useState("Gateway token");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState("");
+  const [issued, setIssued] = useState<IssueResult | null>(null);
+
+  async function handleIssue(e: React.FormEvent) {
+    e.preventDefault();
+    setBusy(true);
+    setError("");
+    // A prior full-token card is stale once a new token is issued — clear it.
+    setIssued(null);
+    try {
+      const res = await issueToken({ projectId, label: label.trim() });
+      setIssued(res);
+    } catch (err) {
+      setError(
+        friendlyError(err, "Could not issue a token. Try again in a moment."),
+      );
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="mx-auto max-w-3xl p-6">
+      <header>
+        <div className="flex items-center gap-2">
+          <Radio aria-hidden="true" className="h-5 w-5 text-primary" />
+          <h1 className="text-2xl font-bold">Continuous ingest (OTLP)</h1>
+        </div>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Push agent traces to Blind Bench automatically from Cloudflare AI
+          Gateway or any OpenTelemetry source.
+        </p>
+      </header>
+
+      <Card className="mt-6 border-amber-500/40 bg-amber-500/5">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-base">
+            <ShieldAlert
+              aria-hidden="true"
+              className="h-4 w-4 text-amber-600 dark:text-amber-400"
+            />
+            Data boundary
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="text-sm text-muted-foreground">
+          <p>
+            Blind Bench{" "}
+            <strong className="text-foreground">
+              never holds your gateway credential
+            </strong>
+            . You issue a token here and add it to YOUR gateway config — we only
+            receive what your gateway pushes.
+          </p>
+        </CardContent>
+      </Card>
+
+      {/* Ingest URL */}
+      <section className="mt-6 space-y-1.5">
+        <Label htmlFor="ingest-url">Ingest URL</Label>
+        <div className="flex items-center gap-2">
+          <Input
+            id="ingest-url"
+            value={ingestUrl}
+            readOnly
+            spellCheck={false}
+            className="font-mono text-xs"
+            onFocus={(e) => e.currentTarget.select()}
+          />
+          <CopyButton
+            text={ingestUrl}
+            label="Copy"
+            variant="inline"
+            className="h-8 shrink-0 border border-input px-2.5"
+          />
+        </div>
+        <p className="text-xs text-muted-foreground">
+          Point your gateway's OTLP HTTP exporter at this endpoint.
+        </p>
+      </section>
+
+      {/* Issue token */}
+      <section className="mt-8">
+        <h2 className="mb-3 flex items-center gap-2 text-sm font-medium uppercase tracking-wider text-muted-foreground">
+          <KeyRound aria-hidden="true" className="h-3.5 w-3.5" />
+          Ingest tokens
+        </h2>
+
+        <form onSubmit={handleIssue} className="flex flex-wrap items-end gap-2">
+          <div className="flex-1 space-y-1.5">
+            <Label htmlFor="token-label">Label</Label>
+            <Input
+              id="token-label"
+              value={label}
+              onChange={(e) => setLabel(e.target.value)}
+              placeholder="Gateway token"
+              maxLength={80}
+            />
+          </div>
+          <Button type="submit" disabled={busy}>
+            {busy ? "Issuing…" : "Issue token"}
+          </Button>
+        </form>
+
+        {error && (
+          <p className="mt-2 text-sm text-destructive" role="alert">
+            {error}
+          </p>
+        )}
+
+        {issued && (
+          <IssuedTokenCard
+            token={issued.token}
+            onDismiss={() => setIssued(null)}
+          />
+        )}
+
+        <div className="mt-4">
+          <TokenList tokens={tokens} />
+        </div>
+      </section>
+
+      {/* Gateway setup */}
+      <GatewaySetupCard ingestUrl={ingestUrl} />
+    </div>
+  );
+}
+
+function IssuedTokenCard({
+  token,
+  onDismiss,
+}: {
+  token: string;
+  onDismiss: () => void;
+}) {
+  return (
+    <Card className="mt-4 border-amber-500/40 bg-amber-500/5">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-base">
+          <ShieldAlert
+            aria-hidden="true"
+            className="h-4 w-4 text-amber-600 dark:text-amber-400"
+          />
+          Copy this now — it won't be shown again
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3 text-sm">
+        <div className="flex items-center gap-2">
+          <code className="min-w-0 flex-1 overflow-x-auto rounded-md border bg-background px-3 py-2 font-mono text-xs">
+            {token}
+          </code>
+          <CopyButton
+            text={token}
+            label="Copy"
+            variant="inline"
+            className="h-8 shrink-0 border border-input px-2.5"
+          />
+        </div>
+        <p className="text-xs text-muted-foreground">
+          Store it in your gateway config as a bearer token. We only keep a
+          masked preview — there is no way to retrieve the full value later.
+        </p>
+        <Button variant="outline" size="sm" onClick={onDismiss}>
+          Done
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}
+
+function TokenList({ tokens }: { tokens: IngestToken[] | undefined }) {
+  if (tokens === undefined) {
+    return (
+      <div className="space-y-2" role="status" aria-label="Loading tokens">
+        {[1, 2].map((i) => (
+          <Skeleton key={i} className="h-14 w-full" />
+        ))}
+        <span className="sr-only">Loading ingest tokens…</span>
+      </div>
+    );
+  }
+
+  if (tokens.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        No ingest tokens yet — issue one to start receiving traces.
+      </p>
+    );
+  }
+
+  return (
+    <div className="divide-y rounded-lg border">
+      {tokens.map((t) => (
+        <TokenRow key={t._id} token={t} />
+      ))}
+    </div>
+  );
+}
+
+function TokenRow({ token }: { token: IngestToken }) {
+  const revokeToken = useMutation(api.ingestTokens.revokeIngestToken);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState("");
+
+  async function handleRevoke() {
+    setBusy(true);
+    setError("");
+    try {
+      await revokeToken({ tokenId: token._id });
+    } catch (err) {
+      setError(friendlyError(err, "Could not revoke this token. Try again."));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-3 px-4 py-3">
+      <div className="min-w-0 space-y-0.5 text-sm">
+        <p className={cn("font-medium", token.revoked && "text-muted-foreground")}>
+          {token.label}{" "}
+          <span className="font-mono text-xs text-muted-foreground">
+            {token.preview}
+          </span>
+        </p>
+        <p className="text-xs text-muted-foreground">
+          Created {formatTimestamp(token.createdAt)} · Last used{" "}
+          {token.lastUsedAt ? formatTimestamp(token.lastUsedAt) : "never"}
+        </p>
+        {error && (
+          <p className="text-xs text-destructive" role="alert">
+            {error}
+          </p>
+        )}
+      </div>
+      {token.revoked ? (
+        <span className="text-xs font-medium text-muted-foreground">Revoked</span>
+      ) : (
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={handleRevoke}
+          disabled={busy}
+        >
+          {busy ? "Revoking…" : "Revoke"}
+        </Button>
+      )}
+    </div>
+  );
+}
+
+function GatewaySetupCard({ ingestUrl }: { ingestUrl: string }) {
+  const snippet = [
+    `OTLP endpoint: ${ingestUrl}`,
+    `Header: Authorization: Bearer <your token>`,
+    `Format: JSON`,
+  ].join("\n");
+
+  return (
+    <Card className="mt-8">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-base">
+          <Settings2 aria-hidden="true" className="h-4 w-4 text-primary" />
+          Gateway setup
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4 text-sm text-muted-foreground">
+        <ol className="list-decimal space-y-2 pl-5">
+          <li>Issue an ingest token above and copy it.</li>
+          <li>
+            In Cloudflare AI Gateway, enable the OpenTelemetry (OTLP) exporter
+            and set its HTTP endpoint to the ingest URL above.
+          </li>
+          <li>
+            Add an auth header{" "}
+            <code className="text-foreground">
+              Authorization: Bearer &lt;token&gt;
+            </code>{" "}
+            (or, if your source can't set that header, use{" "}
+            <code className="text-foreground">
+              x-blindbench-ingest-token: &lt;token&gt;
+            </code>
+            ).
+          </li>
+          <li>
+            Send spans as <strong className="text-foreground">JSON</strong>{" "}
+            (protobuf support is coming later).
+          </li>
+        </ol>
+
+        <div className="relative">
+          <pre className="overflow-x-auto rounded-lg border bg-muted/30 p-3 pr-12 font-mono text-xs text-foreground">
+            {snippet}
+          </pre>
+          <CopyButton
+            text={snippet}
+            label="Copy config"
+            variant="overlay"
+          />
+        </div>
+
+        <p>
+          Once your gateway starts pushing gen_ai spans, incoming traces appear
+          under this project's trajectories and review surfaces.
+        </p>
+
+        <p>
+          <a
+            href="https://developers.cloudflare.com/ai-gateway/observability/otel-integration/"
+            target="_blank"
+            rel="noreferrer"
+            className="text-primary hover:underline"
+          >
+            Cloudflare AI Gateway OTel integration docs →
+          </a>
+        </p>
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
Closes #263. Flips ingestion from export-and-paste to **push**: the customer points their gateway at our URL + a token we issue, and gen_ai traces flow in continuously — landing as agent trajectories in the M31 spine (review / blind / DPO export).

## Decided with Noah
OTLP delivers gen_ai spans grouped under a `trace_id`. Chosen model: **group spans by trace_id → one agent trajectory** (via `persistTrace`), so ingested traces feed everything M31 built — not the older per-span eval-case path.

## Data boundary (BYOK)
**Blind Bench never holds the customer's gateway credential.** They issue a per-project token here and add it to *their* gateway config; we only receive what their gateway pushes. Inverse of holding customer CF tokens + polling.

## Backend
- **`lib/otelGenAI.ts`** — pure OTLP/HTTP JSON → `AgentRunTrace[]`. Groups gen_ai spans by `trace_id` (time-ordered) into one trajectory; reads `gen_ai.request.model`, system/provider, usage tokens/cost; prompt/completion via CF `*_json`, OTel indexed `gen_ai.prompt.N.*`, or plain strings; `tool_calls` → redacted `tool_call` steps. **Body-optional** (mirrors the redacted-body posture).
- **`ingestTokens`** — per-project opaque 128-bit bearer tokens (`generateToken`, plaintext + `by_token`, the house pattern), issue (full token shown once) / revoke / list-masked. Owner/editor only.
- **`otlpIngest`** — public `POST /otlp/v1/traces` (`httpAction`, mounted in `http.ts`, secret-gated like the Polar webhook). Verifies token (`Authorization: Bearer` / `x-blindbench-ingest-token`), maps, dedups by `(source "otlp", sourceTraceId)`, persists via the spine (token-authed `insertTraceParentForIngest` + `storeTraceSteps` **extracted from `persistTrace`** — no duplication). Counts-only response; raw payload retained.

## Frontend
Project **Ingest** tab: copyable ingest URL (derived from the deployment), issue/revoke tokens (full token shown once, list masked), amber data-boundary card, and gateway setup instructions with a copyable endpoint + header block.

## Verification
`npm run test:convex` → **212 passed** (5 new: mapper grouping + body-optional; token issue/mask/revoke; **end-to-end `t.fetch` POST** persists a 4-step trajectory + re-POST dedups; 401 on missing/bad token) · `npm run build` clean.

## Honest scope / deferred (in-code + here)
- **JSON only** (protobuf later). **No volume quotas** — metering is a net-new billing seam (there's no consumption path today); deferred to #236.
- **Live-unverified**: whether CF's OTel export carries prompt/completion payloads independent of the "Log payloads" setting (couldn't verify live) — hence body-optional by design.
- Does OTLP **subsume the #130/#131/#133 adapters**? — strategic call left open, not decided here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)