### PR TITLE
Add Cloudflare Gateway export preflight

### DIFF
--- a/convex/traceAdapters/cloudflareGatewayPreflight.test.ts
+++ b/convex/traceAdapters/cloudflareGatewayPreflight.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from "vitest";
+import {
+  formatGatewayPreflightJson,
+  formatGatewayPreflightText,
+  summarizeGatewayPreflight,
+} from "./cloudflareGatewayPreflight";
+
+const SENSITIVE_SENTINEL = "TOKEN_DO_NOT_PRINT_123456";
+const RAW_PROMPT = "Do not leak this raw user prompt";
+const RAW_OUTPUT = "Do not leak this raw model output";
+const ACCOUNT_ID = "acct_DO_NOT_PRINT_123";
+
+function gatewayJsonl(): string {
+  const good = {
+    log_id: "log_TEST_001",
+    account_id: ACCOUNT_ID,
+    timestamp: "2026-07-09T10:00:00Z",
+    provider: "anthropic",
+    model: "claude-sonnet-4-0",
+    metadata: { trace_id: "tr_safe_001", product: "support-assistant" },
+    request: {
+      messages: [
+        { role: "user", content: RAW_PROMPT },
+      ],
+      credential_marker: SENSITIVE_SENTINEL,
+    },
+    response: { choices: [{ message: { content: RAW_OUTPUT } }] },
+    usage: { input_tokens: 42, output_tokens: 12, total_tokens: 54 },
+  };
+  const redacted = {
+    log_id: "log_TEST_002",
+    timestamp: "2026-07-09T10:01:00Z",
+    provider: "openai",
+    model: "gpt-4.1-mini",
+    request: { redacted: true },
+  };
+  return [JSON.stringify(good), "{ malformed json with " + SENSITIVE_SENTINEL, JSON.stringify(redacted)].join("\n");
+}
+
+function sidecarJson(): string {
+  return JSON.stringify({
+    tr_safe_001: { release: "r1", note: SENSITIVE_SENTINEL },
+    no_match: { release: "r2" },
+  });
+}
+
+function expectNoLeak(text: string) {
+  expect(text).not.toContain(SENSITIVE_SENTINEL);
+  expect(text).not.toContain(RAW_PROMPT);
+  expect(text).not.toContain(RAW_OUTPUT);
+  expect(text).not.toContain(ACCOUNT_ID);
+  expect(text).not.toContain("malformed json");
+  expect(text).not.toContain("no_match");
+}
+
+describe("Cloudflare Gateway preflight", () => {
+  test("summarizes Gateway JSONL without leaking raw content", () => {
+    const summary = summarizeGatewayPreflight(gatewayJsonl());
+    expect(summary.status).toBe("ready");
+    expect(summary.parsed).toBe(2);
+    expect(summary.invalid).toBe(1);
+    expect(summary.invalid_lines).toEqual([2]);
+    expect(summary.models).toEqual(["claude-sonnet-4-0", "gpt-4.1-mini"]);
+    expect(summary.providers).toEqual(["anthropic", "openai"]);
+    expect(summary.redacted_request).toBe(1);
+    expect(summary.redacted_response).toBe(1);
+    expect(summary.earliest).toBe("2026-07-09T10:00:00Z");
+    expect(summary.latest).toBe("2026-07-09T10:01:00Z");
+    expectNoLeak(JSON.stringify(summary));
+  });
+
+  test("reports sidecar counts without leaking sidecar content", () => {
+    const summary = summarizeGatewayPreflight(gatewayJsonl(), { sidecarJson: sidecarJson() });
+    expect(summary.sidecar).toEqual({ supplied: true, entries: 2, matched: 1 });
+    const text = formatGatewayPreflightText(summary);
+    const json = formatGatewayPreflightJson(summary);
+    expect(text).toContain("sidecar_entries: 2");
+    expect(text).toContain("sidecar_matched_records: 1");
+    expect(JSON.parse(json).sidecar.matched).toBe(1);
+    expectNoLeak(text);
+    expectNoLeak(json);
+  });
+
+  test("blocks empty parses with a clear caveat", () => {
+    const summary = summarizeGatewayPreflight("{ not json }\n");
+    expect(summary.status).toBe("blocked");
+    expect(summary.parsed).toBe(0);
+    expect(summary.invalid).toBe(1);
+    expect(summary.caveats.join(" ")).toContain("No valid Gateway log records");
+  });
+});

