### PR TITLE
feat(ingest): native eval-record v1 JSON endpoint as the public contract

### DIFF
--- a/convex/http.ts
+++ b/convex/http.ts
@@ -4,6 +4,7 @@ import { internal } from "./_generated/api";
 import { auth } from "./auth";
 import { verifyWebhook } from "./lib/polarSignature";
 import { otlpIngestHandler } from "./otlpIngest";
+import { nativeIngestHandler } from "./nativeIngest";
 
 const http = httpRouter();
 
@@ -167,6 +168,27 @@ http.route({
 });
 http.route({
   path: "/otlp/v1/traces",
+  method: "OPTIONS",
+  handler: httpAction(async () => {
+    return new Response(null, {
+      status: 204,
+      headers: {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Methods": "POST, OPTIONS",
+        "Access-Control-Allow-Headers": "Content-Type, Authorization, x-blindbench-ingest-token",
+      },
+    });
+  }),
+});
+
+// --- Native `eval-record` v1 JSON trace ingest (per-project token auth) ---
+http.route({
+  path: "/ingest/v1/traces",
+  method: "POST",
+  handler: nativeIngestHandler,
+});
+http.route({
+  path: "/ingest/v1/traces",
   method: "OPTIONS",
   handler: httpAction(async () => {
     return new Response(null, {

--- a/convex/nativeIngest.ts
+++ b/convex/nativeIngest.ts
@@ -1,0 +1,150 @@
+/**
+ * Native JSON trace ingest. A public endpoint (mounted in http.ts) authenticated
+ * by the same per-project ingest token as the OTLP path (#263) — Blind Bench never
+ * holds the customer's gateway credential (BYOK). Unlike OTLP, this accepts Blind
+ * Bench's own versioned public schema (`eval-record` v1: one record = one model
+ * interaction) directly, so a customer's harness can emit it with no OTel envelope.
+ *
+ * Records normalize into the same `AgentRunTrace` spine (via normalizeEvalRecordV1)
+ * and persist through the shared token-authed storeTraceSteps path. Body accepts a
+ * bare array, `{records:[]}`, or a single object. Dedup by (source "native",
+ * sourceTraceId); a bad record is counted (`invalid`) and skipped, never failing
+ * the whole batch. Counts-only response (never echoes trace content).
+ */
+import { httpAction } from "./_generated/server";
+import { internal } from "./_generated/api";
+import type { Id } from "./_generated/dataModel";
+import { MAX_BYTES, json, readToken } from "./otlpIngest";
+import { normalizeEvalRecordV1 } from "./lib/agentTrace";
+import { storeTraceSteps } from "./agentTraces";
+
+// ponytail: batch caps bound per-request work (storage writes) against a token
+// holder POSTing a huge/amplified body; raise if real batches legitimately exceed.
+const MAX_RECORDS = 1000;
+const MAX_TOTAL_STEPS = 10_000;
+
+export const nativeIngestHandler = httpAction(async (ctx, req) => {
+  const token = readToken(req);
+  if (!token) return json({ error: "Missing ingest token" }, 401);
+  const resolved = await ctx.runQuery(internal.otlpIngest.resolveIngestToken, { token });
+  if (!resolved) return json({ error: "Invalid or revoked ingest token" }, 401);
+
+  const body = await req.text();
+  // UTF-8 byte length, not JS string length (which undercounts multibyte content).
+  if (new TextEncoder().encode(body).length > MAX_BYTES) {
+    return json({ error: "Payload too large" }, 413);
+  }
+  let payload: unknown;
+  try {
+    payload = JSON.parse(body);
+  } catch {
+    return json({ error: "Invalid JSON" }, 400);
+  }
+
+  const asRec = (v: unknown): Record<string, unknown> | undefined =>
+    v && typeof v === "object" && !Array.isArray(v) ? (v as Record<string, unknown>) : undefined;
+  const envelope = asRec(payload);
+  const records: unknown[] = Array.isArray(payload)
+    ? payload
+    : Array.isArray(envelope?.records)
+      ? (envelope!.records as unknown[])
+      : [payload];
+  if (records.length > MAX_RECORDS) {
+    return json({ error: `Too many records (max ${MAX_RECORDS} per request)` }, 413);
+  }
+
+  // Persist the raw request once for provenance / re-parse; link to new imports.
+  let rawStorageId: Id<"_storage"> | undefined;
+  try {
+    rawStorageId = await ctx.storage.store(new Blob([body], { type: "application/json" }));
+  } catch {
+    rawStorageId = undefined;
+  }
+
+  let traces = 0;
+  let imported = 0;
+  let deduped = 0;
+  let steps = 0;
+  let responseMissing = 0;
+  let invalid = 0;
+  let truncated = false;
+  // Count of new import rows created; each references rawStorageId, so the blob
+  // is orphaned (safe to delete) only when this stays 0.
+  let importRowsCreated = 0;
+  // `requestMissing` cannot occur: normalizeEvalRecordV1 rejects an empty
+  // input.messages, so such records are counted as `invalid` instead.
+  const requestMissing = 0;
+
+  for (const record of records) {
+    let trace;
+    try {
+      trace = normalizeEvalRecordV1(record);
+    } catch {
+      invalid++;
+      continue;
+    }
+    // Bound total storage writes per request regardless of record count.
+    if (steps + trace.steps.length > MAX_TOTAL_STEPS) {
+      truncated = true;
+      break;
+    }
+    traces++;
+
+    const sourceTraceId = trace.run_id ?? trace.trace_id;
+    const imp = await ctx.runMutation(internal.otlpIngest.insertIngestImport, {
+      projectId: resolved.projectId,
+      importedById: resolved.createdById,
+      source: "native",
+      sourceTraceId,
+      rawPayloadStorageId: rawStorageId,
+    });
+    if (imp.deduped) {
+      deduped++;
+      continue;
+    }
+    importRowsCreated++;
+    const parent = await ctx.runMutation(internal.agentTraces.insertTraceParentForIngest, {
+      projectId: resolved.projectId,
+      importedById: resolved.createdById,
+      traceImportId: imp.importId,
+      traceId: trace.trace_id,
+      harnessName: trace.harness.name,
+      harnessVersion: trace.harness.version,
+      harnessSdk: trace.harness.sdk,
+      product: trace.product,
+      module: trace.module,
+      environment: trace.environment,
+      model: trace.model,
+      runId: trace.run_id,
+      stepCount: trace.steps.length,
+      privacyClass: trace.privacy.class,
+      costUsd: trace.usage.cost_usd,
+      durationMs: trace.usage.duration_ms,
+      totalTokens: trace.usage.total_tokens,
+    });
+    if (parent.deduped) {
+      deduped++;
+      continue;
+    }
+    await storeTraceSteps(ctx, parent.agentTraceId, trace);
+    steps += trace.steps.length;
+    imported++;
+    // Count only records actually imported (docs define responseMissing that way).
+    if (trace.final_answer === undefined) responseMissing++;
+  }
+
+  // Drop the raw-body blob if it ended up referenced by no new import row.
+  if (importRowsCreated === 0 && rawStorageId) {
+    try {
+      await ctx.storage.delete(rawStorageId);
+    } catch {
+      /* best-effort cleanup */
+    }
+  }
+
+  await ctx.runMutation(internal.otlpIngest.touchIngestToken, { token });
+  return json(
+    { traces, imported, deduped, steps, requestMissing, responseMissing, invalid, truncated },
+    200,
+  );
+});

--- a/convex/otlpIngest.ts
+++ b/convex/otlpIngest.ts
@@ -15,15 +15,15 @@ import { mapOtlpToTraces } from "./lib/otelGenAI";
 import { storeTraceSteps } from "./agentTraces";
 import type { AgentRunTrace } from "./lib/agentTrace";
 
-const MAX_BYTES = 8 * 1024 * 1024;
+export const MAX_BYTES = 8 * 1024 * 1024;
 
-const json = (body: unknown, status: number): Response =>
+export const json = (body: unknown, status: number): Response =>
   new Response(JSON.stringify(body), {
     status,
     headers: { "Content-Type": "application/json" },
   });
 
-const readToken = (req: Request): string | undefined => {
+export const readToken = (req: Request): string | undefined => {
   const auth = req.headers.get("authorization");
   if (auth?.toLowerCase().startsWith("bearer ")) return auth.slice(7).trim();
   return req.headers.get("x-blindbench-ingest-token")?.trim() || undefined;
@@ -55,11 +55,19 @@ export const touchIngestToken = internalMutation({
   },
 });
 
-/** Dedup + insert an otlp traceImport for provenance/raw retention. */
-export const insertOtlpImport = internalMutation({
+/** The token-authed ingest sources that share this import-row path (#263). */
+export const ingestSourceValidator = v.union(v.literal("otlp"), v.literal("native"));
+
+/**
+ * Dedup + insert a traceImport for provenance/raw retention. Shared by both the
+ * OTLP and native ingest endpoints — `source` is passed by the caller so the
+ * dedup key `(source, sourceTraceId)` stays correct per endpoint.
+ */
+export const insertIngestImport = internalMutation({
   args: {
     projectId: v.id("projects"),
     importedById: v.id("users"),
+    source: ingestSourceValidator,
     sourceTraceId: v.string(),
     rawPayloadStorageId: v.optional(v.id("_storage")),
   },
@@ -70,14 +78,14 @@ export const insertOtlpImport = internalMutation({
     const existing = await ctx.db
       .query("traceImports")
       .withIndex("by_source_trace", (q) =>
-        q.eq("source", "otlp").eq("sourceTraceId", args.sourceTraceId),
+        q.eq("source", args.source).eq("sourceTraceId", args.sourceTraceId),
       )
       .filter((q) => q.eq(q.field("projectId"), args.projectId))
       .first();
     if (existing) return { importId: existing._id, deduped: true };
     const importId = await ctx.db.insert("traceImports", {
       projectId: args.projectId,
-      source: "otlp",
+      source: args.source,
       sourceTraceId: args.sourceTraceId,
       importedById: args.importedById,
       rawPayloadStorageId: args.rawPayloadStorageId,
@@ -115,9 +123,10 @@ export const otlpIngestHandler = httpAction(async (ctx, req) => {
   let deduped = 0;
   for (const trace of traces as AgentRunTrace[]) {
     const sourceTraceId = trace.run_id ?? trace.trace_id;
-    const imp = await ctx.runMutation(internal.otlpIngest.insertOtlpImport, {
+    const imp = await ctx.runMutation(internal.otlpIngest.insertIngestImport, {
       projectId: resolved.projectId,
       importedById: resolved.createdById,
+      source: "otlp",
       sourceTraceId,
       rawPayloadStorageId: rawStorageId,
     });

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -640,6 +640,8 @@ const schema = defineSchema({
       v.literal("claude_code"),
       // #263: OTLP Gen-AI span push (Cloudflare AI Gateway + any OTel source).
       v.literal("otlp"),
+      // Native `eval-record` v1 JSON push — Blind Bench's own public ingest schema.
+      v.literal("native"),
     ),
     // Provider's stable trace identifier when available — manual_paste imports
     // don't have one. Combined with `source` it forms the dedup key.

--- a/convex/tests/nativeIngest.test.ts
+++ b/convex/tests/nativeIngest.test.ts
@@ -1,0 +1,187 @@
+/// <reference types="vite/client" />
+import { convexTest } from "convex-test";
+import { describe, expect, test } from "vitest";
+import { api } from "../_generated/api";
+import schema from "../schema";
+import { normalizeEvalRecordV1 } from "../lib/agentTrace";
+
+// One eval-record v1: a two-message request + assistant output with a tool call.
+const validRecord = {
+  version: "1",
+  id: "rec-abc",
+  timestamp: "2026-07-08T00:00:00Z",
+  model: "gpt-4",
+  provider: "openai",
+  input: {
+    messages: [
+      { role: "system", content: "You are helpful." },
+      { role: "user", content: "What is 2+2?" },
+    ],
+  },
+  output: {
+    content: "4",
+    tool_calls: [{ id: "call-1", name: "calc", arguments: { expr: "2+2" } }],
+    tool_results: [{ tool_call_id: "call-1", name: "calc", result: 4 }],
+  },
+  usage: { input_tokens: 10, output_tokens: 5, cost_usd: 0.001, duration_ms: 42 },
+};
+
+async function seed(t: ReturnType<typeof convexTest>) {
+  const ids = await t.run(async (ctx) => {
+    const ownerUserId = await ctx.db.insert("users", { name: "Owner", email: "o@test.com" });
+    const orgId = await ctx.db.insert("organizations", { name: "Org", slug: "org", createdById: ownerUserId });
+    await ctx.db.insert("organizationMembers", { organizationId: orgId, userId: ownerUserId, role: "owner" });
+    const projectId = await ctx.db.insert("projects", { organizationId: orgId, name: "P", createdById: ownerUserId });
+    await ctx.db.insert("projectCollaborators", { projectId, userId: ownerUserId, role: "owner", invitedById: ownerUserId, invitedAt: Date.now() });
+    return { ownerUserId, projectId };
+  });
+  return { ids, asOwner: t.withIdentity({ subject: `${ids.ownerUserId}|s`, tokenIdentifier: `test|${ids.ownerUserId}` }) };
+}
+
+describe("native eval-record v1 normalizer (pure)", () => {
+  test("maps request messages, output content, tool call/result into steps", () => {
+    const trace = normalizeEvalRecordV1(validRecord);
+    // trace_id is namespaced (native-) so a client id can't collide with another
+    // source's parent trace; run_id stays the raw id for source-scoped dedup.
+    expect(trace.trace_id).toBe("native-rec-abc");
+    expect(trace.run_id).toBe("rec-abc");
+    expect(trace.model).toBe("gpt-4");
+    expect(trace.harness.name).toBe("openai");
+    expect(trace.product).toBe("openai");
+    // 2 request messages + 1 assistant message + 1 tool_call + 1 tool_result
+    expect(trace.steps.map((s) => s.type)).toEqual([
+      "message",
+      "message",
+      "message",
+      "tool_call",
+      "tool_result",
+    ]);
+    const contents = trace.steps.flatMap((s) => (s.type === "message" ? [s.message.content] : []));
+    expect(contents).toEqual(["You are helpful.", "What is 2+2?", "4"]);
+    expect(trace.final_answer).toBe("4");
+    expect(trace.usage.total_tokens).toBe(15);
+    expect(trace.usage.cost_usd).toBe(0.001);
+    expect(trace.usage.duration_ms).toBe(42);
+    expect(trace.source_ids).toEqual({ record_id: "rec-abc", provider: "openai" });
+  });
+
+  test("throws on missing version", () => {
+    expect(() => normalizeEvalRecordV1({ input: { messages: [{ role: "user", content: "hi" }] } })).toThrow(/version/);
+  });
+
+  test("throws on missing/empty input.messages", () => {
+    expect(() => normalizeEvalRecordV1({ version: "1", input: { messages: [] } })).toThrow(/messages/);
+    expect(() => normalizeEvalRecordV1({ version: "1" })).toThrow(/messages/);
+  });
+
+  test("derives a deterministic trace_id when id is absent", () => {
+    const { id: _omit, ...noId } = validRecord;
+    const a = normalizeEvalRecordV1(noId);
+    const b = normalizeEvalRecordV1(noId);
+    expect(a.trace_id).toBe(b.trace_id);
+    expect(a.trace_id).toMatch(/^native-[0-9a-f]{16}$/);
+  });
+
+  test("id-less records differing only in usage derive distinct trace_ids", () => {
+    const { id: _omit, ...base } = validRecord;
+    const a = normalizeEvalRecordV1(base);
+    const b = normalizeEvalRecordV1({ ...base, usage: { ...base.usage, cost_usd: 9.99 } });
+    expect(a.trace_id).not.toBe(b.trace_id);
+  });
+
+  test("explicit privacy_class raises but never lowers computed sensitivity", () => {
+    // sensitive tool arg → computed pii; explicit "public" must not downgrade it.
+    const sensitive = {
+      version: "1",
+      input: { messages: [{ role: "user", content: "hi" }] },
+      output: { tool_calls: [{ name: "lookup", arguments: { ssn: "123-45-6789" } }] },
+      privacy_class: "public",
+    };
+    expect(normalizeEvalRecordV1(sensitive).privacy.class).toBe("pii");
+  });
+
+  test("rejects malformed output fields (counted invalid by caller)", () => {
+    const bad = {
+      version: "1",
+      input: { messages: [{ role: "user", content: "hi" }] },
+      output: { tool_calls: [{ name: 123, arguments: "not-object" }] },
+    };
+    expect(() => normalizeEvalRecordV1(bad)).toThrow(/tool_calls/);
+  });
+});
+
+describe("native HTTP ingest end-to-end", () => {
+  test("token-authed POST persists a trajectory through the spine; re-POST dedups", async () => {
+    const t = convexTest(schema);
+    const { ids, asOwner } = await seed(t);
+    const { token } = await asOwner.mutation(api.ingestTokens.issueIngestToken, { projectId: ids.projectId, label: "t" });
+
+    const post = (b: unknown) =>
+      t.fetch("/ingest/v1/traces", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+        body: JSON.stringify(b),
+      });
+
+    const res = await post(validRecord);
+    expect(res.status).toBe(200);
+    const summary = await res.json();
+    expect(summary.traces).toBe(1);
+    expect(summary.imported).toBe(1);
+    expect(summary.steps).toBe(5);
+    expect(summary.invalid).toBe(0);
+
+    // Persisted as an agentTrace with steps, source native import linked.
+    const persisted = await t.run(async (ctx) => {
+      const trace = await ctx.db.query("agentTraces").first();
+      const steps = trace
+        ? await ctx.db.query("agentTraceSteps").withIndex("by_trace_and_index", (q) => q.eq("agentTraceId", trace._id)).collect()
+        : [];
+      const imp = trace?.traceImportId ? await ctx.db.get(trace.traceImportId) : null;
+      return { status: trace?.status, stepCount: steps.length, source: imp?.source };
+    });
+    expect(persisted.status).toBe("ready");
+    expect(persisted.stepCount).toBe(5);
+    expect(persisted.source).toBe("native");
+
+    // Idempotent re-POST of the same id.
+    const again = await (await post(validRecord)).json();
+    expect(again.imported).toBe(0);
+    expect(again.deduped).toBe(1);
+    const traceCount = await t.run(async (ctx) => (await ctx.db.query("agentTraces").collect()).length);
+    expect(traceCount).toBe(1);
+  });
+
+  test("accepts a {records:[]} batch; one bad record is counted invalid, good ones imported", async () => {
+    const t = convexTest(schema);
+    const { ids, asOwner } = await seed(t);
+    const { token } = await asOwner.mutation(api.ingestTokens.issueIngestToken, { projectId: ids.projectId, label: "t" });
+
+    const good = { ...validRecord, id: "rec-good" };
+    const bad = { version: "1", input: { messages: [] } }; // empty messages → invalid
+    const res = await t.fetch("/ingest/v1/traces", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+      body: JSON.stringify({ records: [good, bad] }),
+    });
+    expect(res.status).toBe(200);
+    const summary = await res.json();
+    expect(summary.imported).toBe(1);
+    expect(summary.invalid).toBe(1);
+    const traceCount = await t.run(async (ctx) => (await ctx.db.query("agentTraces").collect()).length);
+    expect(traceCount).toBe(1);
+  });
+
+  test("missing or invalid token is rejected 401", async () => {
+    const t = convexTest(schema);
+    await seed(t);
+    const noToken = await t.fetch("/ingest/v1/traces", { method: "POST", body: "{}" });
+    expect(noToken.status).toBe(401);
+    const badToken = await t.fetch("/ingest/v1/traces", {
+      method: "POST",
+      headers: { Authorization: "Bearer deadbeef" },
+      body: "{}",
+    });
+    expect(badToken.status).toBe(401);
+  });
+});

--- a/docs/agent-harness-traces.md
+++ b/docs/agent-harness-traces.md
@@ -30,7 +30,13 @@ Expected fields are intentionally simple:
 }
 ```
 
-No SDK integration is required yet. The capture path is intentionally export/import first.
+No SDK integration is required for this export shape. Beyond it, a **native HTTP
+ingest endpoint** now exists — `POST /ingest/v1/traces` on `{deployment}.convex.site`,
+authenticated by a per-project ingest token — so a harness can push traces live
+without an export/import step. It accepts the versioned `eval-record` v1 schema
+(one record = one model interaction), which normalizes into the same
+`AgentRunTrace` spine described below. See [`native-ingest.md`](./native-ingest.md)
+for the full contract.
 
 ## Normalized shape
 
@@ -119,5 +125,8 @@ The eval case stores messages and scorer-visible tool/policy context while keepi
 
 - No LangGraph/LangSmith/Phoenix replacement.
 - No sandboxed agent execution yet.
-- No automatic capture from production Jeeves agents yet.
+- Live capture exists via the native ingest endpoint (`/ingest/v1/traces`, see
+  [`native-ingest.md`](./native-ingest.md)) and OTLP; there is still no
+  auto-instrumentation baked into the Jeeves agents themselves — the harness must
+  emit records to the endpoint.
 - No customer production data committed to the repo.

--- a/docs/cloudflare-gateway-live-import.md
+++ b/docs/cloudflare-gateway-live-import.md
@@ -4,6 +4,10 @@ Import production prompt traffic from a customer-owned Cloudflare AI Gateway
 into Blind Bench as deduplicated trace imports, so it can become a measurable
 eval set.
 
+> **Contract of record:** this gateway import is an *adapter*. The durable public
+> ingest contract is the native `eval-record` v1 schema in
+> [`native-ingest.md`](./native-ingest.md); gateway logs normalize into it.
+
 **Blind Bench makes no calls to Cloudflare.** The customer exports logs from
 their own gateway and pastes/uploads them. This keeps the data boundary
 one-directional and avoids holding any Cloudflare credentials.

--- a/docs/gateway-onboarding.md
+++ b/docs/gateway-onboarding.md
@@ -1,5 +1,12 @@
 # Cloudflare AI Gateway — user onboarding guide
 
+> **This is the Cloudflare gateway *adapter* path.** The durable public contract
+> for getting model interactions into Blind Bench is the native `eval-record` v1
+> schema — see [`native-ingest.md`](./native-ingest.md). This gateway import
+> normalizes gateway logs *into* that same schema; it is one of several adapters,
+> not the source of truth. **If you don't have a Cloudflare AI Gateway, skip this
+> doc and POST native JSON** per [`native-ingest.md`](./native-ingest.md).
+
 End-to-end checklist for a Blind Bench user to take a Cloudflare AI Gateway from
 "logs exist somewhere" to "I have a baseline scorecard and a shortlist of rows
 worth training on." It stitches together the pieces that already ship:

--- a/docs/native-ingest.md
+++ b/docs/native-ingest.md
@@ -1,0 +1,259 @@
+# Native JSON ingest — the `eval-record` v1 contract
+
+Blind Bench's own versioned native schema is the **durable public contract** for
+getting model interactions into a project. OTLP and the Cloudflare AI Gateway
+import are **adapters** that normalize *into* this same schema — they are not
+separate products. Concretely:
+
+- **Native JSON (this doc)** — POST `eval-record` v1 records straight to Blind
+  Bench. This is the contract of record; nothing else here is more authoritative.
+- **OTLP** — POST OpenTelemetry GenAI spans to `/otlp/v1/traces`. A customer with
+  a gateway (or any OTel exporter) points it here for **live** capture; Blind
+  Bench normalizes the spans into `eval-record` v1 on arrival.
+- **Cloudflare AI Gateway import** — export/upload gateway logs to backfill. See
+  [`gateway-onboarding.md`](./gateway-onboarding.md) for that adapter path end to
+  end.
+
+**You do not need to adopt OpenTelemetry to use Blind Bench.** If you have a
+gateway, point its OTLP exporter at `/otlp/v1/traces` (live) or upload logs to
+backfill. If you don't, POST the native JSON described here. All three paths land
+in the same normalized trace store.
+
+---
+
+## Endpoint
+
+```
+POST https://{deployment}.convex.site/ingest/v1/traces
+Content-Type: application/json
+```
+
+> **⚠️ Use `.convex.site`, not `.convex.cloud`.** HTTP actions (this endpoint and
+> the OTLP one) are served from the `.convex.site` host. The `.convex.cloud` host
+> serves the query/mutation API and will not route `/ingest/v1/traces`.
+
+## Auth
+
+Per-project **ingest token** — the **same tokens as the OTLP endpoint**. Send it
+either way:
+
+```
+Authorization: Bearer <token>
+```
+
+or
+
+```
+x-blindbench-ingest-token: <token>
+```
+
+Tokens are issued and revoked on the project's **Ingest** tab. Each token is
+scoped to exactly one project, so ingestion is **per-project isolated** — a
+token can never write to another project's traces. A missing or revoked token
+returns **401**; Blind Bench holds **no customer credentials** of its own (BYOK —
+the customer's provider/gateway keys never reach Blind Bench).
+
+---
+
+## The `eval-record` v1 schema
+
+**One record = one model interaction.** All fields:
+
+| Field | Required | Type | Notes |
+| --- | --- | --- | --- |
+| `version` | **required** | string | Must be `"1"`. |
+| `id` | optional | string | Dedup key — re-POSTing the same `id` is idempotent (counted as `deduped`, never re-imported). If omitted, a deterministic id is derived from record content. |
+| `timestamp` | optional | string | ISO-8601. |
+| `model` | recommended | string | e.g. `"anthropic/claude-4.7-opus"`. |
+| `provider` | recommended | string | e.g. `"anthropic"`. |
+| `input` | **required** | object | `{ "messages": [{ "role": string, "content": string }] }`. Must be a **non-empty** `messages` array; each message needs string `role` and `content`. |
+| `output` | optional | object | See [output shape](#output-shape) below. |
+| `usage` | optional | object | `{ "input_tokens"?, "output_tokens"?, "total_tokens"?, "cost_usd"?, "duration_ms"? }` — all numbers. If `total_tokens` is omitted but both `input_tokens` and `output_tokens` are present, it is summed. |
+| `product` | optional | string | Grouping. |
+| `module` | optional | string | Grouping. |
+| `environment` | optional | string | Grouping, e.g. `"prod"` / `"staging"` / `"dev"`. |
+| `harness` | optional | object | `{ "name"?, "version"?, "sdk"? }` — the SDK/tool that emitted the record. |
+| `metadata` | optional | object | Arbitrary object, stored as-is. |
+| `privacy_class` | optional | string | One of `"public" \| "internal" \| "confidential" \| "pii" \| "phi"`. If set it is honored as an explicit governance signal; if omitted it is inferred (records with redacted sensitive fields infer `pii`, else `internal`). |
+
+### Output shape
+
+`output` is optional; every sub-field is optional:
+
+```json
+{
+  "content": "string — the assistant's text answer",
+  "tool_calls": [
+    { "id": "call-1", "name": "lookup_account", "arguments": { "id": "A-42" } }
+  ],
+  "tool_results": [
+    { "tool_call_id": "call-1", "name": "lookup_account", "result": { "status": "active" } }
+  ]
+}
+```
+
+- `tool_calls[]` — `{ "id"?: string, "name": string, "arguments": object }`.
+- `tool_results[]` — `{ "tool_call_id": string, "name"?: string, "result"?: any }`.
+
+A record with no `output.content` is still valid; it is counted in
+`responseMissing` (see [response](#response)) but imported.
+
+---
+
+## Batching
+
+The endpoint accepts any of three envelope shapes:
+
+- a **single record** object,
+- a **bare JSON array** of records, or
+- `{ "records": [ … ] }`.
+
+A malformed **individual record** is counted in `invalid` and skipped — the batch
+does **not** fail. A malformed **JSON envelope** (unparseable body) returns
+**400**; a **missing/invalid token** returns **401**; an oversized body returns
+**413**.
+
+---
+
+## Response (counts-only)
+
+`200` responses are **counts only** — the endpoint **never echoes prompt or
+output content**:
+
+```json
+{
+  "traces": 0,
+  "imported": 0,
+  "deduped": 0,
+  "steps": 0,
+  "requestMissing": 0,
+  "responseMissing": 0,
+  "invalid": 0,
+  "truncated": false
+}
+```
+
+| Field | Meaning |
+| --- | --- |
+| `traces` | Records that normalized successfully (valid `eval-record` v1). |
+| `imported` | New traces persisted this request. |
+| `deduped` | Records skipped as duplicates of an already-stored `id`. |
+| `steps` | Total trace steps stored (messages + tool calls/results across imported traces). |
+| `requestMissing` | Always `0` — a record with no `input.messages` is rejected as `invalid` instead. |
+| `responseMissing` | Imported records that carried no `output.content`. |
+| `invalid` | Malformed records skipped (does not fail the batch). |
+| `truncated` | `true` if the batch hit the per-request step cap and stopped early — resend the remainder. |
+
+### Limits
+
+- **8 MB** max request body (UTF-8), **1000** records per request, **2000** messages per record, **10,000** total steps per request. Over the body/record limit → `413`; over the step cap → the batch stops and `truncated` is `true`. Split larger exports into batches.
+
+---
+
+## Idempotency & dedup
+
+Dedup is keyed on `(source "native", id)`. Re-POSTing a record with the same `id`
+is a no-op that reports as `deduped` — safe to retry a batch after a network
+failure without double-counting. Omit `id` and a deterministic id is derived from
+the record's content, so byte-identical records still dedup; records that differ
+in any content get distinct derived ids.
+
+---
+
+## Data & redaction boundary
+
+- **Per-project isolation.** The ingest token scopes every write to one project.
+  Blind Bench holds no customer credentials; there is no outbound call to your
+  provider or gateway.
+- **Counts-only responses.** The endpoint returns aggregate counts and never
+  echoes stored prompt/output content.
+- **Server-side redaction at ingest.** Redaction is **key-name based**: fields
+  inside tool arguments, tool results, and state whose key matches a sensitive
+  category — `ssn` / `social`, `phone`, `email`, `address`, `token`, `secret`,
+  `password`, `account_number`, `card`, `dob` — are replaced with `[REDACTED]`
+  for blind/reviewer views before storage.
+- **Free-text is not auto-scrubbed.** Key-redaction does **not** scan free-text
+  `input.messages[].content` or `output.content` for secrets. **Do not send
+  secrets in message or answer text that you don't want stored.**
+
+---
+
+## Example — single record
+
+```bash
+curl -X POST "https://{deployment}.convex.site/ingest/v1/traces" \
+  -H "Authorization: Bearer $BLINDBENCH_INGEST_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "version": "1",
+    "id": "req-2026-07-08-0001",
+    "timestamp": "2026-07-08T14:03:21Z",
+    "model": "anthropic/claude-4.7-opus",
+    "provider": "anthropic",
+    "product": "support-assistant",
+    "module": "assistant",
+    "environment": "prod",
+    "input": {
+      "messages": [
+        { "role": "system", "content": "You are a support agent." },
+        { "role": "user", "content": "Where is my order?" }
+      ]
+    },
+    "output": {
+      "content": "Your order shipped yesterday and arrives Thursday.",
+      "tool_calls": [
+        { "id": "call-1", "name": "lookup_order", "arguments": { "order_id": "O-42" } }
+      ],
+      "tool_results": [
+        { "tool_call_id": "call-1", "name": "lookup_order", "result": { "status": "shipped" } }
+      ]
+    },
+    "usage": { "input_tokens": 210, "output_tokens": 34, "cost_usd": 0.004, "duration_ms": 1180 },
+    "harness": { "name": "support-svc", "version": "1.4.0", "sdk": "blindbench-native" },
+    "privacy_class": "internal",
+    "metadata": { "tenant": "acme", "prompt_version": "v7" }
+  }'
+```
+
+## Example — batch
+
+```bash
+curl -X POST "https://{deployment}.convex.site/ingest/v1/traces" \
+  -H "Authorization: Bearer $BLINDBENCH_INGEST_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "records": [
+      {
+        "version": "1",
+        "id": "req-0001",
+        "model": "anthropic/claude-4.7-opus",
+        "provider": "anthropic",
+        "input": { "messages": [{ "role": "user", "content": "Summarize this ticket." }] },
+        "output": { "content": "Customer reports a billing discrepancy." }
+      },
+      {
+        "version": "1",
+        "id": "req-0002",
+        "model": "anthropic/claude-4.7-sonnet",
+        "provider": "anthropic",
+        "input": { "messages": [{ "role": "user", "content": "Draft a reply." }] },
+        "output": { "content": "Hi — thanks for flagging this…" },
+        "usage": { "input_tokens": 88, "output_tokens": 120 }
+      }
+    ]
+  }'
+```
+
+A bare array (`[ {…}, {…} ]`) is accepted identically.
+
+---
+
+## Related
+
+- [`gateway-onboarding.md`](./gateway-onboarding.md) — the Cloudflare AI Gateway
+  **adapter** path (export/upload logs to backfill), end to end.
+- [`cloudflare-gateway-live-import.md`](./cloudflare-gateway-live-import.md) — the
+  gateway log import mechanics.
+- **OTLP endpoint** — `POST /otlp/v1/traces` on the same `.convex.site` host,
+  authenticated by the **same** per-project ingest tokens. Use it for live
+  OTel-based capture; it normalizes into this same `eval-record` v1 spine.

--- a/src/components/SideNavContent.tsx
+++ b/src/components/SideNavContent.tsx
@@ -99,7 +99,7 @@ export function SideNavContent({
         onClick={onNavigate}
       >
         <Plug aria-hidden="true" className="h-4 w-4 shrink-0" />
-        Gateway onboarding
+        Ingest &amp; onboarding
       </NavLink>
       <NavLink
         to={`/orgs/${org.slug}/gateway-import`}

--- a/src/lib/evals/agentTrace.core.ts
+++ b/src/lib/evals/agentTrace.core.ts
@@ -231,6 +231,227 @@ export function normalizeJeevesClogRun(
   };
 }
 
+/**
+ * Blind Bench's own public ingest schema: `eval-record` v1. One record = one
+ * model interaction (the request messages plus the model's output). Mirrors the
+ * shape a customer's harness can emit directly (no OTLP/OTel envelope), and
+ * normalizes into the same `AgentRunTrace` spine everything else flows through.
+ */
+export interface EvalRecordV1 {
+  version: "1";
+  id?: string;
+  timestamp?: string;
+  model?: string;
+  provider?: string;
+  input: { messages: { role: string; content: string }[] };
+  output?: {
+    content?: string;
+    tool_calls?: { id?: string; name: string; arguments: Record<string, unknown> }[];
+    tool_results?: { tool_call_id: string; name?: string; result?: unknown }[];
+  };
+  usage?: {
+    input_tokens?: number;
+    output_tokens?: number;
+    total_tokens?: number;
+    cost_usd?: number;
+    duration_ms?: number;
+  };
+  product?: string;
+  module?: string;
+  environment?: string;
+  harness?: { name?: string; version?: string; sdk?: string };
+  metadata?: Record<string, unknown>;
+  privacy_class?: PrivacyClass;
+}
+
+const PRIVACY_CLASSES: readonly string[] = ["public", "internal", "confidential", "pii", "phi"];
+const asPrivacyClass = (v: unknown): PrivacyClass | undefined =>
+  typeof v === "string" && PRIVACY_CLASSES.includes(v) ? (v as PrivacyClass) : undefined;
+/** More sensitive of two classes (by PRIVACY_CLASSES order); explicit may raise, never lower. */
+const maxPrivacyClass = (a: PrivacyClass, b: PrivacyClass): PrivacyClass =>
+  PRIVACY_CLASSES.indexOf(a) >= PRIVACY_CLASSES.indexOf(b) ? a : b;
+const MAX_EVAL_RECORD_MESSAGES = 2000;
+
+/**
+ * Normalize a public `eval-record` v1 payload into an `AgentRunTrace`. Structure
+ * and redaction MIRROR `normalizeJeevesClogRun` (same `normalizeStep` helper,
+ * same privacy computation) — the only difference is the source schema shape.
+ */
+export function normalizeEvalRecordV1(
+  raw: unknown,
+  options: { privacyMode?: PrivacyMode } = {},
+): AgentRunTrace {
+  // ponytail: hand-rolled validation; move to zod at the convex boundary if error ergonomics matter
+  const root = asRecord(raw);
+  if (!root) throw new Error("eval-record v1: root must be an object");
+  if (root.version !== "1") throw new Error('eval-record v1: version must be "1"');
+  const input = asRecord(root.input);
+  const messagesRaw = input?.messages;
+  if (!Array.isArray(messagesRaw) || messagesRaw.length === 0) {
+    throw new Error("eval-record v1: input.messages must be a non-empty array");
+  }
+  // ponytail: per-record cap bounds per-request storage writes; raise if real
+  // traces legitimately exceed it (the handler also caps records + total steps).
+  if (messagesRaw.length > MAX_EVAL_RECORD_MESSAGES) {
+    throw new Error(`eval-record v1: input.messages exceeds ${MAX_EVAL_RECORD_MESSAGES}`);
+  }
+  const messages: Message[] = messagesRaw.map((m, i) => {
+    const o = asRecord(m);
+    if (typeof o?.role !== "string" || typeof o?.content !== "string") {
+      throw new Error(`eval-record v1: input.messages[${i}] must have string role and content`);
+    }
+    return { role: o.role, content: o.content };
+  });
+
+  // Validate optional output fields when present so malformed data is rejected
+  // (counted `invalid` by the caller) rather than silently coerced on normalize.
+  const outputRec = asRecord(root.output);
+  if (outputRec) {
+    if (outputRec.content !== undefined && typeof outputRec.content !== "string") {
+      throw new Error("eval-record v1: output.content must be a string");
+    }
+    if (outputRec.tool_calls !== undefined) {
+      if (!Array.isArray(outputRec.tool_calls)) {
+        throw new Error("eval-record v1: output.tool_calls must be an array");
+      }
+      outputRec.tool_calls.forEach((tc, i) => {
+        const o = asRecord(tc);
+        if (typeof o?.name !== "string" || asRecord(o?.arguments) === undefined) {
+          throw new Error(
+            `eval-record v1: output.tool_calls[${i}] must have string name and object arguments`,
+          );
+        }
+      });
+    }
+    if (outputRec.tool_results !== undefined) {
+      if (!Array.isArray(outputRec.tool_results)) {
+        throw new Error("eval-record v1: output.tool_results must be an array");
+      }
+      outputRec.tool_results.forEach((tr, i) => {
+        const o = asRecord(tr);
+        if (typeof o?.tool_call_id !== "string") {
+          throw new Error(`eval-record v1: output.tool_results[${i}] must have string tool_call_id`);
+        }
+      });
+    }
+  }
+
+  const privacyMode = options.privacyMode ?? "blind_view";
+  const id = str(root.id);
+  const provider = str(root.provider);
+  const model = str(root.model);
+  const timestamp = str(root.timestamp);
+  const output = asRecord(root.output);
+  const usage = asRecord(root.usage);
+  const harnessRaw = asRecord(root.harness);
+  const harnessName = str(harnessRaw?.name);
+
+  const steps: AgentTraceStep[] = [];
+  for (const message of messages) {
+    steps.push({ type: "message", index: steps.length, timestamp, message });
+  }
+  const outputContent = str(output?.content);
+  if (outputContent !== undefined) {
+    steps.push({
+      type: "message",
+      index: steps.length,
+      timestamp,
+      message: { role: "assistant", content: outputContent },
+    });
+  }
+  const toolCalls = Array.isArray(output?.tool_calls) ? output!.tool_calls : [];
+  for (const tc of toolCalls) {
+    const t = asRecord(tc) ?? {};
+    steps.push(
+      normalizeStep(
+        { type: "tool_call", id: t.id, name: t.name, arguments: t.arguments },
+        steps.length,
+        privacyMode,
+      ),
+    );
+  }
+  const toolResults = Array.isArray(output?.tool_results) ? output!.tool_results : [];
+  for (const tr of toolResults) {
+    const t = asRecord(tr) ?? {};
+    steps.push(
+      normalizeStep(
+        { type: "tool_result", tool_call_id: t.tool_call_id, name: t.name, result: t.result },
+        steps.length,
+        privacyMode,
+      ),
+    );
+  }
+
+  // Hash ALL public content fields so two id-less records differing in any of
+  // them derive distinct trace ids (contract promise), not just message/output.
+  const traceSeed = {
+    model,
+    provider,
+    timestamp,
+    messages,
+    output: root.output,
+    usage: root.usage,
+    product: str(root.product),
+    module: str(root.module),
+    environment: str(root.environment),
+    harness: root.harness,
+    metadata: root.metadata,
+    privacy_class: root.privacy_class,
+  };
+  const inTok = num(usage?.input_tokens);
+  const outTok = num(usage?.output_tokens);
+  const totalTokens =
+    num(usage?.total_tokens) ??
+    (inTok !== undefined && outTok !== undefined ? inTok + outTok : undefined);
+
+  const source_ids: Record<string, unknown> = {};
+  if (id !== undefined) source_ids.record_id = id;
+  if (provider !== undefined) source_ids.provider = provider;
+
+  const redactionNotes = steps.some((s) => stableStringify(s).includes("[REDACTED]"))
+    ? ["sensitive tool/state fields redacted for blind/reviewer views"]
+    : [];
+  const computedClass: PrivacyClass = steps.some(
+    (s) => "privacy_class" in s && s.privacy_class === "pii",
+  )
+    ? "pii"
+    : "internal";
+  // Explicit privacy_class (emitter governance signal) may RAISE sensitivity but
+  // never lower the class the redaction heuristic computed — no silent downgrade.
+  const explicitClass = asPrivacyClass(root.privacy_class);
+  const effectiveClass = explicitClass
+    ? maxPrivacyClass(explicitClass, computedClass)
+    : computedClass;
+
+  return {
+    // Namespace native trace ids (`native-`) so a client-supplied `id` can never
+    // collide with another source's parent trace (e.g. OTLP's `otlp-<id>`), which
+    // dedups by (projectId, traceId) across sources. run_id stays the raw id so
+    // source-scoped import dedup and re-POST idempotency are unaffected.
+    trace_id: id !== undefined ? `native-${id}` : `native-${hash(traceSeed)}`,
+    source: "agent_harness",
+    harness: harnessName
+      ? { name: harnessName, version: str(harnessRaw?.version), sdk: str(harnessRaw?.sdk) }
+      : { name: provider ?? "eval-record", sdk: "eval-record" },
+    product: str(root.product) ?? provider ?? "eval-record",
+    module: str(root.module),
+    environment: str(root.environment),
+    model,
+    run_id: id,
+    source_ids,
+    messages: [],
+    steps,
+    final_answer: outputContent,
+    usage: {
+      cost_usd: num(usage?.cost_usd),
+      duration_ms: num(usage?.duration_ms),
+      total_tokens: totalTokens,
+    },
+    privacy: { class: effectiveClass, redaction_notes: redactionNotes },
+    metadata: asRecord(root.metadata) ?? {},
+  };
+}
+
 export interface ScorerVisibleAgentRun {
   trace_id: string;
   harness: AgentRunTrace["harness"];

--- a/src/routes/orgs/GatewayOnboarding.tsx
+++ b/src/routes/orgs/GatewayOnboarding.tsx
@@ -282,6 +282,13 @@ export function GatewayOnboarding() {
         <h2 id="paths-heading" className="text-lg font-semibold">
           Two ways to feed logs in
         </h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Both paths below are gateway adapters — they get your existing
+          Cloudflare AI Gateway logs into Blind Bench. No gateway? You can skip
+          this entirely and POST Blind Bench's native JSON schema straight from
+          your app: open a project's <strong className="text-foreground">Ingest</strong>{" "}
+          tab for the endpoint, token, and a copyable <code>curl</code> example.
+        </p>
         <div className="mt-3 grid gap-4 sm:grid-cols-2">
           <Card>
             <CardHeader>

--- a/src/routes/orgs/projects/IngestEndpoint.tsx
+++ b/src/routes/orgs/projects/IngestEndpoint.tsx
@@ -11,13 +11,22 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { CopyButton } from "@/components/ui/copy-button";
 import { friendlyError } from "@/lib/errors";
 import { cn } from "@/lib/utils";
-import { Radio, ShieldAlert, KeyRound, Settings2 } from "lucide-react";
+import { Radio, ShieldAlert, KeyRound, Settings2, Braces } from "lucide-react";
 
 type IngestToken = FunctionReturnType<
   typeof api.ingestTokens.listIngestTokens
 >[number];
 
 type IssueResult = FunctionReturnType<typeof api.ingestTokens.issueIngestToken>;
+
+/** {CONVEX_SITE_URL}/ingest/v1/traces — native JSON path; httpActions serve on .convex.site. */
+function deriveNativeIngestUrl(): string {
+  const raw = (import.meta.env.VITE_CONVEX_URL ?? "").trim();
+  const siteUrl = raw.replace(".convex.cloud", ".convex.site");
+  return siteUrl
+    ? `${siteUrl}/ingest/v1/traces`
+    : "https://<your-deployment>.convex.site/ingest/v1/traces";
+}
 
 /** {CONVEX_SITE_URL}/otlp/v1/traces — httpActions serve on .convex.site, not .cloud. */
 function deriveIngestUrl(): string {
@@ -44,6 +53,7 @@ export function IngestEndpoint() {
   const tokens = useQuery(api.ingestTokens.listIngestTokens, { projectId });
   const issueToken = useMutation(api.ingestTokens.issueIngestToken);
 
+  const nativeIngestUrl = deriveNativeIngestUrl();
   const ingestUrl = deriveIngestUrl();
 
   const [label, setLabel] = useState("Gateway token");
@@ -74,11 +84,13 @@ export function IngestEndpoint() {
       <header>
         <div className="flex items-center gap-2">
           <Radio aria-hidden="true" className="h-5 w-5 text-primary" />
-          <h1 className="text-2xl font-bold">Continuous ingest (OTLP)</h1>
+          <h1 className="text-2xl font-bold">Continuous ingest</h1>
         </div>
         <p className="mt-1 text-sm text-muted-foreground">
-          Push agent traces to Blind Bench automatically from Cloudflare AI
-          Gateway or any OpenTelemetry source.
+          Meet your data where it is. POST Blind Bench's native JSON directly
+          from your app — or, if you already run an OpenTelemetry / AI gateway,
+          point its exporter at the OTLP adapter endpoint. Both paths use the
+          same per-project ingest token.
         </p>
       </header>
 
@@ -96,37 +108,14 @@ export function IngestEndpoint() {
           <p>
             Blind Bench{" "}
             <strong className="text-foreground">
-              never holds your gateway credential
+              never holds your model or gateway credentials
             </strong>
-            . You issue a token here and add it to YOUR gateway config — we only
-            receive what your gateway pushes.
+            . You issue an ingest token here and add it to YOUR caller — whether
+            that's your app POSTing native JSON or a gateway's OTLP exporter — so
+            we only ever receive what you push.
           </p>
         </CardContent>
       </Card>
-
-      {/* Ingest URL */}
-      <section className="mt-6 space-y-1.5">
-        <Label htmlFor="ingest-url">Ingest URL</Label>
-        <div className="flex items-center gap-2">
-          <Input
-            id="ingest-url"
-            value={ingestUrl}
-            readOnly
-            spellCheck={false}
-            className="font-mono text-xs"
-            onFocus={(e) => e.currentTarget.select()}
-          />
-          <CopyButton
-            text={ingestUrl}
-            label="Copy"
-            variant="inline"
-            className="h-8 shrink-0 border border-input px-2.5"
-          />
-        </div>
-        <p className="text-xs text-muted-foreground">
-          Point your gateway's OTLP HTTP exporter at this endpoint.
-        </p>
-      </section>
 
       {/* Issue token */}
       <section className="mt-8">
@@ -169,9 +158,87 @@ export function IngestEndpoint() {
         </div>
       </section>
 
-      {/* Gateway setup */}
+      {/* Native JSON — the default path */}
+      <NativeIngestCard nativeUrl={nativeIngestUrl} />
+
+      {/* Gateway / OTLP adapter */}
       <GatewaySetupCard ingestUrl={ingestUrl} />
     </div>
+  );
+}
+
+function NativeIngestCard({ nativeUrl }: { nativeUrl: string }) {
+  const curl = [
+    `curl -X POST ${nativeUrl} \\`,
+    `  -H "Authorization: Bearer <your token>" \\`,
+    `  -H "Content-Type: application/json" \\`,
+    `  -d '{`,
+    `    "version": "1",`,
+    `    "id": "req_abc123",`,
+    `    "model": "anthropic/claude-4.7-opus",`,
+    `    "provider": "anthropic",`,
+    `    "input": { "messages": [{ "role": "user", "content": "Summarize this ticket…" }] },`,
+    `    "output": { "content": "The ticket describes…" },`,
+    `    "usage": { "input_tokens": 812, "output_tokens": 143, "cost_usd": 0.0121 },`,
+    `    "product": "support-assistant",`,
+    `    "metadata": { "team": "support" }`,
+    `  }'`,
+  ].join("\n");
+
+  return (
+    <Card className="mt-8">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-base">
+          <Braces aria-hidden="true" className="h-4 w-4 text-primary" />
+          POST native JSON (recommended)
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4 text-sm text-muted-foreground">
+        <p>
+          No gateway required. POST one eval record per model interaction to this
+          endpoint with your ingest token as a bearer credential.
+        </p>
+
+        {/* Native ingest URL */}
+        <div className="space-y-1.5">
+          <Label htmlFor="native-ingest-url">Native ingest URL</Label>
+          <div className="flex items-center gap-2">
+            <Input
+              id="native-ingest-url"
+              value={nativeUrl}
+              readOnly
+              spellCheck={false}
+              className="font-mono text-xs"
+              onFocus={(e) => e.currentTarget.select()}
+            />
+            <CopyButton
+              text={nativeUrl}
+              label="Copy"
+              variant="inline"
+              className="h-8 shrink-0 border border-input px-2.5"
+            />
+          </div>
+        </div>
+
+        <div className="relative">
+          <pre className="overflow-x-auto rounded-lg border bg-muted/30 p-3 pr-12 font-mono text-xs text-foreground">
+            {curl}
+          </pre>
+          <CopyButton text={curl} label="Copy curl" variant="overlay" />
+        </div>
+
+        <p>
+          Send a single object, a JSON array, or{" "}
+          <code className="text-foreground">{`{"records":[...]}`}</code> to batch
+          many interactions in one request.
+        </p>
+
+        <p className="text-foreground">
+          Response is counts-only — Blind Bench never echoes your prompt/output
+          content back.
+        </p>
+      </CardContent>
+    </Card>
   );
 }
 
@@ -310,10 +377,15 @@ function GatewaySetupCard({ ingestUrl }: { ingestUrl: string }) {
       <CardHeader>
         <CardTitle className="flex items-center gap-2 text-base">
           <Settings2 aria-hidden="true" className="h-4 w-4 text-primary" />
-          Gateway setup
+          Already have a gateway? OTLP exporter
         </CardTitle>
       </CardHeader>
       <CardContent className="space-y-4 text-sm text-muted-foreground">
+        <p>
+          Prefer to reuse an existing OpenTelemetry / AI gateway instead of
+          POSTing native JSON? Point its OTLP HTTP exporter at the adapter
+          endpoint below — it accepts the same ingest token.
+        </p>
         <ol className="list-decimal space-y-2 pl-5">
           <li>Issue an ingest token above and copy it.</li>
           <li>


### PR DESCRIPTION
## Why

Strategic reframe (aligned with Noah, second-opinioned by Codex): **Blind Bench's own versioned schema is the durable ingestion contract; OTLP and the Cloudflare gateway import are adapters that normalize into it.** No customer should have to adopt OpenTelemetry to use Blind Bench — a gateway-less customer can just POST their model interactions as JSON.

The internal normalized `AgentRunTrace` already existed and every adapter fed it; what was missing was (1) a native front door for no-gateway customers, (2) a *validated, versioned public contract*, and (3) onboarding/docs that lead with "meet your data where it is." This PR adds all three.

## What

**Backend**
- New public DTO **`eval-record` v1** — one record = one model interaction (`input.messages`, `output`, `model`, `provider`, `usage`, `metadata`). Deliberately *not* raw `AgentRunTrace` (which mixes in server-computed `redacted_*`/`privacy_class` a client must never supply).
- `normalizeEvalRecordV1` in the isomorphic core (hand-rolled validation, no new dep — the core stays zero-dependency), mirroring `normalizeJeevesClogRun`.
- `POST /ingest/v1/traces` (`convex/nativeIngest.ts`) — **reuses** the per-project ingest tokens (format-agnostic, shared with OTLP), `insertTraceParentForIngest`, and `storeTraceSteps`. Accepts a single record, a bare array, or `{records:[]}`. Bad record → counted `invalid`, batch continues. Counts-only response (never echoes content).
- `insertOtlpImport` → `insertIngestImport` parametrized by `source`; added `"native"` to `traceImports.source`.

**UI** — `IngestEndpoint` reframed native-first (OTLP demoted to "already have a gateway?" adapter card); onboarding copy + sidebar label updated. Token UI unchanged.

**Docs** — `docs/native-ingest.md` published as the contract of record; pointers added from the gateway docs.

## Codex review — all 8 findings fixed

No blockers; hardening applied before this PR:
- **trace_id namespaced** (`native-`) so a client `id` can't collide with another source's parent trace (parent dedups by `(projectId, traceId)` across sources); `run_id` stays the raw id so source-scoped import dedup + re-POST idempotency are unaffected.
- **dedup hash** now covers all public content fields (id-less records differing in any field get distinct ids).
- **privacy_class** may *raise* but never *lower* the computed class (no silent PHI/PII downgrade).
- **strict output-field validation** (malformed `tool_calls`/`tool_results` → `invalid`, not silently coerced).
- **batch caps**: 1000 records, 2000 msgs/record, 10k steps/request + UTF-8 byte size guard (bounds per-request storage writes).
- **orphan raw-body blob** deleted when a batch imports nothing.
- **responseMissing** counts only imported records.

## Verification

- `npm run build` (tsc + vite) — passes.
- `npm run test:convex` — **232 passing** (incl. new `nativeIngest.test.ts`; existing `otlpIngest.test.ts` unchanged/green — OTLP path unaffected).
- Note: an intermittent vitest teardown flake in the unrelated `optimize.test.ts` (`onUserConsoleLog` rpc race) predates this branch.

## Test plan (prod, no current users)

1. Issue an ingest token on a project's Ingest tab.
2. `curl -X POST {deployment}.convex.site/ingest/v1/traces` with the `eval-record` v1 example from `docs/native-ingest.md`.
3. Confirm counts-only response; re-POST same `id` → `deduped`; trace appears in the project (source `native`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)