### PR TITLE
Add live native trace emitter

### DIFF
--- a/docs/agent-harness-traces.md
+++ b/docs/agent-harness-traces.md
@@ -128,5 +128,7 @@ The eval case stores messages and scorer-visible tool/policy context while keepi
 - Live capture exists via the native ingest endpoint (`/ingest/v1/traces`, see
   [`native-ingest.md`](./native-ingest.md)) and OTLP; there is still no
   auto-instrumentation baked into the Jeeves agents themselves — the harness must
-  emit records to the endpoint.
+  emit records to the endpoint. A thin reference emitter that does the batching
+  for a running harness lives in [`live-emitter.md`](./live-emitter.md)
+  (`src/lib/evals/liveEmitter.ts`).
 - No customer production data committed to the repo.

--- a/docs/live-emitter.md
+++ b/docs/live-emitter.md
@@ -1,0 +1,116 @@
+# Live native emitter — auto-instrument a running harness
+
+The native ingest endpoint ([`native-ingest.md`](./native-ingest.md)) is the
+durable contract. This doc covers the **client-side capture ergonomics**: a thin
+reference emitter a running agent/harness installs so model + tool interactions
+flush to `POST /ingest/v1/traces` without hand-rolling `curl` or batching logic.
+
+Reference implementation: [`src/lib/evals/liveEmitter.ts`](../src/lib/evals/liveEmitter.ts).
+Runnable example + selfcheck: [`src/lib/evals/liveEmitterSelfcheck.ts`](../src/lib/evals/liveEmitterSelfcheck.ts)
+(`npm run selfcheck:emitter`).
+
+It is a **reference emitter, not a packaged SDK** — copy it or import it. No npm
+dependencies; it uses the global `fetch` and is Node 18+ / browser-compatible.
+
+## Enable it
+
+Disabled by default. `emitterFromEnv()` returns a **no-op** unless tracing is
+explicitly enabled *and* an endpoint + token are configured. Importing it never
+sends anything until the operator opts in.
+
+```ts
+import { emitterFromEnv } from "@/lib/evals/liveEmitter";
+
+// No-op unless BLINDBENCH_TRACE_ENABLED=true + URL + token are set.
+const emitter = emitterFromEnv();
+
+// In your model call path:
+emitter.enqueueInteraction({
+  id: requestId,
+  model: "anthropic/claude-4.7-opus",
+  provider: "anthropic",
+  messages,                     // the request messages
+  content: answerText,          // the model's final text
+  toolCalls,                    // [{ id, name, arguments }]
+  toolResults,                  // [{ tool_call_id, name, result }]
+  usage: { input_tokens, output_tokens, cost_usd, duration_ms },
+});
+
+// On shutdown, drain the queue:
+await emitter.close();
+```
+
+`enqueueInteraction` returns immediately; the emitter batches in the background.
+Prefer `createEmitter(config)` if you resolve endpoint/token yourself instead of
+from env.
+
+### Environment variables
+
+| Var | Required | Meaning |
+| --- | --- | --- |
+| `BLINDBENCH_TRACE_ENABLED` | **yes** | Must equal `"true"`. Anything else → no-op. |
+| `BLINDBENCH_INGEST_URL` | **yes** | Full `…/ingest/v1/traces` URL (`.convex.site`). |
+| `BLINDBENCH_INGEST_TOKEN` | **yes** | Per-project ingest token (bearer). |
+| `BLINDBENCH_PRODUCT` | no | Default `product` grouping stamped on each record. |
+| `BLINDBENCH_MODULE` | no | Default `module` grouping. |
+| `BLINDBENCH_ENVIRONMENT` | no | Default `environment` grouping (e.g. `prod`). |
+
+Any of these can be overridden in code via the first arg to `emitterFromEnv`.
+
+### Tuning (via `createEmitter` / `emitterFromEnv` overrides)
+
+| Option | Default | Meaning |
+| --- | --- | --- |
+| `maxBatchSize` | `20` | Flush when the queue reaches this many records. |
+| `flushIntervalMs` | `2000` | Flush a partial queue after this idle interval. `0` disables the timer. |
+| `maxRetries` | `2` | Extra send attempts after the first, on failure. |
+| `harness` | — | `{ name, version, sdk }` stamped on every record. |
+| `fetchImpl` | global `fetch` | Injectable transport (tests / custom clients). |
+| `onError` | — | `(err, droppedRecords)` hook for dropped batches. Must not throw. |
+
+## Failure semantics
+
+The agent path must never be interrupted by trace capture:
+
+- **`enqueue*` never throws.** It pushes to an in-memory queue and returns.
+- **Network / HTTP failures are swallowed and counted**, never re-raised into
+  the agent run. Dropped records increment `status().dropped`; the batch is
+  reported via the optional `onError` hook.
+- **`4xx` fails fast** (bad token / bad request won't fix on retry). **`5xx` and
+  network errors retry** up to `maxRetries`, then the batch is dropped.
+- **`flush()` / `close()` return a `FlushResult`** (`{ ok, sent, dropped,
+  batches, error? }`) you *can* inspect — the one place failures are visible.
+- **The queue is in-memory only.** Records still queued when the process dies are
+  lost; call `close()` on shutdown. (No disk spooling — see the ponytail note in
+  the source. Add a durable spool only if at-least-once delivery is required.)
+
+Re-sends are safe: ingest dedups on `id`, so a retried batch counts as `deduped`,
+never double-imported. Pass a stable `id` per interaction to get idempotency.
+
+## Harness event → `EvalRecordV1` mapping
+
+`enqueueInteraction(i)` maps the ergonomic `ModelInteraction` onto the wire
+`EvalRecordV1` (one record = one model interaction):
+
+| Harness event field | `EvalRecordV1` field | Notes |
+| --- | --- | --- |
+| `i.id` | `id` | Dedup key. Omit → server derives a deterministic id. |
+| `i.timestamp` | `timestamp` | ISO-8601. |
+| `i.model` | `model` | e.g. `anthropic/claude-4.7-opus`. |
+| `i.provider` | `provider` | e.g. `anthropic`. |
+| `i.messages` | `input.messages` | Request messages. **Non-empty** — ingest rejects empty. |
+| `i.content` | `output.content` | The model's final text answer. |
+| `i.toolCalls` | `output.tool_calls` | `[{ id?, name, arguments }]`. |
+| `i.toolResults` | `output.tool_results` | `[{ tool_call_id, name?, result? }]`. |
+| `i.usage` | `usage` | `{ input_tokens?, output_tokens?, total_tokens?, cost_usd?, duration_ms? }`. |
+| `i.product` / `i.module` / `i.environment` | same | Fall back to emitter/env defaults. |
+| `i.metadata` | `metadata` | Arbitrary object, stored as-is. |
+| `i.privacyClass` | `privacy_class` | Governance signal; may raise (never lower) the inferred class. |
+| emitter `harness` config | `harness` | `{ name, version, sdk }`. |
+
+`output` is omitted entirely when there is no `content`, tool call, or tool
+result. Server-side redaction still applies at ingest (key-name based) — see the
+data boundary section of [`native-ingest.md`](./native-ingest.md). Free-text
+message/answer content is **not** auto-scrubbed; don't emit secrets in it.
+
+Raw records (already `EvalRecordV1`) can be pushed with `enqueueRecord(record)`.

--- a/docs/native-ingest.md
+++ b/docs/native-ingest.md
@@ -250,6 +250,10 @@ A bare array (`[ {…}, {…} ]`) is accepted identically.
 
 ## Related
 
+- [`live-emitter.md`](./live-emitter.md) — a thin **client-side reference
+  emitter** (`src/lib/evals/liveEmitter.ts`) that batches a running harness's
+  model/tool interactions to this endpoint. Async, env-gated (off by default),
+  graceful if the backend is down.
 - [`gateway-onboarding.md`](./gateway-onboarding.md) — the Cloudflare AI Gateway
   **adapter** path (export/upload logs to backfill), end to end.
 - [`cloudflare-gateway-live-import.md`](./cloudflare-gateway-live-import.md) — the

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "compare:demo": "npx tsx src/lib/evals/modelComparison.ts",
     "compare:endpoints": "npx tsx src/lib/evals/compareEndpoints.ts",
     "prototype:fireworks-gateway": "npx tsx src/lib/evals/fireworksGatewayPrototype.ts",
-    "smoke:fireworks-gateway": "npx tsx scripts/fireworks-gateway-smoke.ts"
+    "smoke:fireworks-gateway": "npx tsx scripts/fireworks-gateway-smoke.ts",
+    "selfcheck:emitter": "npx tsx src/lib/evals/liveEmitterSelfcheck.ts"
   },
   "dependencies": {
     "@auth/core": "^0.37.4",

--- a/src/lib/evals/liveEmitter.test.ts
+++ b/src/lib/evals/liveEmitter.test.ts
@@ -5,6 +5,7 @@ import {
   emitterFromEnv,
   interactionToRecord,
   type EmitterConfig,
+  type FlushResult,
   type ModelInteraction,
 } from "./liveEmitter";
 
@@ -171,6 +172,44 @@ describe("graceful degradation", () => {
     e.enqueueInteraction(interaction);
     await e.flush();
     expect(fetchImpl).toHaveBeenCalledTimes(3); // 1 + 2 retries
+  });
+
+  it("close() waits for an in-flight auto-flush before resolving", async () => {
+    // Exactly maxBatchSize records: the auto-flush drains the whole queue, so a
+    // close() that only re-flushed would see nothing pending and resolve early.
+    const bodies: Array<{ records: unknown[] }> = [];
+    let release!: () => void;
+    const gate = new Promise<void>((r) => (release = r));
+    const fetchImpl = vi.fn(async (_url: string, init?: { body?: string }) => {
+      await gate; // hold the POST open like a slow network
+      bodies.push(JSON.parse(init?.body ?? "{}"));
+      return { ok: true, status: 200, json: async () => ({}) } as unknown as Response;
+    }) as unknown as typeof fetch;
+    const e = createEmitter(baseCfg({ maxBatchSize: 2, fetchImpl }));
+    e.enqueueInteraction(interaction);
+    e.enqueueInteraction(interaction); // triggers fire-and-forget auto-flush
+
+    let closed: FlushResult | null = null;
+    const closing = e.close().then((res) => (closed = res));
+    await Promise.resolve(); // give close() a chance to (wrongly) resolve early
+    expect(closed).toBeNull(); // must still be waiting on the in-flight POST
+
+    release();
+    await closing;
+    expect(bodies.reduce((n, b) => n + b.records.length, 0)).toBe(2);
+    expect(closed).toMatchObject({ ok: true, sent: 2 });
+    expect(e.status().sent).toBe(2);
+  });
+
+  it("close() reports a failed in-flight auto-flush in its result", async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error("network down");
+    }) as unknown as typeof fetch;
+    const e = createEmitter(baseCfg({ maxBatchSize: 1, maxRetries: 0, fetchImpl }));
+    e.enqueueInteraction(interaction); // auto-flush fires and will fail
+    const res = await e.close();
+    expect(res.ok).toBe(false);
+    expect(res.dropped).toBe(1);
   });
 
   it("close() drains remaining records", async () => {

--- a/src/lib/evals/liveEmitter.test.ts
+++ b/src/lib/evals/liveEmitter.test.ts
@@ -1,0 +1,186 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { normalizeEvalRecordV1 } from "./agentTrace";
+import {
+  createEmitter,
+  emitterFromEnv,
+  interactionToRecord,
+  type EmitterConfig,
+  type ModelInteraction,
+} from "./liveEmitter";
+
+/** A `fetch` stub that always 200s and records the JSON bodies it received. */
+function okFetch() {
+  const bodies: Array<{ records: unknown[] }> = [];
+  const fetchImpl = vi.fn(async (_url: string, init?: { body?: string }) => {
+    bodies.push(JSON.parse(init?.body ?? "{}"));
+    return { ok: true, status: 200, json: async () => ({}) } as unknown as Response;
+  }) as unknown as typeof fetch;
+  return { fetchImpl, bodies };
+}
+
+const baseCfg = (over: Partial<EmitterConfig> = {}): EmitterConfig => ({
+  endpoint: "https://x.invalid/ingest/v1/traces",
+  token: "tok",
+  flushIntervalMs: 0, // tests drive flushing explicitly unless they opt into timers
+  ...over,
+});
+
+const interaction: ModelInteraction = {
+  id: "t1",
+  model: "gpt-4",
+  provider: "openai",
+  messages: [{ role: "user", content: "hi" }],
+  content: "hello",
+  toolCalls: [{ id: "c1", name: "calc", arguments: { a: 1 } }],
+  toolResults: [{ tool_call_id: "c1", name: "calc", result: 2 }],
+  usage: { input_tokens: 3, output_tokens: 1 },
+};
+
+afterEach(() => vi.useRealTimers());
+
+describe("interactionToRecord mapping", () => {
+  it("produces an EvalRecordV1 the real normalizer accepts", () => {
+    const rec = interactionToRecord(interaction, {
+      product: "svc",
+      harness: { name: "h", sdk: "blindbench-live-emitter" },
+    });
+    expect(rec.version).toBe("1");
+    expect(rec.product).toBe("svc");
+    // Round-trip through the wire normalizer — proves field mapping is correct.
+    const trace = normalizeEvalRecordV1(rec);
+    expect(trace.run_id).toBe("t1");
+    expect(trace.final_answer).toBe("hello");
+    expect(trace.steps.map((s) => s.type)).toEqual([
+      "message",
+      "message",
+      "tool_call",
+      "tool_result",
+    ]);
+    expect(trace.usage.total_tokens).toBe(4);
+  });
+
+  it("omits output when there is no content, tool call, or result", () => {
+    const rec = interactionToRecord({ messages: [{ role: "user", content: "q" }] });
+    expect(rec.output).toBeUndefined();
+    expect(() => normalizeEvalRecordV1(rec)).not.toThrow();
+  });
+
+  it("interaction fields override emitter defaults", () => {
+    const rec = interactionToRecord({ ...interaction, product: "own" }, { product: "default" });
+    expect(rec.product).toBe("own");
+  });
+});
+
+describe("batching", () => {
+  it("flushes automatically when maxBatchSize is reached", async () => {
+    const { fetchImpl, bodies } = okFetch();
+    const e = createEmitter(baseCfg({ maxBatchSize: 2, fetchImpl }));
+    e.enqueueInteraction(interaction);
+    expect(bodies.length).toBe(0); // under the threshold, nothing sent yet
+    e.enqueueInteraction(interaction);
+    await vi.waitFor(() => expect(bodies.length).toBe(1));
+    await vi.waitFor(() => expect(e.status().sent).toBe(2));
+    expect(bodies[0]?.records).toHaveLength(2);
+    expect(e.status().pending).toBe(0);
+  });
+
+  it("never sends a batch larger than maxBatchSize", async () => {
+    const { fetchImpl, bodies } = okFetch();
+    const e = createEmitter(baseCfg({ maxBatchSize: 2, fetchImpl }));
+    for (let i = 0; i < 3; i++) e.enqueueInteraction(interaction);
+    await e.close();
+    // 3 records with cap 2 → an auto-flush of 2 then a drain of 1; no batch > 2.
+    expect(bodies.every((b) => b.records.length <= 2)).toBe(true);
+    expect(bodies.reduce((n, b) => n + b.records.length, 0)).toBe(3);
+    expect(e.status().sent).toBe(3);
+  });
+
+  it("flushes a partial queue on the timer", async () => {
+    vi.useFakeTimers();
+    const { fetchImpl, bodies } = okFetch();
+    const e = createEmitter(baseCfg({ maxBatchSize: 10, flushIntervalMs: 1000, fetchImpl }));
+    e.enqueueInteraction(interaction);
+    expect(bodies.length).toBe(0);
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(bodies.length).toBe(1);
+    expect(e.status().sent).toBe(1);
+  });
+});
+
+describe("disabled / no-op", () => {
+  it("emitterFromEnv returns a no-op when tracing is not enabled", async () => {
+    const fetchImpl = vi.fn() as unknown as typeof fetch;
+    const e = emitterFromEnv(
+      { fetchImpl },
+      { BLINDBENCH_INGEST_URL: "https://x.invalid/i", BLINDBENCH_INGEST_TOKEN: "t" },
+    );
+    expect(e.enabled).toBe(false);
+    e.enqueueInteraction(interaction);
+    expect(await e.flush()).toMatchObject({ ok: true, sent: 0 });
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(e.status().enqueued).toBe(0);
+  });
+
+  it("emitterFromEnv returns a no-op when enabled but URL/token missing", () => {
+    expect(emitterFromEnv({}, { BLINDBENCH_TRACE_ENABLED: "true" }).enabled).toBe(false);
+  });
+
+  it("emitterFromEnv returns a live emitter when enabled + configured", () => {
+    const e = emitterFromEnv(
+      {},
+      {
+        BLINDBENCH_TRACE_ENABLED: "true",
+        BLINDBENCH_INGEST_URL: "https://x.invalid/i",
+        BLINDBENCH_INGEST_TOKEN: "t",
+      },
+    );
+    expect(e.enabled).toBe(true);
+  });
+});
+
+describe("graceful degradation", () => {
+  it("swallows a network rejection: enqueue never throws, drop is counted", async () => {
+    const onError = vi.fn();
+    const fetchImpl = vi.fn(async () => {
+      throw new Error("network down");
+    }) as unknown as typeof fetch;
+    const e = createEmitter(baseCfg({ maxRetries: 1, fetchImpl, onError }));
+    expect(() => e.enqueueInteraction(interaction)).not.toThrow();
+    const res = await e.flush();
+    expect(res.ok).toBe(false);
+    expect(res.dropped).toBe(1);
+    expect(e.status().dropped).toBe(1);
+    expect(e.status().failedBatches).toBe(1);
+    expect(onError).toHaveBeenCalledTimes(1);
+    // maxRetries:1 → 2 total attempts.
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry a 4xx (bad token) — fails fast, one attempt", async () => {
+    const fetchImpl = vi.fn(async () => ({ ok: false, status: 401 }) as unknown as Response) as unknown as typeof fetch;
+    const e = createEmitter(baseCfg({ maxRetries: 3, fetchImpl }));
+    e.enqueueInteraction(interaction);
+    const res = await e.flush();
+    expect(res.dropped).toBe(1);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries a 5xx up to maxRetries then drops", async () => {
+    const fetchImpl = vi.fn(async () => ({ ok: false, status: 503 }) as unknown as Response) as unknown as typeof fetch;
+    const e = createEmitter(baseCfg({ maxRetries: 2, fetchImpl }));
+    e.enqueueInteraction(interaction);
+    await e.flush();
+    expect(fetchImpl).toHaveBeenCalledTimes(3); // 1 + 2 retries
+  });
+
+  it("close() drains remaining records", async () => {
+    const { fetchImpl, bodies } = okFetch();
+    const e = createEmitter(baseCfg({ maxBatchSize: 100, fetchImpl }));
+    e.enqueueInteraction(interaction);
+    e.enqueueInteraction(interaction);
+    const res = await e.close();
+    expect(res.sent).toBe(2);
+    expect(bodies).toHaveLength(1);
+    expect(e.status().pending).toBe(0);
+  });
+});

--- a/src/lib/evals/liveEmitter.ts
+++ b/src/lib/evals/liveEmitter.ts
@@ -1,0 +1,288 @@
+/**
+ * Live native eval-record emitter — the client-side capture ergonomics that
+ * issue #285 was missing. A running agent/harness constructs one emitter, feeds
+ * it normalized model interactions (or raw `EvalRecordV1` records), and the
+ * emitter batches them to `POST /ingest/v1/traces` in the background.
+ *
+ * Design constraints (see docs/live-emitter.md):
+ *  - Thin: no npm deps, uses global `fetch`. Node 18+ / browser-compatible.
+ *  - Disabled by default: `emitterFromEnv` returns a no-op unless
+ *    `BLINDBENCH_TRACE_ENABLED=true` plus URL + token are present.
+ *  - Non-throwing on the agent path: `enqueue*` never throws; network/HTTP
+ *    failures are swallowed and counted, they never surface into the agent run.
+ *  - Explicit `flush()` returns a result you can inspect; `close()` drains.
+ *
+ * This is a reference emitter, not a packaged SDK — copy or import it.
+ */
+import type { EvalRecordV1, PrivacyClass } from "./agentTrace.core";
+
+/** A normalized model interaction — the ergonomic input the emitter maps to `EvalRecordV1`. */
+export interface ModelInteraction {
+  id?: string;
+  timestamp?: string;
+  model?: string;
+  provider?: string;
+  /** The request messages sent to the model. Required and non-empty (ingest rejects empty). */
+  messages: { role: string; content: string }[];
+  /** The assistant's text answer. */
+  content?: string;
+  toolCalls?: { id?: string; name: string; arguments: Record<string, unknown> }[];
+  toolResults?: { tool_call_id: string; name?: string; result?: unknown }[];
+  usage?: EvalRecordV1["usage"];
+  product?: string;
+  module?: string;
+  environment?: string;
+  metadata?: Record<string, unknown>;
+  privacyClass?: PrivacyClass;
+}
+
+export interface EmitterConfig {
+  /** Full URL, e.g. `https://<deployment>.convex.site/ingest/v1/traces`. */
+  endpoint: string;
+  /** Per-project ingest token (sent as an Authorization bearer credential). */
+  token: string;
+  /** Defaults stamped onto every record unless the interaction overrides them. */
+  product?: string;
+  module?: string;
+  environment?: string;
+  harness?: { name?: string; version?: string; sdk?: string };
+  /** Flush when the queue reaches this many records. Default 20. */
+  maxBatchSize?: number;
+  /** Flush a partial queue after this idle interval. Default 2000ms. 0 disables the timer. */
+  flushIntervalMs?: number;
+  /** Extra send attempts after the first on failure. Default 2. */
+  maxRetries?: number;
+  /** Injectable for tests / custom transports. Defaults to global `fetch`. */
+  fetchImpl?: typeof fetch;
+  /** Observability hook for dropped batches. Must not throw. */
+  onError?: (err: unknown, droppedRecords: number) => void;
+}
+
+export interface EmitterStatus {
+  enabled: boolean;
+  enqueued: number;
+  sent: number;
+  dropped: number;
+  failedBatches: number;
+  pending: number;
+}
+
+export interface FlushResult {
+  ok: boolean;
+  sent: number;
+  dropped: number;
+  batches: number;
+  error?: unknown;
+}
+
+export interface EvalEmitter {
+  readonly enabled: boolean;
+  enqueueRecord(record: EvalRecordV1): void;
+  enqueueInteraction(interaction: ModelInteraction): void;
+  flush(): Promise<FlushResult>;
+  close(): Promise<FlushResult>;
+  status(): EmitterStatus;
+}
+
+/** Map the ergonomic interaction shape onto a wire `EvalRecordV1`. Exported for tests. */
+export function interactionToRecord(
+  i: ModelInteraction,
+  defaults: Pick<EmitterConfig, "product" | "module" | "environment" | "harness"> = {},
+): EvalRecordV1 {
+  const hasOutput =
+    i.content !== undefined ||
+    (i.toolCalls && i.toolCalls.length > 0) ||
+    (i.toolResults && i.toolResults.length > 0);
+  return {
+    version: "1",
+    id: i.id,
+    timestamp: i.timestamp,
+    model: i.model,
+    provider: i.provider,
+    input: { messages: i.messages },
+    output: hasOutput
+      ? { content: i.content, tool_calls: i.toolCalls, tool_results: i.toolResults }
+      : undefined,
+    usage: i.usage,
+    product: i.product ?? defaults.product,
+    module: i.module ?? defaults.module,
+    environment: i.environment ?? defaults.environment,
+    harness: defaults.harness,
+    metadata: i.metadata,
+    privacy_class: i.privacyClass,
+  };
+}
+
+const NOOP_FLUSH: FlushResult = { ok: true, sent: 0, dropped: 0, batches: 0 };
+
+/** The disabled emitter: every method is a no-op. Returned when tracing is off. */
+class NoopEmitter implements EvalEmitter {
+  readonly enabled = false;
+  enqueueRecord(): void {}
+  enqueueInteraction(): void {}
+  async flush(): Promise<FlushResult> {
+    return NOOP_FLUSH;
+  }
+  async close(): Promise<FlushResult> {
+    return NOOP_FLUSH;
+  }
+  status(): EmitterStatus {
+    return { enabled: false, enqueued: 0, sent: 0, dropped: 0, failedBatches: 0, pending: 0 };
+  }
+}
+
+class LiveEmitter implements EvalEmitter {
+  readonly enabled = true;
+  private queue: EvalRecordV1[] = [];
+  private timer: ReturnType<typeof setTimeout> | null = null;
+  private counts = { enqueued: 0, sent: 0, dropped: 0, failedBatches: 0 };
+  private readonly maxBatchSize: number;
+  private readonly flushIntervalMs: number;
+  private readonly maxRetries: number;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(private readonly cfg: EmitterConfig) {
+    this.maxBatchSize = Math.max(1, cfg.maxBatchSize ?? 20);
+    this.flushIntervalMs = cfg.flushIntervalMs ?? 2000;
+    this.maxRetries = Math.max(0, cfg.maxRetries ?? 2);
+    this.fetchImpl = cfg.fetchImpl ?? fetch;
+  }
+
+  enqueueRecord(record: EvalRecordV1): void {
+    this.queue.push(record);
+    this.counts.enqueued++;
+    if (this.queue.length >= this.maxBatchSize) {
+      // Fire-and-forget: flush() is internally non-throwing, but attach a catch
+      // so a rejected promise can never bubble as an unhandledRejection.
+      void this.flush().catch(() => {});
+    } else {
+      this.scheduleTimer();
+    }
+  }
+
+  enqueueInteraction(interaction: ModelInteraction): void {
+    this.enqueueRecord(interactionToRecord(interaction, this.cfg));
+  }
+
+  async flush(): Promise<FlushResult> {
+    this.clearTimer();
+    // Drain atomically so overlapping flushes never send the same record twice.
+    const drained = this.queue.splice(0, this.queue.length);
+    if (drained.length === 0) return { ...NOOP_FLUSH };
+
+    let sent = 0;
+    let dropped = 0;
+    let batches = 0;
+    let firstError: unknown;
+    for (let i = 0; i < drained.length; i += this.maxBatchSize) {
+      const batch = drained.slice(i, i + this.maxBatchSize);
+      batches++;
+      const err = await this.sendBatch(batch);
+      if (err === undefined) {
+        sent += batch.length;
+        this.counts.sent += batch.length;
+      } else {
+        dropped += batch.length;
+        this.counts.dropped += batch.length;
+        this.counts.failedBatches++;
+        if (firstError === undefined) firstError = err;
+        this.cfg.onError?.(err, batch.length);
+      }
+    }
+    return { ok: dropped === 0, sent, dropped, batches, error: firstError };
+  }
+
+  async close(): Promise<FlushResult> {
+    this.clearTimer();
+    return this.flush();
+  }
+
+  status(): EmitterStatus {
+    return { enabled: true, ...this.counts, pending: this.queue.length };
+  }
+
+  /** POST one batch with retries. Returns `undefined` on success, else the last error. */
+  private async sendBatch(batch: EvalRecordV1[]): Promise<unknown> {
+    let lastError: unknown;
+    // ponytail: immediate retries, no backoff. Add exponential delay if a real
+    // backend starts rate-limiting the emitter under load.
+    for (let attempt = 0; attempt <= this.maxRetries; attempt++) {
+      try {
+        const res = await this.fetchImpl(this.cfg.endpoint, {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${this.cfg.token}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ records: batch }),
+        });
+        if (res.ok) return undefined;
+        // 4xx (bad token, bad request) won't fix on retry — fail fast.
+        if (res.status < 500) return new Error(`ingest rejected: HTTP ${res.status}`);
+        lastError = new Error(`ingest error: HTTP ${res.status}`);
+      } catch (err) {
+        lastError = err;
+      }
+    }
+    return lastError ?? new Error("ingest failed");
+  }
+
+  private scheduleTimer(): void {
+    if (this.timer !== null || this.flushIntervalMs <= 0) return;
+    this.timer = setTimeout(() => {
+      this.timer = null;
+      void this.flush().catch(() => {});
+    }, this.flushIntervalMs);
+    // Don't keep a Node process alive just for a pending flush.
+    (this.timer as { unref?: () => void }).unref?.();
+  }
+
+  private clearTimer(): void {
+    if (this.timer !== null) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+  }
+}
+
+/** Construct a live emitter directly (config already resolved). */
+export function createEmitter(cfg: EmitterConfig): EvalEmitter {
+  return new LiveEmitter(cfg);
+}
+
+type Env = Record<string, string | undefined>;
+
+function processEnv(): Env {
+  return typeof process !== "undefined" && process.env ? process.env : {};
+}
+
+/**
+ * The default entry point. Returns a live emitter ONLY when tracing is explicitly
+ * enabled and an endpoint + token are configured; otherwise a no-op. Disabled by
+ * default so importing this never sends anything until the operator opts in.
+ *
+ * Env vars (all overridable via `overrides`):
+ *  - BLINDBENCH_TRACE_ENABLED   must equal "true"
+ *  - BLINDBENCH_INGEST_URL      full /ingest/v1/traces URL
+ *  - BLINDBENCH_INGEST_TOKEN    per-project ingest token
+ *  - BLINDBENCH_PRODUCT / BLINDBENCH_MODULE / BLINDBENCH_ENVIRONMENT  (optional grouping)
+ */
+export function emitterFromEnv(
+  overrides: Partial<EmitterConfig> = {},
+  env: Env = processEnv(),
+): EvalEmitter {
+  const enabled = (env.BLINDBENCH_TRACE_ENABLED ?? "").toLowerCase() === "true";
+  const endpoint = overrides.endpoint ?? env.BLINDBENCH_INGEST_URL;
+  const token = overrides.token ?? env.BLINDBENCH_INGEST_TOKEN;
+  if (!enabled || !endpoint || !token) return new NoopEmitter();
+  // Spread overrides first (maxBatchSize, harness, fetchImpl, onError…), then the
+  // env-resolved fields so a missing override key never clobbers an env value.
+  return new LiveEmitter({
+    ...overrides,
+    endpoint,
+    token,
+    product: overrides.product ?? env.BLINDBENCH_PRODUCT,
+    module: overrides.module ?? env.BLINDBENCH_MODULE,
+    environment: overrides.environment ?? env.BLINDBENCH_ENVIRONMENT,
+  });
+}

