### PR TITLE
Add Claude Code session preflight

### DIFF
--- a/convex/lib/claudeCodePreflight.test.ts
+++ b/convex/lib/claudeCodePreflight.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from "vitest";
+import {
+  formatClaudeCodePreflightJson,
+  formatClaudeCodePreflightText,
+  summarizeClaudeCodePreflight,
+} from "./claudeCodePreflight";
+
+const SID = "0f0e02b8-1111-2222-3333-444455556666";
+const SENSITIVE_SENTINEL = "TOKEN_DO_NOT_PRINT_123456";
+const SSN = "123-45-6789";
+
+function fixture(): string {
+  return [
+    JSON.stringify({
+      type: "user",
+      uuid: "u1",
+      parentUuid: null,
+      sessionId: SID,
+      timestamp: "2026-07-09T10:00:00Z",
+      message: { role: "user", content: "Run a safe preflight." },
+    }),
+    JSON.stringify({
+      type: "assistant",
+      uuid: "a1",
+      parentUuid: "u1",
+      sessionId: SID,
+      timestamp: "2026-07-09T10:00:01Z",
+      message: {
+        id: "m1",
+        role: "assistant",
+        model: "claude-opus-4-8",
+        content: [
+          { type: "text", text: "Checking." },
+          { type: "tool_use", id: "toolu_1", name: "Bash", input: { command: "printenv", api_key: SENSITIVE_SENTINEL, ssn: SSN } },
+        ],
+        usage: { input_tokens: 10, output_tokens: 5 },
+      },
+    }),
+    JSON.stringify({
+      type: "user",
+      uuid: "u2",
+      parentUuid: "a1",
+      sessionId: SID,
+      timestamp: "2026-07-09T10:00:02Z",
+      message: { role: "user", content: [{ type: "tool_result", tool_use_id: "toolu_1", content: `token=${SENSITIVE_SENTINEL}`, is_error: false }] },
+      toolUseResult: { stdout: `token=${SENSITIVE_SENTINEL}`, account: SSN },
+    }),
+    JSON.stringify({ type: "ai-title", aiTitle: "Safe preflight", sessionId: SID }),
+    "{ malformed json",
+  ].join("\n");
+}
+
+function expectNoLeak(text: string) {
+  expect(text).not.toContain(SENSITIVE_SENTINEL);
+  expect(text).not.toContain(SSN);
+  expect(text).not.toContain("Run a safe preflight.");
+  expect(text).not.toContain("token=");
+  expect(text).not.toContain("printenv");
+}
+
+describe("Claude Code preflight summary", () => {
+  test("summarizes parser output without leaking raw transcript content", () => {
+    const summary = summarizeClaudeCodePreflight(fixture());
+    expect(summary.status).toBe("ready");
+    expect(summary.trace_ref).toBe("trace-…55556666");
+    expect(summary.session_ref).toBe("session-…55556666");
+    expect(summary.invalid).toBe(1);
+    expect(summary.invalid_lines).toEqual([5]);
+    expect(summary.dropped_meta).toBe(1);
+    expect(summary.models).toEqual(["claude-opus-4-8"]);
+    expect(summary.step_kind_counts).toMatchObject({ message: 2, tool_call: 1, tool_result: 1 });
+    expect(summary.redaction_detected).toBe(true);
+
+    expectNoLeak(JSON.stringify(summary));
+  });
+
+  test("formats text and json as safe management summaries", () => {
+    const summary = summarizeClaudeCodePreflight(fixture());
+    const text = formatClaudeCodePreflightText(summary);
+    const json = formatClaudeCodePreflightJson(summary);
+    expect(text).toContain("Claude Code session preflight");
+    expect(text).toContain("status: ready");
+    expect(text).toContain("safe_to_upload");
+    expect(JSON.parse(json).status).toBe("ready");
+    expectNoLeak(text);
+    expectNoLeak(json);
+  });
+
+  test("blocks empty-but-valid transcripts with no reviewable steps", () => {
+    const summary = summarizeClaudeCodePreflight("{}\n");
+    expect(summary.status).toBe("blocked");
+    expect(summary.steps).toBe(0);
+    expect(summary.caveats.join(" ")).toContain("No reviewable steps");
+  });
+});

