### PR TITLE
M31 dogfood: validate the flywheel end-to-end + fix degenerate DPO pairs

### DIFF
--- a/convex/lib/trainingExport.ts
+++ b/convex/lib/trainingExport.ts
@@ -70,7 +70,7 @@ export interface ClassifiedRow {
 }
 
 export interface ExcludedRow {
-  reason: "prod_sensitive" | "pii_leak" | "empty";
+  reason: "prod_sensitive" | "pii_leak" | "empty" | "degenerate";
   privacyClass: PrivacyClass;
 }
 
@@ -128,6 +128,13 @@ export function gateRows(
     }
     if (SENSITIVE_CLASSES.has(privacyClass) && !opts.allowSensitive) {
       excluded.push({ reason: "prod_sensitive", privacyClass });
+      continue;
+    }
+    // A DPO pair with identical chosen/rejected carries no preference signal —
+    // it pollutes the dataset. Drop it (e.g. the matchup's divergence index
+    // landed on a shared-prefix step). Surfaced by the M31 dogfood pass.
+    if (row.kind === "dpo" && row.chosen.trim() === row.rejected.trim()) {
+      excluded.push({ reason: "degenerate", privacyClass });
       continue;
     }
     const text = rowText(row);

--- a/convex/tests/dogfoodFlow.test.ts
+++ b/convex/tests/dogfoodFlow.test.ts
@@ -1,0 +1,118 @@
+/// <reference types="vite/client" />
+import { convexTest } from "convex-test";
+import { describe, expect, test } from "vitest";
+import { api } from "../_generated/api";
+import type { Id } from "../_generated/dataModel";
+import schema from "../schema";
+import type { AgentRunTrace } from "../lib/agentTrace";
+import opus from "./fixtures/harbor-opus.json";
+import sonnet from "./fixtures/harbor-sonnet.json";
+import haiku from "./fixtures/harbor-haiku.json";
+
+// M31 dogfood: the WHOLE flywheel as one continuous flow on the real Harbor
+// trajectories — ingest → blind review (comment + verdict) → step-level A/B
+// matchup → real DPO/SFT export — verifying the training artifact actually
+// carries real content end-to-end. This is the seam between the eight M31 issues
+// that per-issue tests don't exercise together.
+const asTrace = (t: unknown) => JSON.parse(JSON.stringify(t)) as unknown as AgentRunTrace;
+
+async function seed(t: ReturnType<typeof convexTest>) {
+  const ids = await t.run(async (ctx) => {
+    const ownerUserId = await ctx.db.insert("users", { name: "Owner", email: "o@d.com" });
+    const evalUserId = await ctx.db.insert("users", { name: "Rev", email: "r@d.com" });
+    const orgId = await ctx.db.insert("organizations", { name: "Org", slug: "org", createdById: ownerUserId });
+    await ctx.db.insert("organizationMembers", { organizationId: orgId, userId: ownerUserId, role: "owner" });
+    const projectId = await ctx.db.insert("projects", { organizationId: orgId, name: "Agent QA", createdById: ownerUserId });
+    await ctx.db.insert("projectCollaborators", { projectId, userId: ownerUserId, role: "owner", invitedById: ownerUserId, invitedAt: Date.now() });
+    await ctx.db.insert("projectCollaborators", { projectId, userId: evalUserId, role: "evaluator", invitedById: ownerUserId, invitedAt: Date.now() });
+    return { ownerUserId, evalUserId, projectId };
+  });
+  return {
+    ids,
+    asOwner: t.withIdentity({ subject: `${ids.ownerUserId}|s`, tokenIdentifier: `test|${ids.ownerUserId}` }),
+    asBlind: t.withIdentity({ subject: `${ids.evalUserId}|s`, tokenIdentifier: `test|${ids.evalUserId}` }),
+  };
+}
+
+describe("M31 dogfood — full flywheel on real trajectories", () => {
+  test("ingest → blind review → A/B → real DPO + SFT export", async () => {
+    const t = convexTest(schema);
+    const { ids, asOwner, asBlind } = await seed(t);
+
+    // 1. INGEST — persist three real Harbor trajectories of the same task.
+    const traces: Record<string, Id<"agentTraces">> = {};
+    for (const [combo, trace] of [["opus", opus], ["sonnet", sonnet], ["haiku", haiku]] as const) {
+      const res = await asOwner.action(api.agentTraces.persistTrace, { projectId: ids.projectId, trace: asTrace(trace) });
+      expect(res.deduped).toBe(false);
+      traces[combo] = res.agentTraceId;
+    }
+
+    // 2. BLIND REVIEW — a reviewer discovers them (no provenance), reads steps,
+    //    comments on a step, and rates the trajectory.
+    const list = await asBlind.query(api.agentTraces.listReviewableTraces, {});
+    expect(list).toHaveLength(3);
+    const steps = await asBlind.query(api.agentTraces.listSteps, {
+      agentTraceId: traces.opus!,
+      paginationOpts: { numItems: 50, cursor: null },
+    });
+    expect(steps.page.length).toBeGreaterThan(0);
+    await asBlind.mutation(api.agentTraceReview.addComment, {
+      agentTraceId: traces.opus!,
+      target: { kind: "step", stepIndex: steps.page[1]!.stepIndex },
+      comment: "Reasonable first move.",
+      label: "praise",
+    });
+    await asBlind.mutation(api.agentTraceReview.setVerdict, { agentTraceId: traces.haiku!, rating: "best" });
+    await asBlind.mutation(api.agentTraceReview.setVerdict, { agentTraceId: traces.opus!, rating: "acceptable" });
+
+    // 3. A/B MATCHUP — the DPO-shaped signal: winner's next action vs loser's.
+    // Real divergence is at step 4 (steps 0-3 are an identical prefix — user
+    // prompt + setup hooks); Opus and Sonnet take different next actions there.
+    const matchupId = await asOwner.mutation(api.agentTraceReview.createMatchup, {
+      leftTraceId: traces.opus!,
+      rightTraceId: traces.sonnet!,
+      divergenceStepIndex: 4,
+      leftBlindLabel: "A",
+      rightBlindLabel: "B",
+    });
+    await asBlind.mutation(api.agentTraceReview.decideMatchup, { matchupId, winner: "left", reasonTags: ["accuracy"] });
+
+    // 4. EXPORT — the flywheel payoff: a real DPO pair falls out of the matchup.
+    const dpo = await asOwner.action(api.exports.generateExport, {
+      projectId: ids.projectId, source: "trajectory", format: "dpo",
+    });
+    expect(dpo.rowCount).toBeGreaterThanOrEqual(1);
+    const dpoJsonl = await t.run(async (ctx) => {
+      const row = await ctx.db.query("trainingExports").order("desc").first();
+      const blob = row ? await ctx.storage.get(row.storageId) : null;
+      return blob ? await blob.text() : "";
+    });
+    const pair = JSON.parse(dpoJsonl.split("\n")[0]!);
+    // The DPO pair carries real content: a prompt (shared prefix), and distinct
+    // chosen (winner) vs rejected (loser) next actions.
+    expect(pair).toHaveProperty("prompt");
+    expect(pair).toHaveProperty("chosen");
+    expect(pair).toHaveProperty("rejected");
+    expect(pair.chosen).not.toBe(pair.rejected);
+    expect(typeof pair.prompt).toBe("string");
+    expect(pair.prompt.length).toBeGreaterThan(0);
+    // No provider/harness provenance leaks into the training data.
+    expect(dpoJsonl).not.toContain("claude-opus");
+
+    // SFT from the best-verdict trajectory.
+    const sft = await asOwner.action(api.exports.generateExport, {
+      projectId: ids.projectId, source: "trajectory", format: "sft",
+    });
+    expect(sft.rowCount).toBeGreaterThanOrEqual(1);
+
+    // Surface the real artifact so a dogfood run shows what shipped.
+    // eslint-disable-next-line no-console
+    console.log(
+      `\n[dogfood] DPO pair from real Harbor A/B (Opus✓ vs Sonnet✗):\n` +
+        `  prompt : ${String(pair.prompt).slice(0, 90).replace(/\n/g, " ")}…\n` +
+        `  chosen : ${String(pair.chosen).slice(0, 90).replace(/\n/g, " ")}…\n` +
+        `  reject : ${String(pair.rejected).slice(0, 90).replace(/\n/g, " ")}…\n` +
+        `  → dpo rows=${dpo.rowCount} excluded=${dpo.excludedCount}, sft rows=${sft.rowCount}`,
+    );
+  });
+});

