### PR TITLE
Validate Polar self-serve billing end-to-end (#236)

### DIFF
--- a/convex/tests/billingWebhook.test.ts
+++ b/convex/tests/billingWebhook.test.ts
@@ -1,0 +1,328 @@
+/// <reference types="vite/client" />
+import { convexTest } from "convex-test";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import schema from "../schema";
+import { signWebhook } from "../lib/polarSignature";
+
+// A plain (non-`whsec_`) secret is accepted as UTF-8 bytes by verifyWebhook,
+// which is fine for driving the route in tests.
+const SECRET = "test-webhook-secret";
+const SANDBOX_ORG = "801c0378-2a22-439e-816f-f874be389bd3";
+
+// Seed a real org + owner exactly like billing.test.ts's seedBillingEnv.
+async function seedBillingEnv() {
+  const t = convexTest(schema);
+  const ids = await t.run(async (ctx) => {
+    const ownerUserId = await ctx.db.insert("users", {
+      name: "Owner",
+      email: "owner@test.com",
+    });
+    const orgId = await ctx.db.insert("organizations", {
+      name: "Acme",
+      slug: "acme",
+      createdById: ownerUserId,
+    });
+    await ctx.db.insert("organizationMembers", {
+      organizationId: orgId,
+      userId: ownerUserId,
+      role: "owner",
+    });
+    return { ownerUserId, orgId };
+  });
+  return { t, ids };
+}
+
+// Build a real-shape Polar `order.paid` webhook body (trimmed to relevant
+// fields; extra fields must be harmlessly ignored).
+function orderPaidBody(
+  orgId: string,
+  orderId: string,
+  opts: { customerId?: string; subscriptionId?: string; dropMetaOrgId?: boolean } = {},
+) {
+  const customerId = opts.customerId ?? "cus_polar_1";
+  const subscriptionId = opts.subscriptionId ?? "sub_polar_1";
+  const metadata: Record<string, string> = {
+    orgId,
+    packageKey: "team",
+    environment: "sandbox",
+  };
+  if (opts.dropMetaOrgId) delete metadata.orgId;
+  return {
+    type: "order.paid",
+    data: {
+      id: orderId,
+      status: "paid",
+      paid: true,
+      billing_reason: "subscription_create",
+      currency: "usd",
+      total_amount: 19900,
+      customer_id: customerId,
+      product_id: "prod_team_x",
+      subscription_id: subscriptionId,
+      checkout_id: "chk_1",
+      metadata,
+      customer: {
+        id: customerId,
+        external_id: orgId,
+        email: "buyer@example.com",
+        organization_id: SANDBOX_ORG,
+      },
+      subscription: {
+        id: subscriptionId,
+        status: "active",
+        metadata: { orgId, packageKey: "team", environment: "sandbox" },
+      },
+    },
+  };
+}
+
+function orderRefundedBody(
+  orgId: string,
+  orderId: string,
+  opts: { customerId?: string; subscriptionId?: string } = {},
+) {
+  const customerId = opts.customerId ?? "cus_polar_1";
+  return {
+    type: "order.refunded",
+    data: {
+      id: orderId,
+      metadata: { orgId, packageKey: "team", environment: "sandbox" },
+      customer: { id: customerId, external_id: orgId },
+      customer_id: customerId,
+      subscription_id: opts.subscriptionId ?? "sub_polar_1",
+    },
+  };
+}
+
+function subscriptionRevokedBody(
+  orgId: string,
+  subscriptionId: string,
+  opts: { customerId?: string } = {},
+) {
+  const customerId = opts.customerId ?? "cus_polar_1";
+  return {
+    type: "subscription.revoked",
+    data: {
+      // NOTE: for subscription events, data.id is the SUBSCRIPTION id.
+      id: subscriptionId,
+      metadata: { orgId, packageKey: "team", environment: "sandbox" },
+      customer: { id: customerId, external_id: orgId },
+      customer_id: customerId,
+    },
+  };
+}
+
+// Drive the route with a valid signature over the exact body bytes.
+async function postSigned(
+  t: ReturnType<typeof convexTest>,
+  id: string,
+  body: unknown,
+) {
+  const raw = JSON.stringify(body);
+  const timestamp = Math.floor(Date.now() / 1000).toString();
+  const signature = await signWebhook(id, timestamp, raw, SECRET);
+  return t.fetch("/polar/webhook", {
+    method: "POST",
+    headers: {
+      "webhook-id": id,
+      "webhook-timestamp": timestamp,
+      "webhook-signature": signature,
+      "Content-Type": "application/json",
+    },
+    body: raw,
+  });
+}
+
+async function ledgerFor(t: ReturnType<typeof convexTest>, orgId: string) {
+  return t.run(async (ctx) => {
+    const rows = await ctx.db
+      .query("billingLedger")
+      .withIndex("by_org", (q) => q.eq("organizationId", orgId as any))
+      .collect();
+    return rows;
+  });
+}
+
+describe("/polar/webhook end-to-end (real Polar event shapes)", () => {
+  let prevSecret: string | undefined;
+
+  beforeEach(() => {
+    prevSecret = process.env.POLAR_WEBHOOK_SECRET;
+    process.env.POLAR_WEBHOOK_SECRET = SECRET;
+  });
+  afterEach(() => {
+    if (prevSecret === undefined) delete process.env.POLAR_WEBHOOK_SECRET;
+    else process.env.POLAR_WEBHOOK_SECRET = prevSecret;
+  });
+
+  test("a. real-shape order.paid grants entitlement + credits + customer", async () => {
+    const { t, ids } = await seedBillingEnv();
+    const body = orderPaidBody(ids.orgId, "ord_real_1", {
+      customerId: "cus_real_1",
+    });
+
+    const res = await postSigned(t, "evt_paid_1", body);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.result.action).toBe("granted");
+
+    await t.run(async (ctx) => {
+      const ledger = await ctx.db
+        .query("billingLedger")
+        .withIndex("by_org", (q) => q.eq("organizationId", ids.orgId))
+        .collect();
+      expect(ledger).toHaveLength(1);
+      expect(ledger[0]!.creditDelta).toBe(2500);
+
+      const ent = await ctx.db
+        .query("billingEntitlements")
+        .withIndex("by_org", (q) => q.eq("organizationId", ids.orgId))
+        .collect();
+      expect(ent).toHaveLength(1);
+      expect(ent[0]!.status).toBe("active");
+      expect(ent[0]!.packageKey).toBe("team");
+
+      const cust = await ctx.db
+        .query("billingCustomers")
+        .withIndex("by_org", (q) => q.eq("organizationId", ids.orgId))
+        .unique();
+      // polarCustomerId must match data.customer_id from the payload.
+      expect(cust?.polarCustomerId).toBe("cus_real_1");
+    });
+  });
+
+  test("b. fallback: no data.metadata.orgId → customer.external_id grants", async () => {
+    const { t, ids } = await seedBillingEnv();
+    const body = orderPaidBody(ids.orgId, "ord_fallback_2", {
+      customerId: "cus_fallback_2",
+      dropMetaOrgId: true,
+    });
+
+    const res = await postSigned(t, "evt_paid_2", body);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.result.action).toBe("granted");
+
+    const ledger = await ledgerFor(t, ids.orgId);
+    expect(ledger).toHaveLength(1);
+    expect(ledger[0]!.creditDelta).toBe(2500);
+  });
+
+  test("c. bad signature → 401 and no ledger row", async () => {
+    const { t, ids } = await seedBillingEnv();
+    const body = orderPaidBody(ids.orgId, "ord_bad_3");
+    const raw = JSON.stringify(body);
+    const timestamp = Math.floor(Date.now() / 1000).toString();
+    // A signature computed under a DIFFERENT secret must not verify.
+    const badSig = await signWebhook("evt_3", timestamp, raw, "wrong-secret");
+
+    const res = await t.fetch("/polar/webhook", {
+      method: "POST",
+      headers: {
+        "webhook-id": "evt_3",
+        "webhook-timestamp": timestamp,
+        "webhook-signature": badSig,
+        "Content-Type": "application/json",
+      },
+      body: raw,
+    });
+    expect(res.status).toBe(401);
+
+    const ledger = await ledgerFor(t, ids.orgId);
+    expect(ledger).toHaveLength(0);
+  });
+
+  test("d. missing signature headers → 400", async () => {
+    const { t, ids } = await seedBillingEnv();
+    const body = orderPaidBody(ids.orgId, "ord_missing_4");
+    const res = await t.fetch("/polar/webhook", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    expect(res.status).toBe(400);
+
+    const ledger = await ledgerFor(t, ids.orgId);
+    expect(ledger).toHaveLength(0);
+  });
+
+  test("e. POLAR_WEBHOOK_SECRET unset → 503", async () => {
+    const { t, ids } = await seedBillingEnv();
+    delete process.env.POLAR_WEBHOOK_SECRET; // afterEach restores it
+    const body = orderPaidBody(ids.orgId, "ord_503_5");
+    const res = await t.fetch("/polar/webhook", {
+      method: "POST",
+      headers: {
+        "webhook-id": "evt_5",
+        "webhook-timestamp": Math.floor(Date.now() / 1000).toString(),
+        "webhook-signature": "v1,ignored",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+    expect(res.status).toBe(503);
+  });
+
+  test("f. order.refunded reverses the grant and revokes entitlement", async () => {
+    const { t, ids } = await seedBillingEnv();
+    const paid = await postSigned(
+      t,
+      "evt_paid_6",
+      orderPaidBody(ids.orgId, "ord_refund_6", { customerId: "cus_6" }),
+    );
+    expect((await paid.json()).result.action).toBe("granted");
+
+    const refund = await postSigned(
+      t,
+      "evt_refund_6",
+      orderRefundedBody(ids.orgId, "ord_refund_6", { customerId: "cus_6" }),
+    );
+    expect(refund.status).toBe(200);
+    expect((await refund.json()).result.action).toBe("refunded");
+
+    const ledger = await ledgerFor(t, ids.orgId);
+    const total = ledger.reduce((a, r) => a + r.creditDelta, 0);
+    expect(total).toBe(0);
+
+    await t.run(async (ctx) => {
+      const ent = await ctx.db
+        .query("billingEntitlements")
+        .withIndex("by_org", (q) => q.eq("organizationId", ids.orgId))
+        .collect();
+      expect(ent[0]!.status).toBe("revoked");
+    });
+  });
+
+  test("g. subscription.revoked (data.id = subscription id) revokes, credits intact", async () => {
+    const { t, ids } = await seedBillingEnv();
+    const paid = await postSigned(
+      t,
+      "evt_paid_7",
+      orderPaidBody(ids.orgId, "ord_revoke_7", {
+        customerId: "cus_7",
+        subscriptionId: "sub_revoke_7",
+      }),
+    );
+    expect((await paid.json()).result.action).toBe("granted");
+
+    const revoke = await postSigned(
+      t,
+      "evt_revoke_7",
+      subscriptionRevokedBody(ids.orgId, "sub_revoke_7", { customerId: "cus_7" }),
+    );
+    expect(revoke.status).toBe(200);
+    expect((await revoke.json()).result.action).toBe("revoked");
+
+    const ledger = await ledgerFor(t, ids.orgId);
+    const total = ledger.reduce((a, r) => a + r.creditDelta, 0);
+    expect(total).toBe(2500); // credits untouched on revoke
+
+    await t.run(async (ctx) => {
+      const ent = await ctx.db
+        .query("billingEntitlements")
+        .withIndex("by_org", (q) => q.eq("organizationId", ids.orgId))
+        .collect();
+      expect(ent[0]!.status).toBe("revoked");
+    });
+  });
+});

--- a/convex/tests/billingWebhook.test.ts
+++ b/convex/tests/billingWebhook.test.ts
@@ -2,7 +2,12 @@
 import { convexTest } from "convex-test";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import schema from "../schema";
+import type { Id } from "../_generated/dataModel";
 import { signWebhook } from "../lib/polarSignature";
+
+// Properly-typed harness (the concrete convexTest(schema) result) so table
+// queries in helpers resolve their indexes under `tsc -b`.
+type Harness = Awaited<ReturnType<typeof seedBillingEnv>>["t"];
 
 // A plain (non-`whsec_`) secret is accepted as UTF-8 bytes by verifyWebhook,
 // which is fine for driving the route in tests.
@@ -114,7 +119,7 @@ function subscriptionRevokedBody(
 
 // Drive the route with a valid signature over the exact body bytes.
 async function postSigned(
-  t: ReturnType<typeof convexTest>,
+  t: Harness,
   id: string,
   body: unknown,
 ) {
@@ -133,11 +138,11 @@ async function postSigned(
   });
 }
 
-async function ledgerFor(t: ReturnType<typeof convexTest>, orgId: string) {
+async function ledgerFor(t: Harness, orgId: Id<"organizations">) {
   return t.run(async (ctx) => {
     const rows = await ctx.db
       .query("billingLedger")
-      .withIndex("by_org", (q) => q.eq("organizationId", orgId as any))
+      .withIndex("by_org", (q) => q.eq("organizationId", orgId))
       .collect();
     return rows;
   });

--- a/docs/polar-self-serve-billing.md
+++ b/docs/polar-self-serve-billing.md
@@ -56,6 +56,21 @@ Metadata we send to Polar at checkout is limited to `orgId`, `packageKey`, and
 Checkout and portal **fail closed** with a `ConvexError` when the token or a
 product id is missing — nothing half-works.
 
+### Sandbox validation (2026-07-07)
+
+Validated against the live Polar sandbox. Real product ids created for cutover
+reference (sandbox org `Mogil Ventures Sandbox`,
+`801c0378-2a22-439e-816f-f874be389bd3`, API base `https://sandbox-api.polar.sh`):
+
+| Env var | Sandbox product id | Product |
+|---------|--------------------|---------|
+| `POLAR_PRODUCT_STARTER` | `3e538112-f161-4961-8cd5-4048bd347b4a` | Blind Bench — Starter, $49/mo |
+| `POLAR_PRODUCT_TEAM` | `a94df903-fbe7-4329-9c41-3ee6fb9c5b47` | Blind Bench — Team, $199/mo |
+| `POLAR_PRODUCT_SCALE` | `e329c871-9750-4c4e-88a6-0b60aaaec577` | Blind Bench — Scale, $499/mo |
+
+These prices are sandbox placeholders; production prices are set when the
+production products are created (see Cutover).
+
 ## Webhook setup
 
 1. In Polar, add a webhook endpoint pointing at
@@ -74,6 +89,13 @@ double-credits).
 - Unit tests, no live Polar:
   - `env -u NODE_ENV npx vitest run --config convex/vitest.config.ts convex/lib/__tests__/polarSignature.test.ts` — signature sign/verify/replay.
   - `env -u NODE_ENV npm run test:convex` — webhook idempotency + ledger/entitlement (`convex/tests/billing.test.ts`). Requires `_generated` (run `npx convex dev` once to codegen).
+  - The full webhook path is now covered end-to-end by
+    `convex/tests/billingWebhook.test.ts`: signed, real-shape Polar events
+    (`order.paid` including the `customer.external_id` fallback, `order.refunded`,
+    `subscription.revoked`) driven through the `/polar/webhook` route, plus the
+    401/400/503 rejection cases. The outbound checkout/portal calls and a real
+    card → webhook delivery remain a manual smoke test against a deployed
+    endpoint (see Cutover).
 - Drive a webhook by hand: use `signWebhook(id, timestamp, body, secret)` from
   `convex/lib/polarSignature.ts` to build a valid `webhook-signature`, then
   `curl` your local `/polar/webhook` with the three headers and a JSON body


### PR DESCRIPTION
## What this is

Issue #236's Polar billing **implementation already shipped** (`ae865b9 feat: add Polar self-serve billing foundation`): config-driven catalog, checkout + customer-portal actions, idempotent webhook apply (event- and order-level, refund reversal), Standard-Webhooks signature verify, owner Billing UI, and `docs/polar-self-serve-billing.md`. But it had **never touched a live Polar API** — it was written against the docs, and the existing tests call `applyPolarEvent` *post-sanitize*, leaving the `/polar/webhook` route and `sanitizePolarEvent` untested against a real payload. That validation is what this PR delivers.

## Verified against the live Polar sandbox

Against the **Mogil Ventures Sandbox** org (`801c0378…`, `https://sandbox-api.polar.sh`) I created the three Blind Bench products and inspected real order objects to confirm the code's assumptions:

| Package | Sandbox product ID | Price (placeholder) |
|---|---|---|
| starter | `3e538112-f161-4961-8cd5-4048bd347b4a` | $49/mo |
| team | `a94df903-fbe7-4329-9c41-3ee6fb9c5b47` | $199/mo |
| scale | `e329c871-9750-4c4e-88a6-0b60aaaec577` | $499/mo |

Confirmed from real events: `data.metadata.{orgId,packageKey}` carry checkout metadata onto the order (and forward through renewal orders), `data.customer.external_id` is the fallback external id, and `data.{customer_id,subscription_id,id}` sit top-level — with `data.id` = **subscription** id on `subscription.revoked`. **The existing sanitizer/route already match this shape exactly — no product code changed.**

## Changes

- **`convex/tests/billingWebhook.test.ts`** (new) — 7 end-to-end tests that POST *signed, real-shape* `order.paid` / `order.refunded` / `subscription.revoked` events through the actual route: grant, `external_id` fallback, bad-signature→401, missing-headers→400, unconfigured→503, refund reversal, revoke-keeps-credits. Assertions check **DB effects** (ledger delta, entitlement status, customer id), not just HTTP status — so a silently-broken sanitizer fails the suite.
- **`docs/polar-self-serve-billing.md`** — record the sandbox product IDs + org for cutover; note the webhook path is now covered e2e while outbound checkout/portal + real card→webhook delivery remain a **deployed-endpoint smoke test** (this VPS has no live Convex deployment).

## Tests / build
- `22 passing` — `billingWebhook` + `billing` + `polarSignature` (convex vitest config)
- `npm run build` (tsc -b + vite) green

## Acceptance criteria (#236)
- [x] Billing model documented (packages vs credits, trial, manual enterprise, refund rules)
- [x] Products/prices in config/metadata, not hard-coded UI — `billingPlans.ts` + env-resolved IDs
- [x] Checkout creates-or-resumes a customer (`ensureBillingCustomer`)
- [x] Signed webhook grants entitlement/credits idempotently by order/subscription/event id — **now proven against real event shapes through the route**
- [x] Billing/portal link in app (Billing page "Manage billing")
- [x] Payment state isolated from trace data (4 billing tables; scalar-only sanitizer)
- [x] Tests cover webhook signature/idempotency + ledger/entitlement
- [x] Docs include cutover/rollback + local testing

## Boundary (not doable from here)
A real card→hosted-checkout→webhook round trip needs a deployed Convex endpoint + Polar dashboard webhook config; it's the documented cutover smoke test. The Polar MCP doesn't expose checkout creation, so the *outbound* checkout/portal calls weren't exercised live — their request shapes match the API schema and the load-bearing metadata-propagation assumption is confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)