--- a/convex/lib/claudeCodePreflight.ts
+++ b/convex/lib/claudeCodePreflight.ts
@@ -1,0 +1,120 @@
+import type { AgentRunTrace } from "./agentTrace";
+import { parseClaudeCodeSession, type ClaudeCodeSummary } from "./claudeCodeTrace";
+
+export type ClaudeCodePreflightStatus = "ready" | "blocked";
+
+export interface ClaudeCodePreflightSummary {
+  status: ClaudeCodePreflightStatus;
+  trace_ref: string;
+  session_ref?: string;
+  events: number;
+  steps: number;
+  invalid: number;
+  invalid_lines: number[];
+  dropped_meta: number;
+  compactions: number;
+  merged_messages: number;
+  models: string[];
+  earliest?: string;
+  latest?: string;
+  privacy_class: string;
+  redaction_detected: boolean;
+  step_kind_counts: Record<string, number>;
+  caveats: string[];
+}
+
+const MAX_INVALID_LINES = 20;
+
+function safeRef(value: string | undefined, prefix: string): string | undefined {
+  if (!value) return undefined;
+  const cleaned = value.replace(/^cc-/, "");
+  if (cleaned.length <= 8) return `${prefix}-${cleaned}`;
+  return `${prefix}-…${cleaned.slice(-8)}`;
+}
+
+function stepKindCounts(trace: AgentRunTrace): Record<string, number> {
+  const counts: Record<string, number> = {};
+  for (const step of trace.steps) {
+    counts[step.type] = (counts[step.type] ?? 0) + 1;
+  }
+  return Object.fromEntries(Object.entries(counts).sort(([a], [b]) => a.localeCompare(b)));
+}
+
+function redactionDetected(trace: AgentRunTrace): boolean {
+  return trace.privacy.class !== "internal" || JSON.stringify(trace.steps).includes("[REDACTED]");
+}
+
+function caveatsFor(summary: ClaudeCodeSummary, trace: AgentRunTrace): string[] {
+  const caveats: string[] = [];
+  if (summary.invalid > 0) {
+    caveats.push("Malformed JSONL lines were skipped; inspect the source transcript if counts look wrong.");
+  }
+  if (summary.droppedMeta > 0) {
+    caveats.push("Claude Code sidecar metadata records were dropped because they are not trajectory steps.");
+  }
+  if (trace.steps.length === 0) {
+    caveats.push("No reviewable steps were parsed; choose a different Claude Code session transcript.");
+  }
+  if (redactionDetected(trace)) {
+    caveats.push("Sensitive-looking fields were redacted in normalized tool/message artifacts.");
+  }
+  return caveats;
+}
+
+export function summarizeClaudeCodePreflight(jsonl: string): ClaudeCodePreflightSummary {
+  const { sessionId, trace, summary } = parseClaudeCodeSession(jsonl);
+  const status: ClaudeCodePreflightStatus = trace.steps.length > 0 ? "ready" : "blocked";
+
+  return {
+    status,
+    trace_ref: safeRef(trace.trace_id, "trace") ?? "trace-unknown",
+    ...(safeRef(sessionId, "session") ? { session_ref: safeRef(sessionId, "session") } : {}),
+    events: summary.events,
+    steps: summary.steps,
+    invalid: summary.invalid,
+    invalid_lines: summary.invalidLines.slice(0, MAX_INVALID_LINES),
+    dropped_meta: summary.droppedMeta,
+    compactions: summary.compactions,
+    merged_messages: summary.mergedMessages,
+    models: [...summary.models].sort(),
+    ...(summary.earliest ? { earliest: summary.earliest } : {}),
+    ...(summary.latest ? { latest: summary.latest } : {}),
+    privacy_class: trace.privacy.class,
+    redaction_detected: redactionDetected(trace),
+    step_kind_counts: stepKindCounts(trace),
+    caveats: caveatsFor(summary, trace),
+  };
+}
+
+export function formatClaudeCodePreflightText(summary: ClaudeCodePreflightSummary): string {
+  const lines: string[] = [];
+  lines.push("Claude Code session preflight");
+  lines.push(`status: ${summary.status}`);
+  lines.push(`trace: ${summary.trace_ref}`);
+  if (summary.session_ref) lines.push(`session: ${summary.session_ref}`);
+  lines.push(`events: ${summary.events}`);
+  lines.push(`steps: ${summary.steps}`);
+  lines.push(`models: ${summary.models.length ? summary.models.join(", ") : "unknown"}`);
+  lines.push(`time_bounds: ${summary.earliest ?? "unknown"} → ${summary.latest ?? "unknown"}`);
+  lines.push(`invalid_lines: ${summary.invalid}${summary.invalid_lines.length ? ` (${summary.invalid_lines.join(", ")})` : ""}`);
+  lines.push(`dropped_meta: ${summary.dropped_meta}`);
+  lines.push(`compactions: ${summary.compactions}`);
+  lines.push(`merged_messages: ${summary.merged_messages}`);
+  lines.push(`privacy_class: ${summary.privacy_class}`);
+  lines.push(`redaction_detected: ${summary.redaction_detected}`);
+  lines.push(
+    `step_kinds: ${Object.entries(summary.step_kind_counts)
+      .map(([kind, count]) => `${kind}=${count}`)
+      .join(", ") || "none"}`,
+  );
+  if (summary.caveats.length) {
+    lines.push("caveats:");
+    for (const caveat of summary.caveats) lines.push(`- ${caveat}`);
+  }
+  lines.push("safe_to_upload: use the authenticated app import next; this preflight did not send data anywhere.");
+  return lines.join("\n") + "\n";
+}
+
+export function formatClaudeCodePreflightJson(summary: ClaudeCodePreflightSummary): string {
+  return JSON.stringify(summary, null, 2) + "\n";
+}