--- a/convex/traceAdapters/cloudflareGatewayPreflight.ts
+++ b/convex/traceAdapters/cloudflareGatewayPreflight.ts
@@ -1,0 +1,109 @@
+import {
+  DEFAULT_LIMITS,
+  MAX_REPORTED_INVALID_LINES,
+  parseGatewayJsonl,
+  parseSidecar,
+  summarizeTraces,
+  type SidecarMap,
+} from "./cloudflareAiGateway";
+
+export type GatewayPreflightStatus = "ready" | "blocked";
+
+export interface GatewayPreflightSummary {
+  status: GatewayPreflightStatus;
+  parsed: number;
+  invalid: number;
+  invalid_lines: number[];
+  truncated: boolean;
+  redacted_request: number;
+  redacted_response: number;
+  models: string[];
+  providers: string[];
+  earliest?: string;
+  latest?: string;
+  sidecar?: {
+    supplied: boolean;
+    entries: number;
+    matched: number;
+  };
+  caveats: string[];
+}
+
+export interface GatewayPreflightOptions {
+  sidecarJson?: string;
+}
+
+function caveatsFor(summary: Omit<GatewayPreflightSummary, "caveats">): string[] {
+  const caveats: string[] = [];
+  if (summary.parsed === 0) caveats.push("No valid Gateway log records were parsed; choose a different export file.");
+  if (summary.invalid > 0) caveats.push("Malformed or unsupported JSONL lines were skipped; line numbers are reported without echoing content.");
+  if (summary.truncated) caveats.push(`Input exceeded ${DEFAULT_LIMITS.maxLines} non-blank lines; split the export into smaller batches.`);
+  if (summary.redacted_request > 0) caveats.push("Some records have redacted or missing request messages.");
+  if (summary.redacted_response > 0) caveats.push("Some records have redacted or missing responses.");
+  if (summary.sidecar?.supplied && summary.sidecar.entries === 0) caveats.push("Sidecar was supplied but no valid primitive metadata entries were parsed.");
+  if (summary.sidecar?.supplied && summary.sidecar.entries > 0 && summary.sidecar.matched === 0) caveats.push("Sidecar entries parsed, but none matched the parsed Gateway records.");
+  return caveats;
+}
+
+export function summarizeGatewayPreflight(
+  jsonl: string,
+  options: GatewayPreflightOptions = {},
+): GatewayPreflightSummary {
+  let sidecar: SidecarMap | undefined;
+  let sidecarEntries = 0;
+  const sidecarSupplied = options.sidecarJson !== undefined;
+  if (sidecarSupplied) {
+    const parsed = parseSidecar(options.sidecarJson ?? "");
+    sidecar = parsed.sidecar;
+    sidecarEntries = parsed.entries;
+  }
+
+  const parsed = parseGatewayJsonl(jsonl, DEFAULT_LIMITS, sidecar);
+  const aggregate = summarizeTraces(parsed.traces);
+  const matched = parsed.sidecarMerged.filter(Boolean).length;
+  const status: GatewayPreflightStatus = parsed.traces.length > 0 ? "ready" : "blocked";
+  const withoutCaveats: Omit<GatewayPreflightSummary, "caveats"> = {
+    status,
+    parsed: parsed.traces.length,
+    invalid: parsed.invalidLines.length,
+    invalid_lines: parsed.invalidLines.slice(0, MAX_REPORTED_INVALID_LINES),
+    truncated: parsed.truncated,
+    redacted_request: aggregate.redactedRequest,
+    redacted_response: aggregate.redactedResponse,
+    models: aggregate.models,
+    providers: aggregate.providers,
+    ...(aggregate.earliest ? { earliest: aggregate.earliest } : {}),
+    ...(aggregate.latest ? { latest: aggregate.latest } : {}),
+    ...(sidecarSupplied ? { sidecar: { supplied: true, entries: sidecarEntries, matched } } : {}),
+  };
+
+  return { ...withoutCaveats, caveats: caveatsFor(withoutCaveats) };
+}
+
+export function formatGatewayPreflightText(summary: GatewayPreflightSummary): string {
+  const lines: string[] = [];
+  lines.push("Cloudflare Gateway export preflight");
+  lines.push(`status: ${summary.status}`);
+  lines.push(`parsed: ${summary.parsed}`);
+  lines.push(`invalid_lines: ${summary.invalid}${summary.invalid_lines.length ? ` (${summary.invalid_lines.join(", ")})` : ""}`);
+  lines.push(`truncated: ${summary.truncated}`);
+  lines.push(`models: ${summary.models.length ? summary.models.join(", ") : "unknown"}`);
+  lines.push(`providers: ${summary.providers.length ? summary.providers.join(", ") : "unknown"}`);
+  lines.push(`time_bounds: ${summary.earliest ?? "unknown"} → ${summary.latest ?? "unknown"}`);
+  lines.push(`redacted_or_missing_requests: ${summary.redacted_request}`);
+  lines.push(`redacted_or_missing_responses: ${summary.redacted_response}`);
+  if (summary.sidecar?.supplied) {
+    lines.push(`sidecar_entries: ${summary.sidecar.entries}`);
+    lines.push(`sidecar_matched_records: ${summary.sidecar.matched}`);
+  }
+  if (summary.caveats.length) {
+    lines.push("caveats:");
+    for (const caveat of summary.caveats) lines.push(`- ${caveat}`);
+  }
+  lines.push("safe_to_import: use the authenticated Gateway Import app surface next; this preflight did not send data anywhere.");
+  return lines.join("\n") + "\n";
+}
+
+export function formatGatewayPreflightJson(summary: GatewayPreflightSummary): string {
+  return JSON.stringify(summary, null, 2) + "\n";
+}

