### PR TITLE
Make billing credits real and align app positioning

### DIFF
--- a/convex/billing.ts
+++ b/convex/billing.ts
@@ -11,11 +11,14 @@ import { QueryCtx, MutationCtx } from "./_generated/server";
 import { requireOrgRole } from "./lib/auth";
 import {
   BILLING_PACKAGES,
+  CREDIT_COSTS,
   TRIAL,
   getPackage,
+  resolvePackageKeyByProductId,
   resolveProductId,
   publicPackageCatalog,
 } from "./lib/billingPlans";
+import { sumBillingCredits } from "./lib/billingCredits";
 
 // Webhook event types we act on. Anything else is acknowledged and ignored.
 const GRANT_EVENTS = new Set(["order.paid"]);
@@ -31,11 +34,7 @@ async function sumCredits(
   ctx: QueryCtx,
   orgId: Id<"organizations">,
 ): Promise<number> {
-  const rows = await ctx.db
-    .query("billingLedger")
-    .withIndex("by_org", (q) => q.eq("organizationId", orgId))
-    .collect();
-  return rows.reduce((acc, r) => acc + r.creditDelta, 0);
+  return sumBillingCredits(ctx, orgId);
 }
 
 async function activeEntitlement(ctx: QueryCtx, orgId: Id<"organizations">) {
@@ -106,6 +105,18 @@ export const getBillingOverview = query({
       // the Polar access token to be configured server-side.
       portalAvailable: !!customer,
       checkoutConfigured: !!process.env.POLAR_ACCESS_TOKEN,
+    };
+  },
+});
+
+export const getCreditStatus = query({
+  args: { orgId: v.id("organizations") },
+  handler: async (ctx, args) => {
+    await requireOrgRole(ctx, args.orgId, ["owner", "admin", "member"]);
+    return {
+      remainingCredits: await sumCredits(ctx, args.orgId),
+      evalRunCost: CREDIT_COSTS.evalRun,
+      trialCredits: TRIAL.evalCredits,
     };
   },
 });