--- a/docs/claude-code-session-preflight.md
+++ b/docs/claude-code-session-preflight.md
@@ -1,0 +1,39 @@
+# Claude Code session preflight
+
+Use this local preflight before uploading an internal Claude Code session transcript through the authenticated Trace Import screen.
+
+```bash
+npm run preflight:claude-code -- /path/to/session.jsonl
+npm run preflight:claude-code -- /path/to/session.jsonl --json
+```
+
+The preflight is intentionally local-only:
+
+- reads one `.jsonl` transcript from disk;
+- reuses the existing `parseClaudeCodeSession` parser;
+- does not import into Convex;
+- does not call Cloudflare, Fireworks, model providers, or other network services;
+- prints only a management-safe summary.
+
+## What the summary includes
+
+- safe trace/session reference suffixes;
+- event and reviewable-step counts;
+- malformed-line count and capped line numbers;
+- model names;
+- earliest/latest timestamps;
+- privacy class and whether parser redaction occurred;
+- step-kind counts;
+- readiness status and caveats.
+
+It deliberately does **not** print raw prompts, raw model outputs, raw tool results, credentials, account identifiers, or transcript content.
+
+## Phase 0 dogfood loop
+
+1. Pick an internal Claude Code session transcript from disk.
+2. Run this preflight locally.
+3. If `status: ready`, upload the same `.jsonl` through the authenticated Trace Import app surface.
+4. Review the normalized trajectory in BlindBench.
+5. Export approved review outputs through the existing Fireworks-ready handoff paths.
+
+If the preflight reports `status: blocked`, pick another transcript or inspect the local source file outside BlindBench. Do not paste raw transcript content into GitHub issues, PRs, or public docs.

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test:evals": "vitest run src/lib/evals/",
     "test:convex": "vitest run --config convex/vitest.config.ts",
     "test:ct": "playwright test -c playwright-ct.config.ts",
+    "preflight:claude-code": "npx tsx scripts/claude-code-session-preflight.ts",
     "scorecard:demo": "npx tsx src/lib/evals/scorecard.ts",
     "dataset:demo": "npx tsx src/lib/evals/trainingDataset.ts",
     "compare:demo": "npx tsx src/lib/evals/modelComparison.ts",

--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
     "compare:demo": "npx tsx src/lib/evals/modelComparison.ts",
     "compare:endpoints": "npx tsx src/lib/evals/compareEndpoints.ts",
     "prototype:fireworks-gateway": "npx tsx src/lib/evals/fireworksGatewayPrototype.ts",