--- a/docs/cloudflare-gateway-preflight.md
+++ b/docs/cloudflare-gateway-preflight.md
@@ -1,0 +1,40 @@
+# Cloudflare Gateway export preflight
+
+Use this local preflight before pasting or uploading a customer-owned Cloudflare AI Gateway JSONL export through the authenticated Gateway Import screen.
+
+```bash
+npm run preflight:gateway -- /path/to/gateway-export.jsonl
+npm run preflight:gateway -- /path/to/gateway-export.jsonl --sidecar /path/to/metadata-sidecar.json
+npm run preflight:gateway -- /path/to/gateway-export.jsonl --json
+```
+
+The preflight is intentionally local-only:
+
+- reads a JSONL export from disk;
+- optionally reads a metadata sidecar from disk;
+- reuses the existing `parseGatewayJsonl`, `parseSidecar`, and `summarizeTraces` parser path;
+- does not import into Convex;
+- does not call Cloudflare, Fireworks, model providers, or other network services;
+- prints only a management-safe summary.
+
+## What the summary includes
+
+- parsed, invalid, and truncated counts;
+- capped invalid line numbers;
+- model and provider names;
+- earliest/latest timestamps;
+- redacted or missing request/response counts;
+- sidecar entry and match counts when supplied;
+- readiness status and caveats.
+
+It deliberately does **not** print raw prompts, raw model outputs, raw tool results, invalid line content, sidecar values, account IDs, credentials, or trace content.
+
+## Live Gateway import loop
+
+1. Export logs from the customer's own Cloudflare AI Gateway account.
+2. Run this preflight locally.
+3. If `status: ready`, paste/upload the same JSONL through the authenticated Gateway Import app surface.
+4. Materialize imported traces into eval cases when ready.
+5. Run blind review, scorecards, and export handoff flows from inside BlindBench.
+
+If the preflight reports `status: blocked`, choose a different export or inspect the local source file outside BlindBench. Do not paste raw Gateway log content into GitHub issues, PRs, or public docs.

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "dataset:demo": "npx tsx src/lib/evals/trainingDataset.ts",
     "compare:demo": "npx tsx src/lib/evals/modelComparison.ts",
     "compare:endpoints": "npx tsx src/lib/evals/compareEndpoints.ts",
+    "preflight:gateway": "npx tsx scripts/cloudflare-gateway-preflight.ts",
     "prototype:fireworks-gateway": "npx tsx src/lib/evals/fireworksGatewayPrototype.ts",
     "smoke:fireworks-gateway": "npx tsx scripts/fireworks-gateway-smoke.ts",
     "preflight:gateway": "npx tsx scripts/cloudflare-gateway-preflight.ts"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "compare:demo": "npx tsx src/lib/evals/modelComparison.ts",
     "compare:endpoints": "npx tsx src/lib/evals/compareEndpoints.ts",
     "prototype:fireworks-gateway": "npx tsx src/lib/evals/fireworksGatewayPrototype.ts",
