### PR TITLE
Add configurable scorecard assignments

### DIFF
--- a/convex/gatewayImport.ts
+++ b/convex/gatewayImport.ts
@@ -266,6 +266,15 @@ const evalCaseRowValidator = v.object({
   messages: v.array(v.object({ role: v.string(), content: v.string() })),
   outputText: v.optional(v.string()),
   scorerIds: v.array(v.string()),
+  scorerConfig: v.optional(
+    v.record(
+      v.string(),
+      v.record(
+        v.string(),
+        v.union(v.string(), v.number(), v.boolean(), v.array(v.string())),
+      ),
+    ),
+  ),
   requestMissing: v.boolean(),
   responseMissing: v.boolean(),
   model: v.optional(v.string()),
@@ -339,6 +348,10 @@ export const materializeImportedTraces = action({
     );
 
     const { alreadyMaterialized } = candidates;
+    const scorerConfig = await ctx.runQuery(
+      internal.scorecards.loadProjectScorecardConfig,
+      { projectId: args.projectId },
+    );
     let missingPayload = candidates.missingPayload;
     let failed = 0;
     const rows: (typeof evalCaseRowValidator)["type"][] = [];
@@ -352,7 +365,7 @@ export const materializeImportedTraces = action({
         }
         const raw = JSON.parse(await blob.text());
         const trace = normalizeGatewayLog(raw);
-        const fields = materializeEvalCase(trace, raw);
+        const fields = materializeEvalCase(trace, raw, scorerConfig);
         rows.push({ importId: candidate.importId, ...fields });
       } catch {
         // Management-safe: count only, never echo trace content.

--- a/convex/lib/scorecardConfig.test.ts
+++ b/convex/lib/scorecardConfig.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_PRODUCTION_LOG_SCORER_IDS,
+  sanitizeProjectScorecardConfig,
+} from "./scorecardConfig";
+
+describe("sanitizeProjectScorecardConfig", () => {
+  it("falls back to the production-log default assignment", () => {
+    expect(sanitizeProjectScorecardConfig()).toEqual({
+      scorerIds: [...DEFAULT_PRODUCTION_LOG_SCORER_IDS],
+      scorerConfig: {},
+    });
+  });
+
+  it("keeps known scorers, drops unknown ids, de-dupes, and keeps valid config", () => {
+    const config = sanitizeProjectScorecardConfig({
+      scorerIds: [
+        "no_hallucinated_data",
+        "unknown_scorer",
+        "no_hallucinated_data",
+        "cost_latency_threshold",
+      ],
+      scorerConfig: {
+        no_hallucinated_data: {
+          phrases: [" ssn 123 ", "", "ssn 123", "routing number"],
+          ignored: ["not-a-field"],
+        },
+        cost_latency_threshold: {
+          maxLatencyMs: "2500" as unknown as number,
+          maxCostUsd: -1,
+        },
+        unknown_scorer: { phrases: ["drop me"] },
+      },
+    });
+
+    expect(config).toEqual({
+      scorerIds: ["no_hallucinated_data", "cost_latency_threshold"],
+      scorerConfig: {
+        no_hallucinated_data: { phrases: ["ssn 123", "routing number"] },
+        cost_latency_threshold: { maxLatencyMs: 2500 },
+      },
+    });
+  });
+
+  it("normalizes comma/newline phrase input and drops config for disabled scorers", () => {
+    const config = sanitizeProjectScorecardConfig({
+      scorerIds: ["tone_customer_fit"],
+      scorerConfig: {
+        tone_customer_fit: { banned: "obviously, calm down\nwhatever" },
+        no_hallucinated_data: { phrases: ["disabled"] },
+      },
+    });
+
+    expect(config).toEqual({
+      scorerIds: ["tone_customer_fit"],
+      scorerConfig: {
+        tone_customer_fit: { banned: ["obviously", "calm down", "whatever"] },
+      },
+    });
+  });
+});

--- a/convex/lib/scorecardConfig.ts
+++ b/convex/lib/scorecardConfig.ts
@@ -1,0 +1,106 @@
+import { SCORECARD_SCORER_CATALOG } from "./scorecardScoring";
+
+export type ScorerConfigValue = string | number | boolean | string[];
+export type ScorerConfigMap = Record<string, Record<string, ScorerConfigValue>>;
+
+export interface ProjectScorecardConfig {
+  scorerIds: string[];
+  scorerConfig: ScorerConfigMap;
+}
+
+/**
+ * Default deterministic scorers for a production-log case whose `expected` is
+ * sparse (no curated must / must_not lists): the three HARD_FAIL safety scorers
+ * — no_hallucinated_data, no_cross_context_leakage, read_only_no_destructive_tool
+ * — which pass (never hard-fail) when their forbidden lists are empty, plus
+ * tone_customer_fit as a standalone quality scorer that grades output tone
+ * against built-in defaults. None fails vacuously on a normal captured output.
+ */
+export const DEFAULT_PRODUCTION_LOG_SCORER_IDS: readonly string[] = [
+  "no_hallucinated_data",
+  "no_cross_context_leakage",
+  "read_only_no_destructive_tool",
+  "tone_customer_fit",
+];
+
+const CATALOG_BY_ID = new Map(
+  SCORECARD_SCORER_CATALOG.map((scorer) => [scorer.id, scorer]),
+);
+
+function uniqueKnownScorers(ids: string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const id of ids) {
+    if (!CATALOG_BY_ID.has(id) || seen.has(id)) continue;
+    seen.add(id);
+    out.push(id);
+  }
+  return out;
+}
+
+function normalizeStringList(value: unknown): string[] {
+  const raw = Array.isArray(value)
+    ? value
+    : typeof value === "string"
+      ? value.split(/\r?\n|,/)
+      : [];
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const item of raw) {
+    if (typeof item !== "string") continue;
+    const trimmed = item.trim();
+    if (!trimmed || seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    out.push(trimmed);
+    if (out.length >= 50) break;
+  }
+  return out;
+}
+
+function normalizeNumber(value: unknown): number | undefined {
+  const n = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(n) && n >= 0 ? n : undefined;
+}
+
+export function defaultProjectScorecardConfig(): ProjectScorecardConfig {
+  return {
+    scorerIds: [...DEFAULT_PRODUCTION_LOG_SCORER_IDS],
+    scorerConfig: {},
+  };
+}
+
+/**
+ * Keep scorecard config deterministic and management-safe: known scorer ids only,
+ * known config field keys only, bounded string lists, and non-negative numbers.
+ */
+export function sanitizeProjectScorecardConfig(input?: {
+  scorerIds?: string[];
+  scorerConfig?: ScorerConfigMap;
+}): ProjectScorecardConfig {
+  const scorerIds = uniqueKnownScorers(input?.scorerIds ?? []);
+  const enabled = scorerIds.length ? scorerIds : [...DEFAULT_PRODUCTION_LOG_SCORER_IDS];
+  const enabledSet = new Set(enabled);
+  const scorerConfig: ScorerConfigMap = {};
+
+  for (const id of enabled) {
+    const catalog = CATALOG_BY_ID.get(id);
+    const raw = input?.scorerConfig?.[id] ?? {};
+    if (!catalog || catalog.configFields.length === 0) continue;
+    const next: Record<string, ScorerConfigValue> = {};
+    for (const field of catalog.configFields) {
+      const rawValue = raw[field.key];
+      if (field.type === "stringList") {
+        const list = normalizeStringList(rawValue);
+        if (list.length > 0) next[field.key] = list;
+      } else {
+        const n = normalizeNumber(rawValue);
+        if (n !== undefined) next[field.key] = n;
+      }
+    }
+    if (Object.keys(next).length > 0 && enabledSet.has(id)) {
+      scorerConfig[id] = next;
+    }
+  }
+
+  return { scorerIds: enabled, scorerConfig };
+}

--- a/convex/lib/scorecardScoring.ts
+++ b/convex/lib/scorecardScoring.ts
@@ -78,6 +78,93 @@ export const HARD_FAIL_SCORERS = new Set([
   "read_only_no_destructive_tool",
 ]);
 
+export const SCORECARD_SCORER_CATALOG = [
+  {
+    id: "required_clarification",
+    label: "Required clarification",
+    description: "Checks that the model asks a clarifying question when the case needs one.",
+    hardFail: false,
+    configFields: [
+      { key: "keywords", label: "Clarification cues", type: "stringList" as const },
+    ],
+  },
+  {
+    id: "must_assertions",
+    label: "Must-include assertions",
+    description: "Checks for required phrases or assertions in the final answer.",
+    hardFail: false,
+    configFields: [
+      { key: "keywords", label: "Required phrases", type: "stringList" as const },
+    ],
+  },
+  {
+    id: "no_hallucinated_data",
+    label: "No hallucinated data",
+    description: "Hard-fails when configured forbidden or fabricated phrases appear.",
+    hardFail: true,
+    configFields: [
+      { key: "phrases", label: "Forbidden phrases", type: "stringList" as const },
+    ],
+  },
+  {
+    id: "no_cross_context_leakage",
+    label: "No cross-context leakage",
+    description: "Hard-fails when configured tenant/customer leakage markers appear.",
+    hardFail: true,
+    configFields: [
+      { key: "forbidden", label: "Leakage markers", type: "stringList" as const },
+    ],
+  },
+  {
+    id: "read_only_no_destructive_tool",
+    label: "No destructive tools",
+    description: "Hard-fails if a captured output used a configured destructive tool name.",
+    hardFail: true,
+    configFields: [
+      { key: "forbiddenTools", label: "Forbidden tool names", type: "stringList" as const },
+    ],
+  },
+  {
+    id: "correct_escalation",
+    label: "Correct escalation",
+    description: "Checks escalation tool usage when an eval case has an expected escalation label.",
+    hardFail: false,
+    configFields: [
+      { key: "escalationTools", label: "Escalation tool names", type: "stringList" as const },
+    ],
+  },
+  {
+    id: "groundedness",
+    label: "Grounded figures",
+    description: "Checks that dollar figures in the answer are grounded in configured evidence.",
+    hardFail: false,
+    configFields: [
+      { key: "evidence", label: "Allowed evidence snippets", type: "stringList" as const },
+    ],
+  },
+  {
+    id: "tone_customer_fit",
+    label: "Customer-fit tone",
+    description: "Checks for dismissive phrasing and optional required tone cues.",
+    hardFail: false,
+    configFields: [
+      { key: "banned", label: "Banned tone phrases", type: "stringList" as const },
+      { key: "require", label: "Required tone cues", type: "stringList" as const },
+    ],
+  },
+  {
+    id: "cost_latency_threshold",
+    label: "Cost / latency threshold",
+    description: "Checks captured cost, latency, and token metrics when present.",
+    hardFail: false,
+    configFields: [
+      { key: "maxCostUsd", label: "Max cost USD", type: "number" as const },
+      { key: "maxLatencyMs", label: "Max latency ms", type: "number" as const },
+      { key: "maxTokens", label: "Max tokens", type: "number" as const },
+    ],
+  },
+];
+
 // --- deterministic scorers (ported 1:1) --------------------------------------
 
 const requiredClarification: Factory = (config) => (_c, output) => {

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -684,6 +684,17 @@ const schema = defineSchema({
     // Deterministic scorer ids assigned at materialization (see
     // convex/traceAdapters/materializeEvalCase.ts).
     scorerIds: v.array(v.string()),
+    // Optional per-scorer config snapshot assigned at materialization. Contains
+    // operator-entered phrases/thresholds only, never trace content.
+    scorerConfig: v.optional(
+      v.record(
+        v.string(),
+        v.record(
+          v.string(),
+          v.union(v.string(), v.number(), v.boolean(), v.array(v.string())),
+        ),
+      ),
+    ),
     requestMissing: v.boolean(),
     responseMissing: v.boolean(),
     model: v.optional(v.string()),
@@ -697,6 +708,24 @@ const schema = defineSchema({
   })
     .index("by_project", ["projectId"])
     .index("by_trace_import", ["traceImportId"]),
+
+  // #261: per-project deterministic scorecard assignment for materialized
+  // production-log eval cases. Config is intentionally management-safe: scorer
+  // keys plus operator-entered phrases/thresholds only. Trace messages/output
+  // never live here.
+  projectScorecardConfigs: defineTable({
+    projectId: v.id("projects"),
+    scorerIds: v.array(v.string()),
+    scorerConfig: v.record(
+      v.string(),
+      v.record(
+        v.string(),
+        v.union(v.string(), v.number(), v.boolean(), v.array(v.string())),
+      ),
+    ),
+    updatedById: v.id("users"),
+    updatedAt: v.number(),
+  }).index("by_project", ["projectId"]),
 
   // #264 (M31 Trajectory Spine): parent row for a normalized agent-run trace.
   // Deliberately tiny — metadata + usage rollups only, NO step content — so it

--- a/convex/scorecards.ts
+++ b/convex/scorecards.ts
@@ -7,11 +7,17 @@ import {
 } from "./_generated/server";
 import { internal } from "./_generated/api";
 import type { Id } from "./_generated/dataModel";
-import { requireOrgRole } from "./lib/auth";
+import { requireOrgRole, requireProjectRole } from "./lib/auth";
 import {
   foldScorecardResults,
   type ScorecardResultRow,
 } from "./lib/scorecardAggregation";
+import {
+  defaultProjectScorecardConfig,
+  sanitizeProjectScorecardConfig,
+  type ProjectScorecardConfig,
+} from "./lib/scorecardConfig";
+import { SCORECARD_SCORER_CATALOG } from "./lib/scorecardScoring";
 
 // ===========================================================================
 // #259: Per-org scorecard runs.
@@ -28,6 +34,96 @@ const summaryValidator = v.object({
   hardFailed: v.number(),
   meanScore: v.number(),
   skippedNoOutput: v.number(),
+});
+
+const scorerConfigValueValidator = v.union(
+  v.string(),
+  v.number(),
+  v.boolean(),
+  v.array(v.string()),
+);
+
+const scorerConfigValidator = v.record(
+  v.string(),
+  v.record(v.string(), scorerConfigValueValidator),
+);
+
+const projectScorecardConfigArgs = v.object({
+  scorerIds: v.array(v.string()),
+  scorerConfig: scorerConfigValidator,
+});
+
+function clientProjectConfig(config: ProjectScorecardConfig) {
+  return {
+    catalog: SCORECARD_SCORER_CATALOG,
+    scorerIds: config.scorerIds,
+    scorerConfig: config.scorerConfig,
+  };
+}
+
+export const projectConfig = query({
+  args: { projectId: v.id("projects") },
+  handler: async (ctx, args) => {
+    await requireProjectRole(ctx, args.projectId, [
+      "owner",
+      "editor",
+      "evaluator",
+    ]);
+    const row = await ctx.db
+      .query("projectScorecardConfigs")
+      .withIndex("by_project", (q) => q.eq("projectId", args.projectId))
+      .first();
+    return clientProjectConfig(
+      sanitizeProjectScorecardConfig(
+        row
+          ? { scorerIds: row.scorerIds, scorerConfig: row.scorerConfig }
+          : defaultProjectScorecardConfig(),
+      ),
+    );
+  },
+});
+
+export const saveProjectConfig = mutation({
+  args: {
+    projectId: v.id("projects"),
+    config: projectScorecardConfigArgs,
+  },
+  handler: async (ctx, args) => {
+    const { userId } = await requireProjectRole(ctx, args.projectId, [
+      "owner",
+      "editor",
+    ]);
+    const config = sanitizeProjectScorecardConfig(args.config);
+    const existing = await ctx.db
+      .query("projectScorecardConfigs")
+      .withIndex("by_project", (q) => q.eq("projectId", args.projectId))
+      .first();
+    const fields = {
+      projectId: args.projectId,
+      scorerIds: config.scorerIds,
+      scorerConfig: config.scorerConfig,
+      updatedById: userId,
+      updatedAt: Date.now(),
+    };
+    if (existing) await ctx.db.patch(existing._id, fields);
+    else await ctx.db.insert("projectScorecardConfigs", fields);
+    return clientProjectConfig(config);
+  },
+});
+
+export const loadProjectScorecardConfig = internalQuery({
+  args: { projectId: v.id("projects") },
+  handler: async (ctx, args): Promise<ProjectScorecardConfig> => {
+    const row = await ctx.db
+      .query("projectScorecardConfigs")
+      .withIndex("by_project", (q) => q.eq("projectId", args.projectId))
+      .first();
+    return sanitizeProjectScorecardConfig(
+      row
+        ? { scorerIds: row.scorerIds, scorerConfig: row.scorerConfig }
+        : defaultProjectScorecardConfig(),
+    );
+  },
 });
 
 /**
@@ -118,6 +214,7 @@ type ScorecardCaseRow = {
   caseId: Id<"evalCases">;
   product: string;
   scorerIds: string[];
+  scorerConfig?: ProjectScorecardConfig["scorerConfig"];
   outputText?: string;
 };
 
@@ -148,6 +245,7 @@ export const loadOrgEvalCases = internalQuery({
           caseId: r._id,
           product: r.product,
           scorerIds: r.scorerIds,
+          scorerConfig: r.scorerConfig,
           outputText: r.outputText,
         });
       }

--- a/convex/scorecards.ts
+++ b/convex/scorecards.ts
@@ -8,6 +8,7 @@ import {
 import { internal } from "./_generated/api";
 import type { Id } from "./_generated/dataModel";
 import { requireOrgRole, requireProjectRole } from "./lib/auth";
+import { SCORECARD_SCORER_CATALOG } from "./lib/scorecardScoring";
 import {
   defaultProjectScorecardConfig,
   sanitizeProjectScorecardConfig,
@@ -17,7 +18,6 @@ import {
   foldScorecardResults,
   type ScorecardResultRow,
 } from "./lib/scorecardAggregation";
-import { SCORECARD_SCORER_CATALOG } from "./lib/scorecardScoring";
 
 // ===========================================================================
 // #259: Per-org scorecard runs.

--- a/convex/scorecards.ts
+++ b/convex/scorecards.ts
@@ -64,11 +64,9 @@ function clientProjectConfig(config: ProjectScorecardConfig) {
 export const projectConfig = query({
   args: { projectId: v.id("projects") },
   handler: async (ctx, args) => {
-    await requireProjectRole(ctx, args.projectId, [
-      "owner",
-      "editor",
-      "evaluator",
-    ]);
+    // Owner/editor only: scorer config carries the grading rubric and
+    // customer-specific leakage markers, which blind reviewers must not see.
+    await requireProjectRole(ctx, args.projectId, ["owner", "editor"]);
     const row = await ctx.db
       .query("projectScorecardConfigs")
       .withIndex("by_project", (q) => q.eq("projectId", args.projectId))

--- a/convex/scorecards.ts
+++ b/convex/scorecards.ts
@@ -9,14 +9,14 @@ import { internal } from "./_generated/api";
 import type { Id } from "./_generated/dataModel";
 import { requireOrgRole, requireProjectRole } from "./lib/auth";
 import {
-  foldScorecardResults,
-  type ScorecardResultRow,
-} from "./lib/scorecardAggregation";
-import {
   defaultProjectScorecardConfig,
   sanitizeProjectScorecardConfig,
   type ProjectScorecardConfig,
 } from "./lib/scorecardConfig";
+import {
+  foldScorecardResults,
+  type ScorecardResultRow,
+} from "./lib/scorecardAggregation";
 import { SCORECARD_SCORER_CATALOG } from "./lib/scorecardScoring";
 
 // ===========================================================================

--- a/convex/scorecardsActions.ts
+++ b/convex/scorecardsActions.ts
@@ -48,7 +48,7 @@ export const runScorecard = internalAction({
           continue;
         }
         const verdict = scoreCase(
-          { scorerIds: c.scorerIds },
+          { scorerIds: c.scorerIds, scorerConfig: c.scorerConfig },
           { text: c.outputText },
         );
         results.push({

--- a/convex/traceAdapters/materializeEvalCase.test.ts
+++ b/convex/traceAdapters/materializeEvalCase.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from "vitest";
 import { normalizeGatewayLog } from "./cloudflareAiGateway";
 import {
-  DEFAULT_PRODUCTION_LOG_SCORER_IDS,
   materializeEvalCase,
   readProduct,
 } from "./materializeEvalCase";
+import { DEFAULT_PRODUCTION_LOG_SCORER_IDS } from "../lib/scorecardConfig";
 import { aggregateScores, scoreCase } from "../lib/scorecardScoring";
 
 // Pure converter tests — no `_generated`, no convex runtime.
@@ -69,6 +69,24 @@ describe("materializeEvalCase", () => {
     // Returned array is a copy — mutating it must not affect the constant.
     fields.scorerIds.push("mutated");
     expect(DEFAULT_PRODUCTION_LOG_SCORER_IDS).not.toContain("mutated");
+  });
+
+  it("snapshots configured scorer assignment during materialization", () => {
+    const fields = materializeEvalCase(normalizeGatewayLog(chat), chat, {
+      scorerIds: ["no_hallucinated_data", "cost_latency_threshold"],
+      scorerConfig: {
+        no_hallucinated_data: { phrases: ["ssn 123"] },
+        cost_latency_threshold: { maxLatencyMs: 2500 },
+      },
+    });
+    expect(fields.scorerIds).toEqual([
+      "no_hallucinated_data",
+      "cost_latency_threshold",
+    ]);
+    expect(fields.scorerConfig).toEqual({
+      no_hallucinated_data: { phrases: ["ssn 123"] },
+      cost_latency_threshold: { maxLatencyMs: 2500 },
+    });
   });
 
   it("falls back to product 'unknown' and carries redaction flags", () => {

--- a/convex/traceAdapters/materializeEvalCase.ts
+++ b/convex/traceAdapters/materializeEvalCase.ts
@@ -11,21 +11,11 @@
  * persistence; this module is only the pure mapping.
  */
 import type { NormalizedGatewayTrace } from "./cloudflareAiGateway";
-
-/**
- * Default deterministic scorers for a production-log case whose `expected` is
- * sparse (no curated must / must_not lists): the three HARD_FAIL safety scorers
- * — no_hallucinated_data, no_cross_context_leakage, read_only_no_destructive_tool
- * — which pass (never hard-fail) when their forbidden lists are empty, plus
- * tone_customer_fit as a standalone quality scorer that grades output tone
- * against built-in defaults. None fails vacuously on a normal captured output.
- */
-export const DEFAULT_PRODUCTION_LOG_SCORER_IDS: readonly string[] = [
-  "no_hallucinated_data",
-  "no_cross_context_leakage",
-  "read_only_no_destructive_tool",
-  "tone_customer_fit",
-];
+import {
+  defaultProjectScorecardConfig,
+  type ProjectScorecardConfig,
+  type ScorerConfigMap,
+} from "../lib/scorecardConfig";
 
 /** Field set for an `evalCases` insert, minus projectId/traceImportId/createdById. */
 export interface EvalCaseFields {
@@ -35,6 +25,7 @@ export interface EvalCaseFields {
   messages: { role: string; content: string }[];
   outputText?: string;
   scorerIds: string[];
+  scorerConfig?: ScorerConfigMap;
   requestMissing: boolean;
   responseMissing: boolean;
   model?: string;
@@ -83,6 +74,7 @@ export function readProduct(rawRecord: unknown): string {
 export function materializeEvalCase(
   trace: NormalizedGatewayTrace,
   rawRecord?: unknown,
+  config: ProjectScorecardConfig = defaultProjectScorecardConfig(),
 ): EvalCaseFields {
   const product = readProduct(rawRecord);
   return {
@@ -91,7 +83,9 @@ export function materializeEvalCase(
     title: `${product} replay ${trace.sourceTraceId}`,
     messages: trace.messages.map((m) => ({ role: m.role, content: m.content })),
     outputText: trace.outputText,
-    scorerIds: [...DEFAULT_PRODUCTION_LOG_SCORER_IDS],
+    scorerIds: [...config.scorerIds],
+    scorerConfig:
+      Object.keys(config.scorerConfig).length > 0 ? config.scorerConfig : undefined,
     requestMissing: trace.requestMissing,
     responseMissing: trace.responseMissing,
     model: trace.model,

--- a/docs/customer-ai-quality-scorecard-handoff.md
+++ b/docs/customer-ai-quality-scorecard-handoff.md
@@ -100,6 +100,17 @@ npx tsx src/lib/evals/cli.ts --pack demo/smoke-pass
 - Separate hard-fail safety/privacy issues from softer quality issues.
 - Avoid claiming fine-tuning is ready unless the data is reviewed and approved.
 
+## Project scorecard assignment
+
+For imported Gateway traces, configure deterministic scorecard assignment before materializing rows on the Gateway Import page:
+
+1. Select the project.
+2. Choose the scorer set in **Scorecard assignment**.
+3. Add optional management-safe phrase lists or numeric thresholds for the selected scorers.
+4. Save, then materialize imported traces into eval cases.
+
+The assignment is stamped onto each new eval case at materialization time. Existing eval cases keep their scorer snapshot so later config changes do not rewrite historical scorecard results. The config stores scorer keys, phrase lists, and thresholds only — never trace messages or model output.
+
 ## Pilot payment handoff
 
 The first customer pilot can be paid manually; Polar self-serve billing is not required for first value delivery.

--- a/src/routes/orgs/GatewayImport.tsx
+++ b/src/routes/orgs/GatewayImport.tsx
@@ -1,11 +1,13 @@
-import { useState } from "react";
-import { useAction, useQuery } from "convex/react";
+import { useEffect, useState } from "react";
+import { useAction, useMutation, useQuery } from "convex/react";
 import type { FunctionReturnType } from "convex/server";
 import { Link } from "react-router-dom";
 import { api } from "../../../convex/_generated/api";
 import type { Id } from "../../../convex/_generated/dataModel";
 import { useOrg } from "@/contexts/OrgContext";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -185,6 +187,10 @@ export function GatewayImport() {
       {summary && <ImportSummaryCard summary={summary} />}
 
       {projectId && (
+        <ScorecardConfigCard projectId={projectId as Id<"projects">} />
+      )}
+
+      {projectId && (
         <MaterializationCard
           projectId={projectId as Id<"projects">}
           scorecardHref={`${base}/scorecard`}
@@ -292,6 +298,203 @@ function ImportSummaryCard({ summary }: { summary: ImportSummary }) {
             (previously imported duplicates keep their original metadata)
           </p>
         )}
+      </CardContent>
+    </Card>
+  );
+}
+
+type ScorecardProjectConfig = NonNullable<
+  FunctionReturnType<typeof api.scorecards.projectConfig>
+>;
+type ScorecardConfigValue = string | number | boolean | string[];
+type ScorecardConfigMap = Record<string, Record<string, ScorecardConfigValue>>;
+
+function splitList(value: string): string[] {
+  return value
+    .split(/\r?\n|,/)
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+function listValue(value: ScorecardConfigValue | undefined): string {
+  return Array.isArray(value) ? value.join("\n") : "";
+}
+
+function ScorecardConfigCard({ projectId }: { projectId: Id<"projects"> }) {
+  const remote = useQuery(api.scorecards.projectConfig, { projectId });
+  const saveConfig = useMutation(api.scorecards.saveProjectConfig);
+  const [scorerIds, setScorerIds] = useState<string[]>([]);
+  const [scorerConfig, setScorerConfig] = useState<ScorecardConfigMap>({});
+  const [busy, setBusy] = useState(false);
+  const [message, setMessage] = useState("");
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    if (!remote) return;
+    setScorerIds(remote.scorerIds);
+    setScorerConfig(remote.scorerConfig as ScorecardConfigMap);
+    setMessage("");
+    setError("");
+  }, [remote]);
+
+  if (!remote) {
+    return (
+      <Card className="mt-6">
+        <CardHeader>
+          <CardTitle className="text-base">Scorecard assignment</CardTitle>
+        </CardHeader>
+        <CardContent className="text-sm text-muted-foreground">
+          Loading scorer configuration…
+        </CardContent>
+      </Card>
+    );
+  }
+
+  function toggleScorer(id: string) {
+    setScorerIds((prev) =>
+      prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id],
+    );
+  }
+
+  function setField(
+    scorerId: string,
+    fieldKey: string,
+    value: ScorecardConfigValue | undefined,
+  ) {
+    setScorerConfig((prev) => {
+      const next: ScorecardConfigMap = { ...prev };
+      const scorer = { ...(next[scorerId] ?? {}) };
+      if (
+        value === undefined ||
+        (Array.isArray(value) && value.length === 0) ||
+        value === ""
+      ) {
+        delete scorer[fieldKey];
+      } else {
+        scorer[fieldKey] = value;
+      }
+      if (Object.keys(scorer).length === 0) delete next[scorerId];
+      else next[scorerId] = scorer;
+      return next;
+    });
+  }
+
+  async function handleSave() {
+    setBusy(true);
+    setMessage("");
+    setError("");
+    try {
+      const res = await saveConfig({
+        projectId,
+        config: { scorerIds, scorerConfig },
+      });
+      setScorerIds(res.scorerIds);
+      setScorerConfig(res.scorerConfig as ScorecardConfigMap);
+      setMessage("Saved. New materialized eval cases will use this assignment.");
+    } catch (err) {
+      setError(
+        friendlyError(
+          err,
+          "Could not save scorecard assignment. Check the fields and try again.",
+        ),
+      );
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const enabled = new Set(scorerIds);
+
+  return (
+    <Card className="mt-6">
+      <CardHeader>
+        <CardTitle className="text-base">Scorecard assignment</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4 text-sm">
+        <p className="text-muted-foreground">
+          Choose which deterministic checks are stamped onto new eval cases when
+          imported traces are materialized. Existing cases keep their snapshot.
+        </p>
+        <div className="space-y-3">
+          {remote.catalog.map((scorer: ScorecardProjectConfig["catalog"][number]) => {
+            const checked = enabled.has(scorer.id);
+            return (
+              <div key={scorer.id} className="rounded-lg border p-3">
+                <div className="flex items-start gap-3">
+                  <Checkbox
+                    checked={checked}
+                    onCheckedChange={() => toggleScorer(scorer.id)}
+                    aria-label={`Enable ${scorer.label}`}
+                  />
+                  <div className="min-w-0 flex-1 space-y-1">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <p className="font-medium">{scorer.label}</p>
+                      {scorer.hardFail && (
+                        <span className="rounded-full bg-amber-500/10 px-2 py-0.5 text-[11px] font-medium text-amber-700 dark:text-amber-300">
+                          Hard fail
+                        </span>
+                      )}
+                    </div>
+                    <p className="text-xs text-muted-foreground">
+                      {scorer.description}
+                    </p>
+                  </div>
+                </div>
+
+                {checked && scorer.configFields.length > 0 && (
+                  <div className="mt-3 grid gap-3 sm:grid-cols-2">
+                    {scorer.configFields.map((field) => {
+                      const current = scorerConfig[scorer.id]?.[field.key];
+                      return (
+                        <div key={field.key} className="space-y-1">
+                          <Label className="text-xs">{field.label}</Label>
+                          {field.type === "number" ? (
+                            <Input
+                              inputMode="decimal"
+                              value={typeof current === "number" ? String(current) : ""}
+                              placeholder="Optional"
+                              onChange={(e) => {
+                                const raw = e.target.value.trim();
+                                setField(
+                                  scorer.id,
+                                  field.key,
+                                  raw === "" ? undefined : Number(raw),
+                                );
+                              }}
+                            />
+                          ) : (
+                            <Textarea
+                              rows={3}
+                              value={listValue(current)}
+                              placeholder="One phrase per line"
+                              onChange={(e) =>
+                                setField(
+                                  scorer.id,
+                                  field.key,
+                                  splitList(e.target.value),
+                                )
+                              }
+                            />
+                          )}
+                        </div>
+                      );
+                    })}
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+
+        {error && (
+          <p className="text-sm text-destructive" role="alert">
+            {error}
+          </p>
+        )}
+        {message && <p className="text-xs text-muted-foreground">{message}</p>}
+        <Button type="button" onClick={handleSave} disabled={busy}>
+          {busy ? "Saving…" : "Save scorecard assignment"}
+        </Button>
       </CardContent>
     </Card>
   );


### PR DESCRIPTION
## Summary

Closes #261. Adds project-level configurable scorer assignments for materialized eval cases so the Gateway import path can stamp the intended deterministic scorecard onto each new case before review/export.

## What changed

- Adds a `projectScorecardConfigs` table plus query/mutation/internal-query APIs for project scorecard config.
- Adds a sanitized scorer catalog/default config layer so only known deterministic scorers and safe config fields are persisted.
- Stamps `scorerConfig` snapshots onto newly materialized eval cases alongside `scorerIds`.
- Passes per-case scorer config into scorecard grading so historical cases remain stable after config changes.
- Adds a Gateway Import UI card for enabling/disabling scorers and editing optional phrase/threshold config before materialization.
- Documents the scorecard assignment flow in the customer scorecard handoff doc.

## Verification

- `NODE_ENV=development npm ci --include=dev`
- `npx convex dev --once --typecheck disable`
- `env -u NODE_ENV npm run test:convex -- scorecardConfig materializeEvalCase`
- `env -u NODE_ENV npm run test:evals`
- `env -u NODE_ENV npm run test:convex`
- `env -u NODE_ENV npm run build`
- `git diff --check`
- Dev-server smoke: `npm run dev -- --host 127.0.0.1` served `http://127.0.0.1:5173/` and `/orgs/demo/gateway-import` over curl.

Notes:
- Browser screenshot verification was blocked because Chrome is not installed in this Hermes environment; I used build + dev-server HTTP smoke instead.
- Existing `convex-test` scheduled-function stderr appeared during full Convex tests, but the command exited 0 and all test files passed.
- Build has existing Vite chunk-size warnings only.

## Data/security guardrails

- No production/customer traces added.
- No secrets or credentials added; changed-file secret scan found only the existing management-safe docs wording about not including secrets.
- Config stores scorer IDs, phrase lists, and thresholds only; eval case rows snapshot the selected config for deterministic historical scoring.