-    "smoke:fireworks-gateway": "npx tsx scripts/fireworks-gateway-smoke.ts",
-    "preflight:claude-code": "npx tsx scripts/claude-code-session-preflight.ts"
+    "smoke:fireworks-gateway": "npx tsx scripts/fireworks-gateway-smoke.ts"
   },
   "dependencies": {
     "@auth/core": "^0.37.4",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "compare:demo": "npx tsx src/lib/evals/modelComparison.ts",
     "compare:endpoints": "npx tsx src/lib/evals/compareEndpoints.ts",
     "prototype:fireworks-gateway": "npx tsx src/lib/evals/fireworksGatewayPrototype.ts",
-    "smoke:fireworks-gateway": "npx tsx scripts/fireworks-gateway-smoke.ts"
+    "smoke:fireworks-gateway": "npx tsx scripts/fireworks-gateway-smoke.ts",
+    "preflight:claude-code": "npx tsx scripts/claude-code-session-preflight.ts"
   },
   "dependencies": {
     "@auth/core": "^0.37.4",

--- a/scripts/claude-code-session-preflight.ts
+++ b/scripts/claude-code-session-preflight.ts
@@ -1,0 +1,58 @@
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+import {
+  formatClaudeCodePreflightJson,
+  formatClaudeCodePreflightText,
+  summarizeClaudeCodePreflight,
+} from "../convex/lib/claudeCodePreflight";
+
+interface CliOptions {
+  file?: string;
+  json: boolean;
+}
+
+function parseArgs(argv: string[]): CliOptions {
+  const opts: CliOptions = { json: false };
+  for (const arg of argv) {
+    if (arg === "--json") {
+      opts.json = true;
+    } else if (arg === "--help" || arg === "-h") {
+      printUsage(0);
+    } else if (!opts.file) {
+      opts.file = arg;
+    } else {
+      fail(`unexpected argument: ${arg}`);
+    }
+  }
+  return opts;
+}
+
+function printUsage(code: number): never {
+  const msg = `usage: npx tsx scripts/claude-code-session-preflight.ts <session.jsonl> [--json]\n\nLocal-only, management-safe preflight for a Claude Code session transcript.\nDoes not upload, import, or print raw transcript content.\n`;
+  (code === 0 ? console.log : console.error)(msg);
+  process.exit(code);
+}
+
+function fail(message: string): never {
+  console.error(`Claude Code preflight failed: ${message}`);
+  process.exit(1);
+}
+
+export function runCli(argv = process.argv.slice(2)): void {
+  const opts = parseArgs(argv);
+  if (!opts.file) printUsage(1);
+  if (!existsSync(opts.file)) fail(`file not found: ${opts.file}`);
+  const stat = statSync(opts.file);
+  if (!stat.isFile()) fail(`not a file: ${opts.file}`);
+  if (stat.size === 0) fail("file is empty");
+
+  const jsonl = readFileSync(opts.file, "utf8");
+  if (!jsonl.trim()) fail("file contains only whitespace");
+  const summary = summarizeClaudeCodePreflight(jsonl);
+  const output = opts.json ? formatClaudeCodePreflightJson(summary) : formatClaudeCodePreflightText(summary);
+  process.stdout.write(output);
+  if (summary.status !== "ready") process.exit(1);
+}
+
+const invokedDirectly = process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (invokedDirectly) runCli();


### PR DESCRIPTION
## Summary

Closes #294. Adds a local-only Claude Code session preflight so the Phase 0 dogfood operator can safely validate a `.jsonl` transcript before using the authenticated Trace Import screen.

What changed:
- `npm run preflight:claude-code -- <session.jsonl>` prints a management-safe readiness summary.
- `--json` emits the same safe summary for scripts/runbooks.
- Reuses the existing `parseClaudeCodeSession` parser; no duplicate parser/import path.
- Adds focused tests for malformed lines, redaction/leakage guard, and blocked empty transcripts.
- Documents the local preflight in `docs/claude-code-session-preflight.md`.

## Verification

- `NODE_ENV=development npm ci --include=dev` ✅
- `npx vitest run convex/lib/claudeCodePreflight.test.ts` ✅
  - 1 file, 3 tests passed
- Synthetic CLI smoke ✅
  - `npm run preflight:claude-code -- /tmp/blindbench-claude-preflight-fixture.jsonl`
  - `npm run preflight:claude-code -- /tmp/blindbench-claude-preflight-fixture.jsonl --json`
  - missing-file case exits non-zero
- `env -u NODE_ENV npm run test:evals` ✅
  - 14 files, 139 tests passed
- `npx convex dev --once --typecheck disable && env -u NODE_ENV npm run test:convex` ✅
  - 27 files, 235 tests passed
  - existing non-fatal `convex-test` scheduled-function teardown stderr still appears
- `env -u NODE_ENV npm run build` ✅
  - passes with existing Vite chunk-size warnings
- `git diff --check` ✅

## Guardrails

- No live Convex import from the CLI.
- No Cloudflare, Fireworks, model-provider, or other network calls from the CLI.
- No customer/design-partner data.
- No raw prompt/model/tool/transcript content in CLI output.
- No credentials or secrets; leakage checks use synthetic test sentinels only.

## Notes

Claude Code Opus was launched from `/root/github_repos/ventures` per the standing instruction, but the process stalled on shell/gitstatus initialization and made no file changes. I killed it, implemented the slice manually, and verified the result independently.