--- a/convex/tests/trainingExport.test.ts
+++ b/convex/tests/trainingExport.test.ts
@@ -40,6 +40,16 @@ describe("#53 training-export data-boundary gate", () => {
     expect(excluded.every((e) => e.reason === "pii_leak")).toBe(true);
   });
 
+  test("degenerate DPO pairs (chosen === rejected) are excluded — no training signal", () => {
+    const rows: ClassifiedRow[] = [
+      { row: dpo({ chosen: "same action", rejected: "same action" }), privacyClass: "public" },
+      { row: dpo({ chosen: "better", rejected: "worse" }), privacyClass: "public" },
+    ];
+    const { included, excluded } = gateRows(rows);
+    expect(included).toHaveLength(1);
+    expect(excluded[0]?.reason).toBe("degenerate");
+  });
+
   test("empty rows are excluded with a reason, never silently dropped", () => {
     const rows: ClassifiedRow[] = [
       { row: dpo({ chosen: "   " }), privacyClass: "public" },


### PR DESCRIPTION
Dogfood pass over the completed M31 milestone — ran the **whole flywheel as one continuous flow** on the **real Harbor trajectories** (the ones from #268), not synthetic fixtures: ingest → blind review (comment + verdict) → step-level A/B matchup → **real DPO + SFT export**.

## It worked end-to-end — and produced a real training artifact
The Opus(solved)-vs-Sonnet(failed) `fix-git` A/B yields a genuine DPO pair, extracted blind:
```
prompt : user: I just made some changes to my personal site and checked out master…
chosen : assistant: Let me investigate the git state to find your changes.   (Opus, solved)
reject : thinking: The user made changes to their personal site…              (Sonnet, failed)
```
No provider/harness provenance leaks into the training data.

## The dogfood earned its keep — found + fixed a real gap
When a matchup's `divergenceStepIndex` lands on a **shared-prefix step** (steps 0–3 of these real traces are an identical user-prompt + setup-hooks prefix), the DPO pair comes out **`chosen === rejected`** — zero training signal, and it silently pollutes the paid dataset. The export gate didn't catch it.

**Fix:** `gateRows` now excludes `chosen === rejected` DPO rows (reason `"degenerate"`), reported like every other exclusion — never silently dropped. Unit test added. This is a real data-quality guardrail the training-export flywheel needs.

## Also added
`convex/tests/dogfoodFlow.test.ts` — the full flywheel on the 3 real trajectories, kept as a standing end-to-end regression across the eight M31 issues (the seam per-issue tests don't cover together).

## Verification
`npm run test:convex` → **215 passed** · `npm run build` clean.

## Honest note
This validates the full loop through the **real function code** with real data (convex-test runs actual implementations; the DPO content comes from real stored blobs). The remaining gap is unchanged: a human browser clickthrough of the review UI (real storage-URL rendering, live auth) — the OTLP HTTP path is covered by the existing `t.fetch` integration test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)