@@ -305,6 +316,7 @@ export const applyPolarEvent = internalMutation({
     packageKey: v.optional(v.string()),
     polarCustomerId: v.optional(v.string()),
     polarOrderId: v.optional(v.string()),
+    polarProductId: v.optional(v.string()),
     polarSubscriptionId: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
@@ -354,7 +366,9 @@ export const applyPolarEvent = internalMutation({
 
     // 4. Branch on event type.
     if (GRANT_EVENTS.has(args.eventType)) {
-      const pkg = args.packageKey ? getPackage(args.packageKey) : undefined;
+      const packageKey =
+        args.packageKey ?? resolvePackageKeyByProductId(args.polarProductId);
+      const pkg = packageKey ? getPackage(packageKey) : undefined;
       if (!pkg) return finish("ignored_unknown_package", {});
 
       // Order-level idempotency: never double-credit the same order.

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -16,17 +16,21 @@ auth.addHttpRoutes(http);
  * Pull ONLY the scalar billing fields we need out of a Polar event. Never
  * forwards arbitrary payload (no trace/test-case content can leak this way).
  * `orgId`/`packageKey` come from the metadata we set at checkout, falling back
- * to the customer's external id (which is the org id).
+ * to the customer's external id (which is the org id) and product id.
  */
 function sanitizePolarEvent(eventId: string, event: unknown) {
   if (!event || typeof event !== "object") return null;
   const e = event as Record<string, unknown>;
   const eventType = typeof e.type === "string" ? e.type : "";
   if (!eventType) return null;
-  const data = (e.data ?? {}) as Record<string, unknown>;
-  const meta = (data.metadata ?? {}) as Record<string, unknown>;
-  const customer = (data.customer ?? {}) as Record<string, unknown>;
-  const subscription = (data.subscription ?? {}) as Record<string, unknown>;
+  const asRecord = (x: unknown): Record<string, unknown> =>
+    x && typeof x === "object" && !Array.isArray(x)
+      ? (x as Record<string, unknown>)
+      : {};
+  const data = asRecord(e.data);
+  const meta = asRecord(data.metadata);
+  const customer = asRecord(data.customer);
+  const subscription = asRecord(data.subscription);
 
   const str = (x: unknown): string | undefined =>
     typeof x === "string" && x.length > 0 ? x : undefined;
@@ -46,6 +50,7 @@ function sanitizePolarEvent(eventId: string, event: unknown) {
     polarCustomerId: str(data.customer_id) ?? str(customer.id),
     polarOrderId:
       eventType.startsWith("order") ? str(data.id) ?? str(data.order_id) : str(data.order_id),
+    polarProductId: str(data.product_id) ?? str(asRecord(data.product).id),
     polarSubscriptionId:
       str(data.subscription_id) ?? str(subscription.id) ??
       (eventType.startsWith("subscription") ? str(data.id) : undefined),

--- a/convex/lib/billingCredits.ts
+++ b/convex/lib/billingCredits.ts
@@ -1,0 +1,111 @@
+import { ConvexError } from "convex/values";
+import type { Id } from "../_generated/dataModel";
+import type { MutationCtx, QueryCtx } from "../_generated/server";
+import { CREDIT_COSTS, TRIAL } from "./billingPlans";
+
+export const BILLING_REASONS = {
+  trialGrant: "trial_grant",
+  evalConsumption: "eval_consumption",
+} as const;
+
+type ReadBillingCtx = Pick<QueryCtx, "db">;
+
+/** Remaining credits are the append-only sum of every ledger delta for an org. */
+export async function sumBillingCredits(
+  ctx: ReadBillingCtx,
+  orgId: Id<"organizations">,
+): Promise<number> {
+  const rows = await ctx.db
+    .query("billingLedger")
+    .withIndex("by_org", (q) => q.eq("organizationId", orgId))
+    .collect();
+  return rows.reduce((acc, row) => acc + row.creditDelta, 0);
+}
+
+/** Seed the one-time free trial grant for a fresh workspace. Idempotent by org. */
+export async function ensureTrialCreditGrant(
+  ctx: MutationCtx,
+  orgId: Id<"organizations">,
+): Promise<{ granted: boolean; creditDelta: number }> {
+  const existing = await ctx.db
+    .query("billingLedger")
+    .withIndex("by_org", (q) => q.eq("organizationId", orgId))
+    .filter((q) => q.eq(q.field("reason"), BILLING_REASONS.trialGrant))
+    .first();
+  if (existing) return { granted: false, creditDelta: 0 };
+
+  await ctx.db.insert("billingLedger", {
+    organizationId: orgId,
+    creditDelta: TRIAL.evalCredits,
+    reason: BILLING_REASONS.trialGrant,
+    createdAt: Date.now(),
+  });
+  return { granted: true, creditDelta: TRIAL.evalCredits };
+}
+
+type ConsumptionTarget =
+  | { readonly kind: "prompt_run"; readonly promptRunId: Id<"promptRuns"> }
+  | { readonly kind: "scorecard_run"; readonly scorecardRunId: Id<"scorecardRuns"> };
+
+async function alreadyConsumed(
+  ctx: ReadBillingCtx,
+  target: ConsumptionTarget,
+) {
+  if (target.kind === "prompt_run") {
+    return await ctx.db
+      .query("billingLedger")
+      .withIndex("by_prompt_run", (q) =>
+        q.eq("promptRunId", target.promptRunId),
+      )
+      .first();
+  }
+
+  return await ctx.db
+    .query("billingLedger")
+    .withIndex("by_scorecard_run", (q) =>
+      q.eq("scorecardRunId", target.scorecardRunId),
+    )
+    .first();
+}
+
+/**
+ * Consume eval credits transactionally for a product-started evaluation job.
+ *
+ * Convex mutations are atomic, so the check and negative ledger write cannot
+ * race past zero. The target id is an idempotency key: retrying the same run or
+ * scorecard does not double-charge.
+ */
+export async function consumeEvalCredit(
+  ctx: MutationCtx,
+  orgId: Id<"organizations">,
+  target: ConsumptionTarget,
+): Promise<{ consumed: boolean; remainingCredits: number }> {
+  if (await alreadyConsumed(ctx, target)) {
+    return {
+      consumed: false,
+      remainingCredits: await sumBillingCredits(ctx, orgId),
+    };
+  }
+
+  const remaining = await sumBillingCredits(ctx, orgId);
+  if (remaining < CREDIT_COSTS.evalRun) {
+    throw new ConvexError(
+      "Out of eval credits for this workspace. Add credits in Billing to start another evaluation.",
+    );
+  }
+
+  await ctx.db.insert("billingLedger", {
+    organizationId: orgId,
+    creditDelta: -CREDIT_COSTS.evalRun,
+    reason: BILLING_REASONS.evalConsumption,
+    promptRunId: target.kind === "prompt_run" ? target.promptRunId : undefined,
+    scorecardRunId:
+      target.kind === "scorecard_run" ? target.scorecardRunId : undefined,
+    createdAt: Date.now(),
+  });
+
+  return {
+    consumed: true,
+    remainingCredits: remaining - CREDIT_COSTS.evalRun,
+  };
+}

--- a/convex/lib/billingPlans.ts
+++ b/convex/lib/billingPlans.ts
@@ -12,8 +12,12 @@
  *   - Packages: a monthly subscription that grants a fixed bundle of eval
  *     credits + reviewer seats + trace-import headroom + a support level.
  *   - Credits: a fungible per-eval unit tracked in `billingLedger`. A package
- *     purchase adds a positive ledger entry; a refund/revoke adds a negative
- *     one. Remaining credits = sum of all ledger deltas for the org.
+ *     purchase adds a positive ledger entry; a refund/revoke or eval
+ *     consumption adds a negative one. Remaining credits = sum of all ledger
+ *     deltas for the org.
+ *   - Consumption: v1 charges 1 credit when Blind Bench starts a prompt run or
+ *     a scorecard run. Fan-out outputs, deterministic scorer count, and trace
+ *     imports are not separately metered yet.
  *   - Trial: every workspace starts with a small free credit grant (no card).
  *   - Manual enterprise: the largest tier is sales-assisted, not self-serve;
  *     `manualEnterprise: true` hides the self-serve checkout button.
@@ -52,6 +56,15 @@ export const TRIAL = {
   evalCredits: 50,
   reviewerSeats: 2,
   traceImportLimit: 10,
+} as const;
+
+/**
+ * Launch metering unit. One credit is consumed when the app starts one prompt
+ * run or one scorecard run. Output fan-out, deterministic scorer count, and
+ * trace imports are deliberately not separate credit multipliers in v1.
+ */
+export const CREDIT_COSTS = {
+  evalRun: 1,
 } as const;
 
 export const BILLING_PACKAGES: Record<PackageKey, BillingPackage> = {
@@ -127,6 +140,18 @@ export function resolveProductId(
   env: Record<string, string | undefined> = process.env,
 ): string | undefined {
   return env[pkg.productEnvVar];
+}
+
+/** Resolve a package key from a Polar product id for off-app purchases. */
+export function resolvePackageKeyByProductId(
+  productId: string | undefined,
+  env: Record<string, string | undefined> = process.env,
+): PackageKey | undefined {
+  if (!productId) return undefined;
+  return PACKAGE_ORDER.find((key) => {
+    const pkg = BILLING_PACKAGES[key];
+    return resolveProductId(pkg, env) === productId;
+  });
 }
 
 /**

--- a/convex/organizations.ts
+++ b/convex/organizations.ts
@@ -2,6 +2,7 @@ import { v } from "convex/values";
 import { mutation, query } from "./_generated/server";
 import { internal } from "./_generated/api";
 import { requireAuth, requireOrgRole } from "./lib/auth";
+import { ensureTrialCreditGrant } from "./lib/billingCredits";
 
 const SLUG_REGEX = /^[a-z0-9][a-z0-9-]{1,46}[a-z0-9]$/;
 
@@ -39,6 +40,8 @@ export const createOrg = mutation({
       userId,
       role: "owner",
     });
+
+    await ensureTrialCreditGrant(ctx, orgId);
 
     await ctx.scheduler.runAfter(0, internal.analyticsActions.track, {
       event: "org created",

--- a/convex/runs.ts
+++ b/convex/runs.ts
@@ -16,6 +16,7 @@ import {
   buildInputSnapshot,
   resolveDispatchInputs,
 } from "./lib/inputSnapshot";
+import { consumeEvalCredit } from "./lib/billingCredits";
 
 const CONCURRENT_CAP = 10;
 
@@ -48,6 +49,8 @@ export const execute = mutation({
       "owner",
       "editor",
     ]);
+    const project = await ctx.db.get(version.projectId);
+    if (!project) throw new Error("Project not found");
 
     // Require exactly one of testCaseId or inlineVariables
     if (!args.testCaseId && !args.inlineVariables) {
@@ -178,6 +181,11 @@ export const execute = mutation({
       slotConfigs: isMix ? args.slotConfigs : undefined,
       status: "pending",
       triggeredById: userId,
+    });
+
+    await consumeEvalCredit(ctx, project.organizationId, {
+      kind: "prompt_run",
+      promptRunId: runId,
     });
 
     // Create empty output rows — per-slot model/temp in mix mode

--- a/convex/sampleSeed.ts
+++ b/convex/sampleSeed.ts
@@ -2,6 +2,7 @@ import { mutation, query, MutationCtx, QueryCtx } from "./_generated/server";
 import { internal } from "./_generated/api";
 import { Doc, Id } from "./_generated/dataModel";
 import { requireAuth } from "./lib/auth";
+import { ensureTrialCreditGrant } from "./lib/billingCredits";
 import { genMessageId } from "./lib/messages";
 import {
   SAMPLE_ANNOTATIONS,
@@ -175,6 +176,7 @@ export async function createPersonalOrg(
     userId,
     role: "owner",
   });
+  await ensureTrialCreditGrant(ctx, orgId);
 
   return { orgId, slug };
 }

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1362,8 +1362,9 @@ const schema = defineSchema({
     .index("by_subscription", ["polarSubscriptionId"]),
 
   // Append-only credit ledger. Remaining credits = sum of `creditDelta` for an
-  // org. Purchases add positive deltas; refunds/revocations add negative ones.
-  // Carries Polar IDs for idempotency and audit — never trace/test-case data.
+  // org. Purchases/trials add positive deltas; refunds/revocations and eval
+  // consumption add negative ones. Carries Polar IDs and product-run IDs for
+  // idempotency and audit — never trace/test-case content.
   billingLedger: defineTable({
     organizationId: v.id("organizations"),
     creditDelta: v.number(),
@@ -1372,12 +1373,16 @@ const schema = defineSchema({
     polarOrderId: v.optional(v.string()),
     polarSubscriptionId: v.optional(v.string()),
     polarEventId: v.optional(v.string()),
+    promptRunId: v.optional(v.id("promptRuns")),
+    scorecardRunId: v.optional(v.id("scorecardRuns")),
     createdAt: v.number(),
   })
     .index("by_org", ["organizationId"])
     .index("by_order", ["polarOrderId"])
     .index("by_subscription", ["polarSubscriptionId"])
-    .index("by_event", ["polarEventId"]),
+    .index("by_event", ["polarEventId"])
+    .index("by_prompt_run", ["promptRunId"])
+    .index("by_scorecard_run", ["scorecardRunId"]),
 
   // Idempotency + audit log of every webhook delivery we accepted. Keyed by the
   // Standard Webhooks `webhook-id`; a repeat delivery is a no-op.

--- a/convex/scorecards.ts
+++ b/convex/scorecards.ts
@@ -12,6 +12,7 @@ import {
   foldScorecardResults,
   type ScorecardResultRow,
 } from "./lib/scorecardAggregation";
+import { consumeEvalCredit } from "./lib/billingCredits";
 
 // ===========================================================================
 // #259: Per-org scorecard runs.
@@ -56,6 +57,10 @@ export const start = mutation({
       status: "pending",
       triggeredById: userId,
       startedAt: Date.now(),
+    });
+    await consumeEvalCredit(ctx, args.orgId, {
+      kind: "scorecard_run",
+      scorecardRunId: runId,
     });
     await ctx.scheduler.runAfter(0, internal.scorecardsActions.runScorecard, {
       runId,

--- a/convex/tests/billing.test.ts
+++ b/convex/tests/billing.test.ts
@@ -1,6 +1,8 @@
 import { convexTest } from "convex-test";
 import { expect, test, describe } from "vitest";
 import { api, internal } from "../_generated/api";
+import type { Id } from "../_generated/dataModel";
+import { ensureTrialCreditGrant } from "../lib/billingCredits";
 import schema from "../schema";
 
 async function seedBillingEnv() {
@@ -40,6 +42,87 @@ function orderPaid(orgId: string, eventId: string, orderId: string) {
     polarOrderId: orderId,
     polarSubscriptionId: "sub_123",
   };
+}
+
+type BillingHarness = Awaited<ReturnType<typeof seedBillingEnv>>["t"];
+
+async function seedRunBillingEnv(initialCredits: number) {
+  const t = convexTest(schema);
+  const ids = await t.run(async (ctx) => {
+    const ownerUserId = await ctx.db.insert("users", {
+      name: "Owner",
+      email: "owner@test.com",
+    });
+    const orgId = await ctx.db.insert("organizations", {
+      name: "Acme",
+      slug: `acme-${initialCredits}`,
+      createdById: ownerUserId,
+    });
+    await ctx.db.insert("organizationMembers", {
+      organizationId: orgId,
+      userId: ownerUserId,
+      role: "owner",
+    });
+    const projectId = await ctx.db.insert("projects", {
+      organizationId: orgId,
+      name: "Support Agent",
+      createdById: ownerUserId,
+    });
+    await ctx.db.insert("projectCollaborators", {
+      projectId,
+      userId: ownerUserId,
+      role: "owner",
+      invitedById: ownerUserId,
+      invitedAt: Date.now(),
+    });
+    const versionId = await ctx.db.insert("promptVersions", {
+      projectId,
+      versionNumber: 1,
+      userMessageTemplate: "Help {{name}}.",
+      status: "current",
+      messages: [
+        { id: "m-system", role: "system", content: "You are a support agent." },
+        { id: "m-user", role: "user", content: "Help {{name}}." },
+      ],
+      createdById: ownerUserId,
+    });
+    const testCaseId = await ctx.db.insert("testCases", {
+      projectId,
+      name: "Ada",
+      variableValues: { name: "Ada" },
+      attachmentIds: [],
+      order: 0,
+      createdById: ownerUserId,
+    });
+    if (initialCredits > 0) {
+      await ctx.db.insert("billingLedger", {
+        organizationId: orgId,
+        creditDelta: initialCredits,
+        reason: "test_grant",
+        createdAt: Date.now(),
+      });
+    }
+    return { ownerUserId, orgId, projectId, versionId, testCaseId };
+  });
+
+  const asOwner = t.withIdentity({
+    subject: `${ids.ownerUserId}|s`,
+    tokenIdentifier: `test|${ids.ownerUserId}`,
+  });
+  return { t, ids, asOwner };
+}
+
+async function remainingCredits(
+  t: BillingHarness,
+  orgId: Id<"organizations">,
+): Promise<number> {
+  return await t.run(async (ctx) => {
+    const rows = await ctx.db
+      .query("billingLedger")
+      .withIndex("by_org", (q) => q.eq("organizationId", orgId))
+      .collect();
+    return rows.reduce((sum, row) => sum + row.creditDelta, 0);
+  });
 }
 
 describe("applyPolarEvent", () => {
@@ -190,6 +273,166 @@ describe("applyPolarEvent", () => {
       externalCustomerId: ids.orgId,
     });
     expect(res).toMatchObject({ action: "ignored_unsupported" });
+  });
+
+  test("metadata-less order.paid resolves package by known product id", async () => {
+    const prevTeamProduct = process.env.POLAR_PRODUCT_TEAM;
+    process.env.POLAR_PRODUCT_TEAM = "prod_team_known";
+    try {
+      const { t, ids } = await seedBillingEnv();
+      const res = await t.mutation(internal.billing.applyPolarEvent, {
+        eventId: "evt_product_only",
+        eventType: "order.paid",
+        externalCustomerId: ids.orgId,
+        polarProductId: "prod_team_known",
+        polarOrderId: "ord_product_only",
+      });
+      expect(res).toMatchObject({
+        action: "granted",
+        packageKey: "team",
+        creditDelta: 2500,
+      });
+    } finally {
+      if (prevTeamProduct === undefined) delete process.env.POLAR_PRODUCT_TEAM;
+      else process.env.POLAR_PRODUCT_TEAM = prevTeamProduct;
+    }
+  });
+
+  test("metadata-less order.paid with unknown product id is ignored", async () => {
+    const prevTeamProduct = process.env.POLAR_PRODUCT_TEAM;
+    process.env.POLAR_PRODUCT_TEAM = "prod_team_known";
+    try {
+      const { t, ids } = await seedBillingEnv();
+      const res = await t.mutation(internal.billing.applyPolarEvent, {
+        eventId: "evt_product_unknown",
+        eventType: "order.paid",
+        externalCustomerId: ids.orgId,
+        polarProductId: "prod_unknown",
+        polarOrderId: "ord_product_unknown",
+      });
+      expect(res).toMatchObject({ action: "ignored_unknown_package" });
+      expect(await remainingCredits(t, ids.orgId)).toBe(0);
+    } finally {
+      if (prevTeamProduct === undefined) delete process.env.POLAR_PRODUCT_TEAM;
+      else process.env.POLAR_PRODUCT_TEAM = prevTeamProduct;
+    }
+  });
+});
+
+describe("trial grants and credit consumption", () => {
+  test("createOrg seeds exactly one trial grant promised by billing UI", async () => {
+    const t = convexTest(schema);
+    const userId = await t.run(async (ctx) =>
+      ctx.db.insert("users", { name: "Owner", email: "owner@test.com" }),
+    );
+    const asOwner = t.withIdentity({
+      subject: `${userId}|s`,
+      tokenIdentifier: `test|${userId}`,
+    });
+
+    const orgId = await asOwner.mutation(api.organizations.createOrg, {
+      name: "Trial Org",
+      slug: "trial-org",
+    });
+
+    const overview = await asOwner.query(api.billing.getBillingOverview, {
+      orgId,
+    });
+    expect(overview.remainingCredits).toBe(50);
+    expect(overview.ledger).toHaveLength(1);
+    expect(overview.ledger[0]).toMatchObject({
+      creditDelta: 50,
+      reason: "trial_grant",
+    });
+  });
+
+  test("trial grant helper is idempotent for an org", async () => {
+    const { t, ids } = await seedBillingEnv();
+    await t.run(async (ctx) => {
+      await ensureTrialCreditGrant(ctx, ids.orgId);
+      await ensureTrialCreditGrant(ctx, ids.orgId);
+    });
+
+    const ledger = await t.run(async (ctx) =>
+      ctx.db
+        .query("billingLedger")
+        .withIndex("by_org", (q) => q.eq("organizationId", ids.orgId))
+        .collect(),
+    );
+    expect(ledger.filter((row) => row.reason === "trial_grant")).toHaveLength(1);
+    expect(await remainingCredits(t, ids.orgId)).toBe(50);
+  });
+
+  test("prompt runs fail closed at zero credits", async () => {
+    const { asOwner, ids } = await seedRunBillingEnv(0);
+    await expect(
+      asOwner.mutation(api.runs.execute, {
+        versionId: ids.versionId,
+        testCaseId: ids.testCaseId,
+        model: "openai/gpt-4",
+        temperature: 0.7,
+      }),
+    ).rejects.toThrow("Out of eval credits");
+  });
+
+  test("prompt runs consume one credit and are idempotent per run row", async () => {
+    const { t, asOwner, ids } = await seedRunBillingEnv(2);
+    const runId = await asOwner.mutation(api.runs.execute, {
+      versionId: ids.versionId,
+      testCaseId: ids.testCaseId,
+      model: "openai/gpt-4",
+      temperature: 0.7,
+    });
+    expect(runId).toBeTruthy();
+    expect(await remainingCredits(t, ids.orgId)).toBe(1);
+
+    const promptRunLedger = await t.run(async (ctx) =>
+      ctx.db
+        .query("billingLedger")
+        .withIndex("by_prompt_run", (q) => q.eq("promptRunId", runId))
+        .collect(),
+    );
+    expect(promptRunLedger).toHaveLength(1);
+    expect(promptRunLedger[0]!.creditDelta).toBe(-1);
+    expect(promptRunLedger[0]!.reason).toBe("eval_consumption");
+  });
+
+  test("concurrent prompt-run starts cannot overspend the last credit", async () => {
+    const { t, asOwner, ids } = await seedRunBillingEnv(1);
+    const attempts = await Promise.allSettled([
+      asOwner.mutation(api.runs.execute, {
+        versionId: ids.versionId,
+        testCaseId: ids.testCaseId,
+        model: "openai/gpt-4",
+        temperature: 0.7,
+      }),
+      asOwner.mutation(api.runs.execute, {
+        versionId: ids.versionId,
+        testCaseId: ids.testCaseId,
+        model: "openai/gpt-4",
+        temperature: 0.7,
+      }),
+    ]);
+
+    expect(attempts.filter((a) => a.status === "fulfilled")).toHaveLength(1);
+    expect(attempts.filter((a) => a.status === "rejected")).toHaveLength(1);
+    expect(await remainingCredits(t, ids.orgId)).toBe(0);
+  });
+
+  test("scorecard runs consume one credit", async () => {
+    const { t, asOwner, ids } = await seedRunBillingEnv(1);
+    const runId = await asOwner.mutation(api.scorecards.start, {
+      orgId: ids.orgId,
+    });
+    expect(runId).toBeTruthy();
+    expect(await remainingCredits(t, ids.orgId)).toBe(0);
+  });
+
+  test("scorecard runs fail closed at zero credits", async () => {
+    const { asOwner, ids } = await seedRunBillingEnv(0);
+    await expect(
+      asOwner.mutation(api.scorecards.start, { orgId: ids.orgId }),
+    ).rejects.toThrow("Out of eval credits");
   });
 });
 

--- a/convex/tests/billingWebhook.test.ts
+++ b/convex/tests/billingWebhook.test.ts
@@ -42,7 +42,13 @@ async function seedBillingEnv() {
 function orderPaidBody(
   orgId: string,
   orderId: string,
-  opts: { customerId?: string; subscriptionId?: string; dropMetaOrgId?: boolean } = {},
+  opts: {
+    customerId?: string;
+    subscriptionId?: string;
+    dropMetaOrgId?: boolean;
+    dropMetaPackageKey?: boolean;
+    productId?: string;
+  } = {},
 ) {
   const customerId = opts.customerId ?? "cus_polar_1";
   const subscriptionId = opts.subscriptionId ?? "sub_polar_1";
@@ -52,6 +58,7 @@ function orderPaidBody(
     environment: "sandbox",
   };
   if (opts.dropMetaOrgId) delete metadata.orgId;
+  if (opts.dropMetaPackageKey) delete metadata.packageKey;
   return {
     type: "order.paid",
     data: {
@@ -62,7 +69,7 @@ function orderPaidBody(
       currency: "usd",
       total_amount: 19900,
       customer_id: customerId,
-      product_id: "prod_team_x",
+      product_id: opts.productId ?? "prod_team_x",
       subscription_id: subscriptionId,
       checkout_id: "chk_1",
       metadata,
@@ -213,7 +220,55 @@ describe("/polar/webhook end-to-end (real Polar event shapes)", () => {
     expect(ledger[0]!.creditDelta).toBe(2500);
   });
 
-  test("c. bad signature → 401 and no ledger row", async () => {
+  test("c. metadata-less order.paid grants via known product_id", async () => {
+    const prevTeamProduct = process.env.POLAR_PRODUCT_TEAM;
+    process.env.POLAR_PRODUCT_TEAM = "prod_team_x";
+    try {
+      const { t, ids } = await seedBillingEnv();
+      const body = orderPaidBody(ids.orgId, "ord_product_3", {
+        dropMetaPackageKey: true,
+        productId: "prod_team_x",
+      });
+
+      const res = await postSigned(t, "evt_paid_3", body);
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json.result.action).toBe("granted");
+      expect(json.result.packageKey).toBe("team");
+
+      const ledger = await ledgerFor(t, ids.orgId);
+      expect(ledger).toHaveLength(1);
+      expect(ledger[0]!.creditDelta).toBe(2500);
+    } finally {
+      if (prevTeamProduct === undefined) delete process.env.POLAR_PRODUCT_TEAM;
+      else process.env.POLAR_PRODUCT_TEAM = prevTeamProduct;
+    }
+  });
+
+  test("d. metadata-less order.paid with unknown product_id is ignored", async () => {
+    const prevTeamProduct = process.env.POLAR_PRODUCT_TEAM;
+    process.env.POLAR_PRODUCT_TEAM = "prod_team_x";
+    try {
+      const { t, ids } = await seedBillingEnv();
+      const body = orderPaidBody(ids.orgId, "ord_product_unknown_4", {
+        dropMetaPackageKey: true,
+        productId: "prod_unknown",
+      });
+
+      const res = await postSigned(t, "evt_paid_4", body);
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json.result.action).toBe("ignored_unknown_package");
+
+      const ledger = await ledgerFor(t, ids.orgId);
+      expect(ledger).toHaveLength(0);
+    } finally {
+      if (prevTeamProduct === undefined) delete process.env.POLAR_PRODUCT_TEAM;
+      else process.env.POLAR_PRODUCT_TEAM = prevTeamProduct;
+    }
+  });
+
+  test("e. bad signature → 401 and no ledger row", async () => {
     const { t, ids } = await seedBillingEnv();
     const body = orderPaidBody(ids.orgId, "ord_bad_3");
     const raw = JSON.stringify(body);

--- a/docs/canonical-demo-loop.md
+++ b/docs/canonical-demo-loop.md
@@ -1,0 +1,39 @@
+# Canonical demo loop
+
+Blind Bench's agent-first demo should stay narrow enough that a buyer can repeat
+it without understanding the whole platform.
+
+## One path we lead with
+
+1. **Bring in one agent run** — native `eval-record` v1, Claude Code JSONL,
+   Gateway/OTLP, or another thin adapter. The adapter choice is not the story;
+   every path normalizes into the same agent-trace spine.
+2. **Send one blind review link** — a domain expert opens the run or matchup
+   without version/model/harness provenance. For trajectories, the promise is
+   bias reduction, not perfect anonymity.
+3. **Get a verdict** — rating, step comment, or A/B next-action choice. Optimize
+   for time-to-verdict over full-trace inspection.
+4. **Route it back** — use the verdict as a regression case, training export
+   row, or cited revision input.
+
+## Guardrails
+
+- Do not lead with adapter breadth. Native JSON is the public contract; OTLP,
+  Cloudflare Gateway, Claude Code, Harbor, and future emitters are adapters.
+- Do not lead with sandbox orchestration. Harbor/Daytona/etc. own execution;
+  Blind Bench owns import, blind judgment, and evidence artifacts.
+- Do not lead with DPO unless the captured review data is comparable and
+  non-degenerate. Exclusions must be reported.
+- Do not claim trace anonymity. Say "blind review" and explain it as provenance
+  stripping plus bias reduction.
+- Do not show billing credits as decorative numbers: if credits are visible,
+  trial grants and consumption must be real.
+
+## Activation metric
+
+The loop is activated when a workspace completes:
+
+`agent run imported → blind review opened → verdict/comment submitted → result reused`
+
+Until this is repeatable, new adapters and matrix features should be pilot- or
+demo-driven only.

--- a/docs/polar-self-serve-billing.md
+++ b/docs/polar-self-serve-billing.md
@@ -12,11 +12,15 @@ entitlements — not per-user credits.
   copy. Stable package keys: `starter`, `team`, `scale`, `enterprise`.
 - **Credits** — a fungible per-eval unit tracked in the append-only
   `billingLedger`. **Remaining credits = sum of `creditDelta` for the org.** A
-  package purchase adds a positive entry; a refund/revoke adds a negative one.
+  package purchase or trial adds a positive entry; a refund/revoke or started
+  evaluation adds a negative one.
+- **Consumption unit** — v1 charges **1 eval credit** when Blind Bench starts a
+  prompt run or an org scorecard run. Output fan-out, deterministic scorer
+  count, and trace imports are not separate credit multipliers yet.
 - **Trial** — every workspace starts with a small free grant (`TRIAL` in
   `billingPlans.ts`): 50 eval credits, 2 reviewer seats, 10 trace imports. No
-  card required. (Trial credits are represented in config; seed them into the
-  ledger when you wire trial provisioning — the foundation does not auto-seed.)
+  card required. The grant is seeded idempotently into `billingLedger` when the
+  workspace is created (`reason: trial_grant`).
 - **Manual enterprise** — the `enterprise` package has `manualEnterprise: true`:
   no self-serve product, the checkout button is replaced by "Contact sales".
   Provision it by inserting an `active` `billingEntitlements` row + a ledger
@@ -30,10 +34,12 @@ entitlements — not per-user credits.
 ## Data boundary (payment state vs. trace data)
 
 Payment state lives **only** in four tables: `billingCustomers`,
-`billingEntitlements`, `billingLedger`, `polarWebhookEvents`. None of them
-reference or store trace / test-case / eval content. The webhook handler
+`billingEntitlements`, `billingLedger`, `polarWebhookEvents`. Ledger rows may
+carry product-run ids (`promptRunId` / `scorecardRunId`) solely as idempotency
+keys for credit consumption, but they never store trace / test-case / prompt /
+output content and billing queries do not expose those ids. The webhook handler
 (`convex/http.ts`) extracts **only** scalar billing fields (event id/type,
-external customer id, package key, Polar order/subscription/customer ids) via
+external customer id, package key/product id, Polar order/subscription/customer ids) via
 `sanitizePolarEvent` before anything is persisted — the raw payload is never
 logged or stored, so no customer trace data can leak through billing events.
 Metadata we send to Polar at checkout is limited to `orgId`, `packageKey`, and
@@ -82,7 +88,10 @@ production products are created (see Cutover).
 The handler verifies `webhook-id` / `webhook-timestamp` / `webhook-signature`
 (HMAC-SHA256, 5-minute replay window) and is **idempotent**: by `webhook-id`
 (re-delivery is a no-op) and by Polar order id (a duplicate order never
-double-credits).
+double-credits). If an order arrives without checkout metadata, the grant path
+falls back from `data.product_id` to the configured `POLAR_PRODUCT_*` package
+mapping; unknown products are acknowledged and ignored so Polar does not retry a
+bad event forever.
 
 ## Local testing
 

--- a/project-docs/Blind Bench - Agent Trace Strategy.md
+++ b/project-docs/Blind Bench - Agent Trace Strategy.md
@@ -1,7 +1,7 @@
 ---
 title: "Blind Bench - Agent Trace Strategy"
 created: 2026-07-07
-modified: 2026-07-07
+modified: 2026-07-08
 type: strategy
 status: draft
 tags:
@@ -220,6 +220,25 @@ import, we do not build sandbox infra.
 - **DPO overpromise.** Never market "human feedback → DPO" naively; the
   single-turn constraint shapes what we can honestly export.
 
+## Post-deployment critique (2026-07-08)
+
+After the M31 deployments plus the agent-first landing rewrite, the strategy is
+clearer but the following critiques are load-bearing. Treat these as guardrails,
+not objections to the pivot.
+
+| Critique | Why it matters | Guardrail / response |
+|---|---|---|
+| Demand density is still unproven | The niche may be smaller than the whitespace: teams running serious agents, with internal experts, who care enough to review traces. | Measure activation around one concrete loop: import one run → blind review link opened → verdict/comment submitted → result reused. Kill or narrow if reviewers do not finish. |
+| App and landing can disagree | `blindbench.dev` is now agent-first, but stale app/onboarding copy that says only "prompts" or "optimizer" weakens trust immediately after signup. | Keep all first-run/auth/onboarding surfaces aligned to "blind review for agent runs and model outputs." |
+| Adapter sprawl can bury the product | Native JSON, OTLP, Cloudflare Gateway, Claude Code JSONL, Harbor, and future harness emitters are all plausible, but buyers need one obvious path. | The native `eval-record` v1 contract is the source of truth; every adapter must be thin, pilot-driven, and normalize into the same spine. No adapter without a real user or demo loop. |
+| Trace blinding is weaker than output blinding | Tool names, timing, error formats, and step patterns can fingerprint a harness/model. | Product copy must say "bias reduction, not anonymity" for trajectories; server-side projection remains mandatory. |
+| Training export is valuable but fragile | DPO rows only help when matchups are comparable and non-degenerate; real dogfood already found a degenerate-pair failure mode. | Gate exports aggressively, report exclusions, and avoid marketing DPO until the UI captures enough comparable step-level choices. |
+| Harbor matrix is demo-gold and product-dangerous | Running model+harness matrices proves the thesis, but owning orchestration drifts toward a sandbox/benchmark platform. | Integrate/import only. Harbor/Daytona/etc. own execution; Blind Bench owns blinded judgment and reuse of the verdict. |
+| Billing credibility is not finished | Credits are visible/promised before trial seeding and consumption enforcement are complete. | Finish trial seeding + credit enforcement or remove metered claims until they are real. |
+| Reviewer completion is the hardest UX risk | Rendering a 300-step trace is not success if experts abandon it or leave low-signal comments. | Optimize for short tasks, divergence-focused review, and time-to-verdict. Track completion and useful-comment rate. |
+| Persona widening reintroduces competition | Senior engineers reviewing traces puts Blind Bench nearer Braintrust/LangSmith surfaces. | Stay out of observability. The defensible job is blind expert judgment, shareable review, and evidence artifacts. |
+| The product needs one canonical demo | The strategy is now broad enough to confuse a buyer. | Lead with: bring in an agent run → send one blind review link → get a verdict → route it to regression/training/revision. Everything else serves that path. |
+
 ## Codex second opinion (independent review, 2026-07-07)
 
 Codex reviewed the repo and the pivot unanchored by this doc's recommendation.
@@ -264,8 +283,9 @@ moved ahead of OTLP. The remaining genuine disagreement is E-vs-A priority
 
 ## Next action
 
-Noah reads this doc and approves/amends the Pipeline actions. Then: write the
-M31 issue set (trajectory spine + Harbor integration spike + CC JSONL
-importer + step-level annotation + export bridge), update the Build Plan with
-an M31+ section, update Positioning with the "domain expert reviewer"
-resolution, and start the spine schema.
+The M31 spine, blind trace review surface, Harbor spike, training export bridge,
+OTLP ingest, and native `eval-record` v1 endpoint have shipped. The next work is
+not more breadth by default; it is consolidation against the post-deployment
+critique above: keep app copy aligned with the agent-first landing page, make
+billing credits real, and keep demos/onboarding centered on the canonical loop
+(import one agent run → blind review link → verdict → reuse).

--- a/project-docs/MOC - Blind Bench.md
+++ b/project-docs/MOC - Blind Bench.md
@@ -1,7 +1,7 @@
 ---
 title: "MOC - Blind Bench"
 created: 2026-04-11
-modified: 2026-04-11
+modified: 2026-07-08
 type: moc
 status: planning
 domain: ideas
@@ -12,9 +12,9 @@ tags:
 
 # MOC - Blind Bench
 
-> Navigation hub for Blind Bench — "Git meets Google Docs" for collaborative prompt engineering.
+> Navigation hub for Blind Bench — the blind human-review layer for AI agents.
 
-**Status**: v1 — in planning. Architecture frozen, UX and build plan drafted, optimizer meta-prompt pending (owner drafts).
+**Status**: Agent-first strategy active (2026-07-08). M30/Pennie and M31 Trajectory Spine are tracked in GH issues; older prompt-engineering docs remain historical unless superseded by the positioning one-pager or agent trace strategy.
 
 ---
 
@@ -26,6 +26,12 @@ tags:
 - [[Blind Bench - UX Spec]] — design principles, sitemap, screen catalog, component inventory, user flows, states, blind-eval security rules, accessibility, microcopy, keyboard shortcuts
 - [[Blind Bench - Architecture#Authorization Model]] — role × action matrix that the UX spec enforces at the browser-surface level
 - [[Blind Bench - Architecture#Data Flow: Prompt Optimization Cycle]] — the loop the product is built around
+
+## Strategy & positioning
+- [[Blind Bench - Positioning One-Pager]] — current decision of record: agent-first framing, "blind human-review layer for AI agents"
+- [[Blind Bench - Agent Trace Strategy]] — M31 strategy, sequencing, risks, and the 2026-07-08 post-deployment critique/guardrails
+- [[Blind Bench - AI Quality Bench Spec]] — M30/Pennie product loop: Cloudflare Gateway logs → evals → training → scorecard
+- [Canonical demo loop](../docs/canonical-demo-loop.md) — the one path marketing, onboarding, and demos should lead with
 
 ## Implementation
 - [[Blind Bench - Build Plan]] — M0 through M7 milestones with deliverables, acceptance criteria, testable demos, dependency graph

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -82,7 +82,7 @@ export function CommandPalette() {
 
   return (
     <CommandDialog open={open} onOpenChange={setOpen}>
-      <CommandInput placeholder="Search prompts, versions, actions..." />
+      <CommandInput placeholder="Search projects, versions, actions..." />
       <CommandList>
         <CommandEmpty>
           <div className="py-6 text-center text-sm">
@@ -103,7 +103,7 @@ export function CommandPalette() {
         <CommandGroup heading="Actions">
           <CommandItem onSelect={() => go(basePath)}>
             <FolderOpen className="mr-2 h-4 w-4" />
-            Go to prompts
+            Go to projects
             <CommandShortcut>G P</CommandShortcut>
           </CommandItem>
           {projectPath && canBrowseProject && (

--- a/src/components/InviteDialog.tsx
+++ b/src/components/InviteDialog.tsx
@@ -41,7 +41,7 @@ type RoleOption = {
 
 const ROLE_OPTIONS: Record<Scope, RoleOption[]> = {
   org: [
-    { value: "org_member", label: "Member", description: "Can access org prompts they're added to" },
+    { value: "org_member", label: "Member", description: "Can access org projects they're added to" },
     { value: "org_admin", label: "Admin", description: "Can manage members and projects" },
     { value: "org_owner", label: "Owner", description: "Full control including billing" },
   ],

--- a/src/components/QualityTrend.tsx
+++ b/src/components/QualityTrend.tsx
@@ -19,7 +19,7 @@ export function QualityTrend({ projectId }: QualityTrendProps) {
     return (
       <div className="rounded-lg border border-dashed p-3">
         <p className="text-xs text-muted-foreground">
-          Run prompts and collect feedback to see quality trends.
+          Run evaluations and collect feedback to see quality trends.
         </p>
       </div>
     );

--- a/src/components/SideNavContent.tsx
+++ b/src/components/SideNavContent.tsx
@@ -49,7 +49,7 @@ export function SideNavContent({
     <>
       <div className="flex items-center justify-between px-2 pb-1">
         <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
-          Prompts
+          Projects
         </span>
         <NextActionRing target="write_prompt">
           <button
@@ -58,7 +58,7 @@ export function SideNavContent({
               onNewProject();
               onNavigate?.();
             }}
-            aria-label="New prompt"
+            aria-label="New project"
             className="rounded p-0.5 text-muted-foreground hover:bg-accent hover:text-accent-foreground"
           >
             <Plus className="h-4 w-4" />
@@ -73,7 +73,7 @@ export function SideNavContent({
           ))}
         </div>
       ) : projects.length === 0 ? (
-        <p className="px-2 text-xs text-muted-foreground">No prompts yet</p>
+        <p className="px-2 text-xs text-muted-foreground">No projects yet</p>
       ) : (
         projects.map((p) => (
           <NavLink

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -32,6 +32,8 @@ const friendlyMessages: Record<string, string> = {
     "OpenRouter rejected your API key. Check it in org settings.",
   "10 runs in flight":
     "10 runs are in flight. Wait for one to finish.",
+  "Out of eval credits":
+    "This workspace is out of eval credits. Add credits in Billing, then try again.",
   "API key cannot be empty":
     "API key cannot be empty.",
   "Encryption not configured":

--- a/src/lib/shortcuts.ts
+++ b/src/lib/shortcuts.ts
@@ -26,7 +26,7 @@ export const SHORTCUTS: ShortcutDef[] = [
   { key: "Enter", label: "Enter", description: "Open focused item", contexts: ["org-home", "versions", "test-cases"] },
 
   // Go-to sequences
-  { key: "G then P", label: "G P", description: "Go to prompts", contexts: ["project"] },
+  { key: "G then P", label: "G P", description: "Go to projects", contexts: ["project"] },
   { key: "G then R", label: "G R", description: "Go to runs", contexts: ["project"] },
   { key: "G then T", label: "G T", description: "Go to test cases", contexts: ["project"] },
   { key: "G then V", label: "G V", description: "Go to versions", contexts: ["project"] },

--- a/src/routes/Onboarding.tsx
+++ b/src/routes/Onboarding.tsx
@@ -88,8 +88,8 @@ export function Onboarding() {
           <CardHeader className="text-center">
             <CardTitle className="text-2xl">Create your workspace</CardTitle>
             <p className="text-sm text-muted-foreground">
-              A workspace holds your team's prompts, API keys, and members.
-              You can rename it later.
+              A workspace holds agent runs, prompts, ingest tokens, model keys,
+              trial eval credits, and the people who review them.
             </p>
           </CardHeader>
           <CardContent>

--- a/src/routes/auth/SignIn.tsx
+++ b/src/routes/auth/SignIn.tsx
@@ -1,7 +1,7 @@
 import { useAuthActions } from "@convex-dev/auth/react";
 import { useState } from "react";
 import { Link, useSearchParams } from "react-router-dom";
-import { EyeOff, Link2, Sparkles } from "lucide-react";
+import { EyeOff, Link2, Route } from "lucide-react";
 import { motion, useReducedMotion } from "motion/react";
 import Grainient from "@/components/Grainient";
 import BlurText from "@/components/BlurText";
@@ -12,17 +12,17 @@ const features = [
   {
     icon: Link2,
     label: "One link. No account.",
-    desc: "Experts, teammates, or customers annotate in the browser.",
+    desc: "Domain experts review agent runs and model outputs in the browser.",
   },
   {
     icon: EyeOff,
-    label: "Blinded at the API, not the UI.",
-    desc: "Reviewers never see the version, model, or author.",
+    label: "Blind by construction.",
+    desc: "Version, model, and harness are stripped before reviewers judge.",
   },
   {
-    icon: Sparkles,
-    label: "Annotations become prompt edits.",
-    desc: "The optimizer rewrites from feedback — every edit cites its comment.",
+    icon: Route,
+    label: "Verdicts route back.",
+    desc: "Ratings and comments become regression sets, training data, and revisions.",
   },
 ];
 
@@ -125,7 +125,7 @@ export function SignIn() {
             transition={{ duration: 0.5, ease: EASE, delay: 0.08 }}
             className="mt-3 text-xl text-white drop-shadow-[0_1px_8px_rgba(0,0,0,0.55)]"
           >
-            Real human feedback on every prompt you ship.
+            Blind human review for the agents you ship.
           </motion.p>
           <motion.p
             initial={reduceMotion ? false : { opacity: 0, y: 8 }}
@@ -133,8 +133,8 @@ export function SignIn() {
             transition={{ duration: 0.5, ease: EASE, delay: 0.14 }}
             className="mt-2 text-sm text-white/90 drop-shadow-[0_1px_6px_rgba(0,0,0,0.5)]"
           >
-            One link. Experts, teammates, customers annotate — the optimizer
-            applies it.
+            Import a run, send one review link, and learn whether the agent
+            actually improved.
           </motion.p>
           <div className="mt-8 space-y-4">
             {features.map((f, i) => (
@@ -174,11 +174,11 @@ export function SignIn() {
               Blind Bench
             </h1>
             <p className="text-sm text-foreground/90">
-              Real human feedback on every prompt you ship.
+              Blind human review for the agents you ship.
             </p>
             <p className="text-xs text-muted-foreground">
-              One link. Experts, teammates, customers annotate — the optimizer
-              applies it.
+              Import a run, send one review link, and learn whether the agent
+              actually improved.
             </p>
           </div>
 
@@ -271,7 +271,7 @@ export function SignIn() {
             )}
           </div>
           <p className="text-center text-xs text-muted-foreground">
-            Bring your own OpenRouter key. No per-seat billing. No credit card.
+            Bring your own model key. New workspaces include trial eval credits.
           </p>
           <p className="text-center text-[11px] text-muted-foreground">
             By continuing, you agree to our{" "}

--- a/src/routes/compare/QuickCompare.tsx
+++ b/src/routes/compare/QuickCompare.tsx
@@ -382,7 +382,7 @@ function RevealPhase({
         </p>
         <p className="mt-1 text-sm text-muted-foreground">
           Run real LLM outputs through blind evaluation, collect annotations,
-          and optimize prompts with AI feedback.
+          and route blind-review feedback into the next revision.
         </p>
         <Link
           to="/auth/sign-in"

--- a/src/routes/orgs/OrgHome.tsx
+++ b/src/routes/orgs/OrgHome.tsx
@@ -17,7 +17,9 @@ export function OrgHome() {
   return (
     <div className="p-6">
       <h1 className="text-2xl font-bold">{org.name}</h1>
-      <p className="mt-1 text-sm text-muted-foreground">Your prompts</p>
+      <p className="mt-1 text-sm text-muted-foreground">
+        Agent-review projects and prompt workspaces
+      </p>
 
       {inFlight && inFlight.length > 0 && (
         <div className="mt-4 space-y-2">
@@ -87,20 +89,20 @@ export function OrgHome() {
             className="space-y-2"
             role="status"
             aria-live="polite"
-            aria-label="Loading prompts"
+            aria-label="Loading projects"
           >
             {[1, 2, 3, 4, 5].map((i) => (
               <Skeleton key={i} className="h-14 w-full" />
             ))}
-            <span className="sr-only">Loading prompts…</span>
+            <span className="sr-only">Loading projects…</span>
           </div>
         ) : projects.length === 0 ? (
           <EmptyState
             icon={FolderOpen}
-            heading="No prompts yet"
-            description="A prompt holds all its versions, test cases, and run history. Create one to get started."
+            heading="No agent-review projects yet"
+            description="Create a workspace for an agent prompt, test cases, runs, blind reviews, and the verdicts you route back."
             action={{
-              label: "Create prompt",
+              label: "Create project",
               onClick: openNewProjectDialog,
             }}
           />

--- a/src/routes/orgs/Scorecard.tsx
+++ b/src/routes/orgs/Scorecard.tsx
@@ -62,6 +62,7 @@ export function Scorecard() {
   const canRun = role === "owner" || role === "admin";
 
   const latest = useQuery(api.scorecards.latest, { orgId });
+  const creditStatus = useQuery(api.billing.getCreditStatus, { orgId });
   const startRun = useMutation(api.scorecards.start);
 
   const [busy, setBusy] = useState(false);
@@ -89,10 +90,25 @@ export function Scorecard() {
 
   const runButton = canRun ? (
     <div className="flex flex-col items-end gap-1">
-      <Button onClick={handleRun} disabled={busy || inFlight}>
+      <Button
+        onClick={handleRun}
+        disabled={
+          busy ||
+          inFlight ||
+          (creditStatus !== undefined &&
+            creditStatus.remainingCredits < creditStatus.evalRunCost)
+        }
+      >
         <Play aria-hidden="true" className="h-4 w-4" />
         {inFlight ? "Scorecard running…" : busy ? "Starting…" : "Run scorecard"}
       </Button>
+      {creditStatus !== undefined && (
+        <p className="text-xs text-muted-foreground">
+          {creditStatus.remainingCredits < creditStatus.evalRunCost
+            ? "Out of eval credits — add credits in Billing to run the scorecard."
+            : `Costs ${creditStatus.evalRunCost} eval credit · ${creditStatus.remainingCredits.toLocaleString()} remaining`}
+        </p>
+      )}
       {error && (
         <p className="text-xs text-destructive" role="alert">
           {error}

--- a/src/routes/orgs/projects/RunConfigurator.tsx
+++ b/src/routes/orgs/projects/RunConfigurator.tsx
@@ -30,6 +30,7 @@ import { cn } from "@/lib/utils";
 import {
   AlertCircle,
   ChevronDown,
+  CreditCard,
   ChevronRight,
   ExternalLink,
   FlaskConical,
@@ -150,6 +151,7 @@ export function RunConfigurator() {
   const testCases = useQuery(api.testCases.list, { projectId });
   const variables = useQuery(api.variables.list, { projectId });
   const keyStatus = useQuery(api.openRouterKeys.hasKey, { orgId });
+  const creditStatus = useQuery(api.billing.getCreditStatus, { orgId });
   const { models: catalogModels } = useModelCatalog();
 
   // --- Mutations ---
@@ -470,6 +472,9 @@ export function RunConfigurator() {
     ? summaryRows.reduce((sum, r) => sum + (r.cost ?? 0), 0)
     : null;
   const totalRuns = summaryRows.length;
+  const evalCreditCost = creditStatus?.evalRunCost ?? 1;
+  const totalCreditCost = totalRuns * evalCreditCost;
+  const creditsRemaining = creditStatus?.remainingCredits ?? null;
 
   // ---------------------------------------------------------------------------
   // Step 4: Validation
@@ -487,6 +492,12 @@ export function RunConfigurator() {
         return `Select a model for slot ${missingModel.label}.`;
     } else {
       if (!selectedModel) return "Select a model to run.";
+    }
+    if (
+      creditStatus !== undefined &&
+      totalCreditCost > creditStatus.remainingCredits
+    ) {
+      return "Add eval credits in Billing before starting these runs.";
     }
     return null;
   })();
@@ -1249,6 +1260,24 @@ export function RunConfigurator() {
               Select versions, test cases, and configure a model to see the
               run summary.
             </p>
+          )}
+
+          {summaryRows.length > 0 && creditsRemaining !== null && (
+            <div
+              className={cn(
+                "mt-3 flex items-center justify-between gap-3 rounded-md border px-3 py-2 text-xs",
+                totalCreditCost > creditsRemaining
+                  ? "border-amber-500/50 bg-amber-500/5 text-amber-700 dark:text-amber-300"
+                  : "border-border bg-muted/30 text-muted-foreground",
+              )}
+            >
+              <span className="flex items-center gap-2">
+                <CreditCard aria-hidden="true" className="h-3.5 w-3.5" />
+                {totalCreditCost.toLocaleString()} eval credit
+                {totalCreditCost === 1 ? "" : "s"} for this batch
+              </span>
+              <span>{creditsRemaining.toLocaleString()} remaining</span>
+            </div>
           )}
 
           {/* Run button */}

--- a/src/routes/welcome/WelcomeFirstRun.tsx
+++ b/src/routes/welcome/WelcomeFirstRun.tsx
@@ -126,7 +126,7 @@ export function WelcomeFirstRun() {
               What are you working on?
             </h1>
             <p className="text-sm text-muted-foreground">
-              Pick a path. Both land you in a real, editable project.
+              Bring in an agent prompt now, or load the example blind-review loop.
             </p>
           </div>
 
@@ -134,7 +134,7 @@ export function WelcomeFirstRun() {
             <TabsList className="grid w-full grid-cols-2">
               <TabsTrigger value="paste" className="gap-2">
                 <FileText className="h-3.5 w-3.5" />
-                I have a prompt
+                I have an agent prompt
               </TabsTrigger>
               <TabsTrigger value="example" className="gap-2">
                 <Sparkles className="h-3.5 w-3.5" />
@@ -183,7 +183,7 @@ export function WelcomeFirstRun() {
                   </div>
                   <p className="text-[11px] text-muted-foreground">
                     {pasteRole === "system"
-                      ? "Persistent instructions sent at the top of every run."
+                      ? "Persistent instructions sent at the top of every agent run."
                       : "The turn the model responds to. Use {{name}} for variables."}
                   </p>
                 </div>
@@ -203,11 +203,10 @@ export function WelcomeFirstRun() {
 
             <TabsPanel value="example" className="space-y-4 pt-4">
               <div className="space-y-2 rounded-md border bg-muted/30 p-4 text-xs">
-                <p className="font-medium">Tone-rewrite walkthrough</p>
+                <p className="font-medium">Blind-review walkthrough</p>
                 <p className="text-muted-foreground">
-                  A complete prompt with variables, a test case, three blind
-                  outputs, evaluator feedback, and an optimizer suggestion —
-                  all yours to edit, run, and re-optimize.
+                  A complete example: run a candidate, review outputs blind,
+                  capture feedback, and route the verdict into the next version.
                 </p>
               </div>
               <Button


### PR DESCRIPTION
## Summary

Closes #279 · Closes #280 · Closes #281

Addresses the three immediate post-pivot guardrails we called out:

- **Billing credibility**
  - Seed one idempotent `trial_grant` ledger row when a workspace is created.
  - Define v1 credit metering: 1 eval credit per prompt run or scorecard run.
  - Gate prompt runs and scorecard runs transactionally on remaining credits.
  - Write negative `eval_consumption` ledger rows keyed by `promptRunId` / `scorecardRunId` so consumption is idempotent and auditable.
  - Surface eval credit cost/remaining state on Run Configurator and Scorecard, with an actionable out-of-credits message.
- **Polar webhook safety**
  - Add `product_id → packageKey` fallback for metadata-less/off-app Polar purchases.
  - Unknown product ids still fail closed and are acknowledged.
- **App/landing alignment + canonical demo loop**
  - Update auth/onboarding/org copy away from old prompt-only/optimizer-first framing toward agent runs, blind review, and verdict reuse.
  - Add `docs/canonical-demo-loop.md` and link it from the MOC.
  - Update the post-deployment critique doc with the consolidation next action.

## Testing

- `npx convex dev --once --typecheck disable`
- `env -u NODE_ENV npx vitest run --config convex/vitest.config.ts convex/tests/billing.test.ts convex/tests/billingWebhook.test.ts`
- `env -u NODE_ENV npm run test:convex`
- `npm run test:evals`
- `npm run test:ct`
- `npm run build`

## Notes

- Existing workspaces are not backfilled; new workspaces receive trial credits at creation. This matches the project’s pre-launch/no-backfill posture.
- Trace imports are not metered in this PR; package trace-import headroom remains documented but unenforced.