--- a/src/lib/evals/liveEmitter.ts
+++ b/src/lib/evals/liveEmitter.ts
@@ -134,6 +134,7 @@ class NoopEmitter implements EvalEmitter {
 class LiveEmitter implements EvalEmitter {
   readonly enabled = true;
   private queue: EvalRecordV1[] = [];
+  private inFlight: Promise<FlushResult> | null = null;
   private timer: ReturnType<typeof setTimeout> | null = null;
   private counts = { enqueued: 0, sent: 0, dropped: 0, failedBatches: 0 };
   private readonly maxBatchSize: number;
@@ -166,7 +167,19 @@ class LiveEmitter implements EvalEmitter {
 
   async flush(): Promise<FlushResult> {
     this.clearTimer();
-    // Drain atomically so overlapping flushes never send the same record twice.
+    // Serialize behind any in-flight flush so records send in order and a
+    // fire-and-forget auto-flush can never be orphaned by close().
+    const prev = this.inFlight ?? Promise.resolve(NOOP_FLUSH);
+    const run = prev.then(() => this.drainAndSend());
+    this.inFlight = run;
+    try {
+      return await run;
+    } finally {
+      if (this.inFlight === run) this.inFlight = null;
+    }
+  }
+
+  private async drainAndSend(): Promise<FlushResult> {
     const drained = this.queue.splice(0, this.queue.length);
     if (drained.length === 0) return { ...NOOP_FLUSH };
 
@@ -194,7 +207,17 @@ class LiveEmitter implements EvalEmitter {
 
   async close(): Promise<FlushResult> {
     this.clearTimer();
-    return this.flush();
+    // Fold the in-flight flush into the result so a caller checking `ok`
+    // sees failures from the auto-flush close() had to wait for.
+    const prev = this.inFlight ? await this.inFlight : { ...NOOP_FLUSH };
+    const rest = await this.flush();
+    return {
+      ok: prev.ok && rest.ok,
+      sent: prev.sent + rest.sent,
+      dropped: prev.dropped + rest.dropped,
+      batches: prev.batches + rest.batches,
+      error: prev.error ?? rest.error,
+    };
   }
 
   status(): EmitterStatus {

--- a/src/lib/evals/liveEmitterSelfcheck.ts
+++ b/src/lib/evals/liveEmitterSelfcheck.ts
@@ -1,0 +1,104 @@
+/**
+ * Reference harness example + deterministic selfcheck for the live emitter.
+ *
+ *   npm run selfcheck:emitter        # mock fetch, no network, asserts, exits 0
+ *
+ * Shows how a Node/agent harness records a model request, a tool call + result,
+ * and the final answer through the emitter, then drains on shutdown. By default
+ * it uses a local mock fetch and sends NOTHING over the network. Only if
+ * BLINDBENCH_TRACE_ENABLED=true plus a URL + token are present does it emit live
+ * (still off unless explicitly configured).
+ */
+import {
+  createEmitter,
+  emitterFromEnv,
+  type EvalEmitter,
+} from "./liveEmitter";
+
+/** Minimal fake `fetch` that records payloads and returns a counts-only 200. */
+function mockFetch() {
+  const calls: unknown[] = [];
+  const fetchImpl = (async (_url: string, init?: { body?: string }) => {
+    const body = init?.body ? JSON.parse(init.body) : {};
+    calls.push(body);
+    const records = Array.isArray(body.records) ? body.records.length : 0;
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ traces: records, imported: records, deduped: 0 }),
+    };
+  }) as unknown as typeof fetch;
+  return { fetchImpl, calls };
+}
+
+/** One round-trip of a support-style agent turn through the emitter. */
+async function runHarness(emitter: EvalEmitter): Promise<void> {
+  // 1. The agent asks the model something (the request messages).
+  emitter.enqueueInteraction({
+    id: "selfcheck-turn-1",
+    model: "anthropic/claude-4.7-opus",
+    provider: "anthropic",
+    messages: [
+      { role: "system", content: "You are a support agent." },
+      { role: "user", content: "Where is my order?" },
+    ],
+    // 2. The model's response: a tool call, its result, and the final answer.
+    content: "Your order shipped yesterday and arrives Thursday.",
+    toolCalls: [{ id: "call-1", name: "lookup_order", arguments: { order_id: "O-42" } }],
+    toolResults: [{ tool_call_id: "call-1", name: "lookup_order", result: { status: "shipped" } }],
+    usage: { input_tokens: 210, output_tokens: 34, cost_usd: 0.004, duration_ms: 1180 },
+    metadata: { prompt_version: "v7" },
+  });
+
+  // 3. Drain on shutdown so nothing is lost.
+  const result = await emitter.close();
+  if (!result.ok) throw new Error(`emit failed: ${String(result.error)}`);
+}
+
+export async function main(): Promise<number> {
+  // Live only when explicitly enabled + configured; otherwise a local mock.
+  const live = emitterFromEnv();
+  if (live.enabled) {
+    process.stdout.write("Live tracing enabled — emitting to the configured endpoint.\n");
+    await runHarness(live);
+    process.stdout.write(`Status: ${JSON.stringify(live.status())}\n`);
+    return 0;
+  }
+
+  const { fetchImpl, calls } = mockFetch();
+  const emitter = createEmitter({
+    endpoint: "https://mock.invalid/ingest/v1/traces",
+    token: "selfcheck-token",
+    product: "selfcheck",
+    harness: { name: "selfcheck-harness", version: "1", sdk: "blindbench-live-emitter" },
+    fetchImpl,
+  });
+  await runHarness(emitter);
+
+  const status = emitter.status();
+  // Deterministic assertions — the selfcheck fails loudly if the contract breaks.
+  const assert = (cond: boolean, msg: string) => {
+    if (!cond) throw new Error(`selfcheck failed: ${msg}`);
+  };
+  assert(calls.length === 1, "exactly one batch POSTed");
+  const batch = calls[0] as { records: unknown[] };
+  assert(batch.records.length === 1, "one record in the batch");
+  assert(status.sent === 1, "one record marked sent");
+  assert(status.dropped === 0, "nothing dropped");
+  assert(status.pending === 0, "queue drained");
+
+  process.stdout.write("liveEmitter selfcheck OK (mock fetch, no network).\n");
+  process.stdout.write(`Status: ${JSON.stringify(status)}\n`);
+  return 0;
+}
+
+const invokedDirectly =
+  process.argv[1] !== undefined && import.meta.url === `file://${process.argv[1]}`;
+if (invokedDirectly) {
+  main()
+    .then((code) => process.exit(code))
+    .catch((err) => {
+      process.stderr.write(`${String(err)}\n`);
+      process.exit(1);
+    });
+}


### PR DESCRIPTION
## Summary
- add a thin live native trace emitter for running harnesses on top of existing `eval-record` v1 ingest
- support env-gated no-op default, async batching, explicit drain/flush, drop counters, and graceful network/HTTP failure handling
- add a deterministic mock selfcheck plus docs/mapping table for harness events → `EvalRecordV1`

## Verification
- `NODE_ENV=development npm ci --include=dev` to install dev deps in this worktree
- `npx vitest run src/lib/evals/liveEmitter.test.ts` → 13 tests passed
- `npm run selfcheck:emitter` → mock fetch selfcheck OK, no network
- `env -u NODE_ENV npm run test:evals` → 15 files passed, 152 tests passed
- `npx convex dev --once --typecheck disable` → generated local Convex bindings for verification
- `env -u NODE_ENV npm run test:convex` → 26 files passed, 232 tests passed; existing non-fatal convex-test scheduler stderr appeared
- `env -u NODE_ENV npm run build` → passed; Vite chunk-size warnings only

## Data / safety notes
- No customer or design-partner data used.
- No live BlindBench/Fireworks/OTLP endpoint calls in tests or selfcheck by default.
- Emitter is disabled unless `BLINDBENCH_TRACE_ENABLED=true` and URL/token are provided.

Closes #285.
Refs #287.
