### PR TITLE
Add canonical demo readiness selfcheck

### DIFF
--- a/docs/canonical-demo-readiness.md
+++ b/docs/canonical-demo-readiness.md
@@ -1,0 +1,33 @@
+# Canonical demo readiness selfcheck
+
+Run the local readiness selfcheck before customer-test demos or PR handoff:
+
+```bash
+npx tsx scripts/canonical-demo-readiness.ts
+```
+
+The command is deterministic and local-only. It uses synthetic/internal fixture data and does **not** call Cloudflare, Fireworks, model providers, Convex production, or customer systems.
+
+It writes:
+
+- `artifacts/canonical-demo-readiness.md`
+- `artifacts/canonical-demo-readiness.json`
+- the underlying scorecard, comparison, and training dataset demo artifacts
+
+## What it proves
+
+The selfcheck consolidates the current repeatable demo loop:
+
+1. Generate a management-safe customer scorecard from the synthetic demo pack.
+2. Generate a baseline-vs-candidate comparison report.
+3. Generate Fireworks-compatible SFT JSONL demo splits plus a manifest.
+4. Write one handoff report with status, counts, artifact paths, data-boundary guardrails, and live-operator next steps.
+
+## What it does not prove
+
+- It does not run Fireworks training or deployment.
+- It does not import live Cloudflare AI Gateway logs.
+- It does not prove customer data consent, redaction, or retention approval.
+- It does not replace human blind review on a real imported trace.
+
+Use it as the local readiness gate before moving to an explicit, approved live Gateway/Fireworks operator smoke.

--- a/scripts/canonical-demo-readiness.ts
+++ b/scripts/canonical-demo-readiness.ts
@@ -1,0 +1,19 @@
+import { pathToFileURL } from "node:url";
+import { runCanonicalDemoReadiness } from "../src/lib/evals/canonicalReadiness";
+
+const invokedDirectly =
+  process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (invokedDirectly) {
+  runCanonicalDemoReadiness()
+    .then((report) => {
+      process.stdout.write(
+        `Wrote artifacts/canonical-demo-readiness.{md,json} — status: ${report.status}.\n`,
+      );
+      process.exit(report.status === "pass" ? 0 : 1);
+    })
+    .catch((err) => {
+      process.stderr.write(`canonical-demo-readiness failed: ${err instanceof Error ? err.message : String(err)}\n`);
+      process.exit(1);
+    });
+}

--- a/src/lib/evals/canonicalReadiness.test.ts
+++ b/src/lib/evals/canonicalReadiness.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildCanonicalDemoReadinessReport,
+  formatCanonicalDemoReadinessMarkdown,
+  type ReadinessCheck,
+} from "./canonicalReadiness";
+
+const passCheck: ReadinessCheck = {
+  id: "scorecard_demo",
+  label: "Scorecard demo",
+  status: "pass",
+  artifacts: ["artifacts/scorecard.json"],
+  summary: { cases_evaluated: 50, hard_failed_cases: 1 },
+};
+
+describe("canonical demo readiness report", () => {
+  it("passes when every check passes and deduplicates artifact paths", () => {
+    const report = buildCanonicalDemoReadinessReport({
+      generated_at: "2026-01-01T00:00:00Z",
+      checks: [
+        passCheck,
+        { ...passCheck, id: "dataset", label: "Dataset", artifacts: ["artifacts/scorecard.json", "artifacts/train.jsonl"] },
+      ],
+    });
+
+    expect(report.status).toBe("pass");
+    expect(report.artifact_paths).toEqual([
+      "artifacts/scorecard.json",
+      "artifacts/train.jsonl",
+    ]);
+    expect(report.guardrails.join("\n")).toContain("no live Cloudflare");
+  });
+
+  it("fails when any check fails and keeps management-safe error text", () => {
+    const report = buildCanonicalDemoReadinessReport({
+      generated_at: "2026-01-01T00:00:00Z",
+      checks: [
+        passCheck,
+        {
+          id: "training_dataset_demo",
+          label: "Training dataset",
+          status: "fail",
+          artifacts: ["artifacts/training-dataset.manifest.json"],
+          summary: { train_rows: 0 },
+          errors: ["Missing artifact: artifacts/training-dataset.manifest.json"],
+        },
+      ],
+    });
+
+    expect(report.status).toBe("fail");
+    const md = formatCanonicalDemoReadinessMarkdown(report);
+    expect(md).toContain("❌ Training dataset");
+    expect(md).toContain("Missing artifact");
+    expect(md).not.toMatch(/password|api[_ -]?key|Bearer/i);
+  });
+
+  it("formats the canonical loop and operator steps without raw transcript fields", () => {
+    const report = buildCanonicalDemoReadinessReport({
+      generated_at: "2026-01-01T00:00:00Z",
+      checks: [passCheck],
+    });
+
+    const md = formatCanonicalDemoReadinessMarkdown(report);
+    expect(md).toContain("## Canonical loop");
+    expect(md).toContain("## Next operator steps");
+    expect(md).not.toMatch(/TEST-ACCOUNT|555-01|sk-[A-Za-z0-9]/i);
+  });
+});