-    "smoke:fireworks-gateway": "npx tsx scripts/fireworks-gateway-smoke.ts"
+    "smoke:fireworks-gateway": "npx tsx scripts/fireworks-gateway-smoke.ts",
+    "preflight:gateway": "npx tsx scripts/cloudflare-gateway-preflight.ts"
   },
   "dependencies": {
     "@auth/core": "^0.37.4",

--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
     "compare:endpoints": "npx tsx src/lib/evals/compareEndpoints.ts",
     "preflight:gateway": "npx tsx scripts/cloudflare-gateway-preflight.ts",
     "prototype:fireworks-gateway": "npx tsx src/lib/evals/fireworksGatewayPrototype.ts",
-    "smoke:fireworks-gateway": "npx tsx scripts/fireworks-gateway-smoke.ts",
-    "preflight:gateway": "npx tsx scripts/cloudflare-gateway-preflight.ts"
+    "smoke:fireworks-gateway": "npx tsx scripts/fireworks-gateway-smoke.ts"
   },
   "dependencies": {
     "@auth/core": "^0.37.4",

--- a/scripts/cloudflare-gateway-preflight.ts
+++ b/scripts/cloudflare-gateway-preflight.ts
@@ -1,0 +1,68 @@
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+import {
+  formatGatewayPreflightJson,
+  formatGatewayPreflightText,
+  summarizeGatewayPreflight,
+} from "../convex/traceAdapters/cloudflareGatewayPreflight";
+
+interface CliOptions {
+  file?: string;
+  sidecar?: string;
+  json: boolean;
+}
+
+function parseArgs(argv: string[]): CliOptions {
+  const opts: CliOptions = { json: false };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]!;
+    if (arg === "--json") {
+      opts.json = true;
+    } else if (arg === "--sidecar") {
+      const next = argv[++i];
+      if (!next) fail("--sidecar requires a file path");
+      opts.sidecar = next;
+    } else if (arg === "--help" || arg === "-h") {
+      printUsage(0);
+    } else if (!opts.file) {
+      opts.file = arg;
+    } else {
+      fail(`unexpected argument: ${arg}`);
+    }
+  }
+  return opts;
+}
+
+function printUsage(code: number): never {
+  const msg = `usage: npx tsx scripts/cloudflare-gateway-preflight.ts <gateway.jsonl> [--sidecar metadata.json] [--json]\n\nLocal-only, management-safe preflight for a customer-owned Cloudflare AI Gateway JSONL export.\nDoes not upload, import, call Cloudflare, or print raw trace content.\n`;
+  (code === 0 ? console.log : console.error)(msg);
+  process.exit(code);
+}
+
+function fail(message: string): never {
+  console.error(`Cloudflare Gateway preflight failed: ${message}`);
+  process.exit(1);
+}
+
+function readRequiredFile(path: string, label: string): string {
+  if (!existsSync(path)) fail(`${label} file not found: ${path}`);
+  const stat = statSync(path);
+  if (!stat.isFile()) fail(`${label} path is not a file: ${path}`);
+  if (stat.size === 0) fail(`${label} file is empty`);
+  const text = readFileSync(path, "utf8");
+  if (!text.trim()) fail(`${label} file contains only whitespace`);
+  return text;
+}
+
+export function runCli(argv = process.argv.slice(2)): void {
+  const opts = parseArgs(argv);
+  if (!opts.file) printUsage(1);
+  const jsonl = readRequiredFile(opts.file, "Gateway JSONL");
+  const sidecarJson = opts.sidecar ? readRequiredFile(opts.sidecar, "Sidecar") : undefined;
+  const summary = summarizeGatewayPreflight(jsonl, { sidecarJson });
+  process.stdout.write(opts.json ? formatGatewayPreflightJson(summary) : formatGatewayPreflightText(summary));
+  if (summary.status !== "ready") process.exit(1);
+}
+
+const invokedDirectly = process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (invokedDirectly) runCli();


### PR DESCRIPTION
## Summary

Closes #296. Adds a local-only Cloudflare AI Gateway export preflight so operators can validate a customer-owned JSONL export before using the authenticated Gateway Import app surface.

What changed:
- Added `npm run preflight:gateway -- <gateway.jsonl> [--sidecar metadata.json] [--json]`.
- Reuses existing `parseGatewayJsonl`, `parseSidecar`, and `summarizeTraces` helpers instead of adding a second parser.
- Reports only management-safe counts/metadata: parsed/invalid/truncated counts, capped invalid line numbers, model/provider names, time bounds, redacted/missing request/response counts, sidecar entry/match counts, readiness status, and caveats.
- Added leakage-guard tests proving raw prompt/output/sentinel/account-like content and invalid-line content do not appear in text or JSON summaries.
- Added runbook docs for the customer-owned Gateway export/import loop.

## Verification

- `NODE_ENV=development npm ci --include=dev`
  - passed; npm reports existing dependency audit findings
- `npx vitest run convex/traceAdapters/cloudflareGatewayPreflight.test.ts`
  - passed: 1 file, 3 tests
- Synthetic CLI smoke:
  - `npm run preflight:gateway -- /tmp/blindbench-gateway-preflight.jsonl`
  - `npm run preflight:gateway -- /tmp/blindbench-gateway-preflight.jsonl --sidecar /tmp/blindbench-gateway-sidecar.json --json`
  - missing-file path exits non-zero as expected
- `env -u NODE_ENV npm run test:evals`
  - passed: 14 files, 139 tests
- `npx convex dev --once --typecheck disable && env -u NODE_ENV npm run test:convex`
  - passed: 27 files, 235 tests
  - known non-fatal `convex-test` scheduled-function teardown stderr still appears
- `env -u NODE_ENV npm run build`
  - passed with existing Vite chunk-size warnings
- `git diff --check`
  - passed

## Guardrails

- No Convex import from the CLI.
- No Cloudflare API calls and no Cloudflare credentials required.
- No Fireworks/model-provider calls.
- No customer/design-partner data or credentials added.
- Summary output does not print raw Gateway trace content, prompts, outputs, invalid line content, sidecar values, account IDs, or sentinels.

## Epic

Part of #287.