--- a/src/lib/evals/canonicalReadiness.ts
+++ b/src/lib/evals/canonicalReadiness.ts
@@ -1,0 +1,221 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { main as scorecardMain } from "./scorecard";
+import { main as comparisonMain } from "./modelComparison";
+import { main as trainingDatasetMain } from "./trainingDataset";
+
+export type ReadinessStatus = "pass" | "fail";
+
+export interface ReadinessCheck {
+  id: string;
+  label: string;
+  status: ReadinessStatus;
+  artifacts: string[];
+  summary: Record<string, string | number | boolean | null>;
+  errors?: string[];
+}
+
+export interface CanonicalDemoReadinessReport {
+  status: ReadinessStatus;
+  generated_at: string;
+  loop: {
+    import_source: string;
+    review_signal: string;
+    reuse_artifact: string;
+  };
+  checks: ReadinessCheck[];
+  artifact_paths: string[];
+  guardrails: string[];
+  next_operator_steps: string[];
+}
+
+export interface BuildReportOptions {
+  generated_at: string;
+  checks: ReadinessCheck[];
+}
+
+const GUARDRAILS = [
+  "Local-only deterministic demo: no live Cloudflare, Fireworks, model-provider, or Convex network calls are required.",
+  "Synthetic/internal fixture data only by default; no customer or design-partner traces are imported.",
+  "Readiness report contains aggregate counts, decisions, and artifact paths only — no raw prompts, model outputs, transcripts, credentials, or secrets.",
+  "Fireworks training/deployment remains an operator step after explicit data-boundary approval.",
+];
+
+const NEXT_OPERATOR_STEPS = [
+  "Review artifacts/canonical-demo-readiness.md for the local handoff status.",
+  "For live Gateway testing, import a customer-owned Cloudflare AI Gateway export only after consent/redaction/retention approval.",
+  "For Fireworks testing, use the generated training/export artifacts as handoff inputs; do not start a fine-tune until the dataset manifest says the rows are approved and non-sensitive.",
+  "Use the scorecard and comparison reports as management-safe artifacts; keep raw traces inside the authenticated app/review surfaces.",
+];
+
+export function buildCanonicalDemoReadinessReport(
+  opts: BuildReportOptions,
+): CanonicalDemoReadinessReport {
+  const status: ReadinessStatus = opts.checks.every((c) => c.status === "pass")
+    ? "pass"
+    : "fail";
+  const artifact_paths = [...new Set(opts.checks.flatMap((c) => c.artifacts))].sort();
+
+  return {
+    status,
+    generated_at: opts.generated_at,
+    loop: {
+      import_source: "Synthetic/internal fixture eval pack; live trace import remains operator-gated.",
+      review_signal: "Deterministic scorecard/comparison verdicts stand in for the first local readiness signal.",
+      reuse_artifact: "Training dataset JSONL + manifest and management-safe scorecard/comparison reports.",
+    },
+    checks: opts.checks,
+    artifact_paths,
+    guardrails: GUARDRAILS,
+    next_operator_steps: NEXT_OPERATOR_STEPS,
+  };
+}
+
+export function formatCanonicalDemoReadinessMarkdown(
+  report: CanonicalDemoReadinessReport,
+): string {
+  const lines: string[] = [];
+  lines.push("# Canonical demo readiness");
+  lines.push("");
+  lines.push(`_Generated: ${report.generated_at} · status: **${report.status.toUpperCase()}**_`);
+  lines.push("");
+  lines.push("## Canonical loop");
+  lines.push("");
+  lines.push(`- Bring in one run: ${report.loop.import_source}`);
+  lines.push(`- Get a verdict: ${report.loop.review_signal}`);
+  lines.push(`- Route it back: ${report.loop.reuse_artifact}`);
+  lines.push("");
+  lines.push("## Checks");
+  lines.push("");
+  for (const check of report.checks) {
+    lines.push(`### ${check.status === "pass" ? "✅" : "❌"} ${check.label}`);
+    lines.push("");
+    for (const [key, value] of Object.entries(check.summary)) {
+      lines.push(`- ${key}: ${value ?? "n/a"}`);
+    }
+    if (check.artifacts.length) {
+      lines.push(`- artifacts: ${check.artifacts.map((p) => `\`${p}\``).join(", ")}`);
+    }
+    if (check.errors?.length) {
+      lines.push("- errors:");
+      for (const err of check.errors) lines.push(`  - ${err}`);
+    }
+    lines.push("");
+  }
+  lines.push("## Management-safe guardrails");
+  lines.push("");
+  for (const guardrail of report.guardrails) lines.push(`- ${guardrail}`);
+  lines.push("");
+  lines.push("## Next operator steps");
+  lines.push("");
+  for (const step of report.next_operator_steps) lines.push(`- ${step}`);
+  lines.push("");
+  return lines.join("\n");
+}
+
+export function formatCanonicalDemoReadinessJson(
+  report: CanonicalDemoReadinessReport,
+): string {
+  return JSON.stringify(report, null, 2) + "\n";
+}
+
+function requiredArtifactCheck(
+  id: string,
+  label: string,
+  artifacts: string[],
+  summary: Record<string, string | number | boolean | null>,
+): ReadinessCheck {
+  const missing = artifacts.filter((p) => !existsSync(p));
+  return {
+    id,
+    label,
+    status: missing.length ? "fail" : "pass",
+    artifacts,
+    summary,
+    ...(missing.length ? { errors: missing.map((p) => `Missing artifact: ${p}`) } : {}),
+  };
+}
+
+function readJson<T>(path: string): T {
+  return JSON.parse(readFileSync(path, "utf8")) as T;
+}
+
+export async function runCanonicalDemoReadiness(
+  opts: { outDir?: string; generated_at?: string } = {},
+): Promise<CanonicalDemoReadinessReport> {
+  const outDir = opts.outDir ?? "artifacts";
+  const generated_at = opts.generated_at ?? new Date(0).toISOString();
+  mkdirSync(outDir, { recursive: true });
+
+  await scorecardMain([]);
+  await comparisonMain([]);
+  await trainingDatasetMain([generated_at]);
+
+  const scorecardPath = join(outDir, "ai-quality-scorecard.json");
+  const comparisonPath = join(outDir, "model-comparison.json");
+  const manifestPath = join(outDir, "training-dataset.manifest.json");
+
+  const scorecard = readJson<{
+    quality: { cases_evaluated: number; cases_fully_passing: number; mean_score: number };
+    safety_privacy: { hard_failed_cases: number };
+    fine_tuning_readiness: { status: string };
+  }>(scorecardPath);
+  const comparison = readJson<{
+    cases_compared: number;
+    recommendation: { decision: string; blocking: boolean };
+    safety_privacy: { hard_fail_regressions: unknown[] };
+  }>(comparisonPath);
+  const manifest = readJson<{
+    split_counts: { train: number; validation: number; test: number };
+    excluded: unknown[];
+    dataset_hash: string;
+  }>(manifestPath);
+
+  const checks: ReadinessCheck[] = [
+    requiredArtifactCheck(
+      "scorecard_demo",
+      "Management-safe scorecard demo",
+      [join(outDir, "ai-quality-scorecard.md"), scorecardPath],
+      {
+        cases_evaluated: scorecard.quality.cases_evaluated,
+        cases_fully_passing: scorecard.quality.cases_fully_passing,
+        mean_score: scorecard.quality.mean_score,
+        hard_failed_cases: scorecard.safety_privacy.hard_failed_cases,
+        fine_tuning_status: scorecard.fine_tuning_readiness.status,
+      },
+    ),
+    requiredArtifactCheck(
+      "model_comparison_demo",
+      "Baseline-vs-candidate comparison demo",
+      [join(outDir, "model-comparison.md"), comparisonPath],
+      {
+        cases_compared: comparison.cases_compared,
+        decision: comparison.recommendation.decision,
+        blocking: comparison.recommendation.blocking,
+        hard_fail_regressions: comparison.safety_privacy.hard_fail_regressions.length,
+      },
+    ),
+    requiredArtifactCheck(
+      "training_dataset_demo",
+      "Fireworks-compatible training dataset demo",
+      [
+        join(outDir, "training-dataset.train.jsonl"),
+        join(outDir, "training-dataset.validation.jsonl"),
+        join(outDir, "training-dataset.test.jsonl"),
+        manifestPath,
+      ],
+      {
+        train_rows: manifest.split_counts.train,
+        validation_rows: manifest.split_counts.validation,
+        test_rows: manifest.split_counts.test,
+        excluded_rows: manifest.excluded.length,
+        dataset_hash_prefix: manifest.dataset_hash.slice(0, 16),
+      },
+    ),
+  ];
+
+  const report = buildCanonicalDemoReadinessReport({ generated_at, checks });
+  writeFileSync(join(outDir, "canonical-demo-readiness.md"), formatCanonicalDemoReadinessMarkdown(report));
+  writeFileSync(join(outDir, "canonical-demo-readiness.json"), formatCanonicalDemoReadinessJson(report));
+  return report;
+}


### PR DESCRIPTION
## Summary

Closes #292. Adds a local-only canonical demo readiness selfcheck so the end-to-end customer-test loop has one repeatable handoff command before any live data, Cloudflare, or Fireworks operation.

## What changed

- Added `src/lib/evals/canonicalReadiness.ts` to run and aggregate the existing deterministic scorecard, model comparison, and training dataset demo artifacts.
- Added `scripts/canonical-demo-readiness.ts` as the one-command entry point:
  - `npx tsx scripts/canonical-demo-readiness.ts`
- Writes consolidated reports:
  - `artifacts/canonical-demo-readiness.md`
  - `artifacts/canonical-demo-readiness.json`
- Added unit coverage for readiness status aggregation, artifact path deduplication, and management-safe report formatting.
- Documented the selfcheck in `docs/canonical-demo-readiness.md`.

## Guardrails

- Local-only deterministic fixture flow by default.
- No Fireworks training/deployment.
- No live Cloudflare/Gateway calls.
- No customer/design-partner data import.
- Report carries aggregate counts, decisions, artifact paths, and operator next steps only — not raw prompts, model outputs, transcripts, credentials, or secrets.

## Verification

- `NODE_ENV=development npm ci --include=dev`
- `npx vitest run src/lib/evals/canonicalReadiness.test.ts`
- `npx tsx scripts/canonical-demo-readiness.ts`
- `env -u NODE_ENV npm run test:evals`
- `npx convex dev --once --typecheck disable && env -u NODE_ENV npm run test:convex`
- `env -u NODE_ENV npm run build`
- `git diff --check`

Notes:
- Convex tests pass with the existing non-fatal `convex-test` scheduled-function teardown stderr seen in prior slices.
- Build passes with the existing Vite large chunk warnings.
