### PR TITLE
Add OTLP trace payload preflight

### DIFF
--- a/convex/lib/otlpPreflight.ts
+++ b/convex/lib/otlpPreflight.ts
@@ -1,0 +1,107 @@
+/**
+ * #298: management-safe preflight summary for an OTLP/Gen-AI JSON payload.
+ *
+ * Takes the output of `mapOtlpToTraces` (the ONE mapper — no second parser) and
+ * projects it down to counts + non-sensitive labels, so an operator can sanity
+ * check a captured/exported payload before pointing a live exporter at the
+ * `/otlp/v1/traces` endpoint. Deliberately narrow: it reads ONLY counts, model
+ * names, harness/provider names, and capped trace-id suffixes. It never touches
+ * step contents (prompts/completions/tool args), so raw bodies, credentials, and
+ * account-like sentinels in the payload cannot reach the summary. Pure + node-free
+ * so it bundles in the Convex/edge context alongside the mapper.
+ */
+import type { OtelMapResult } from "./otelGenAI";
+
+export interface PreflightSummary {
+  traces: number;
+  spans: number;
+  steps: number;
+  requestMissing: number;
+  responseMissing: number;
+  /** Distinct gen_ai model names seen (already label-only, never body text). */
+  models: string[];
+  /** Distinct harness/provider names (gen_ai.system|provider), label-only. */
+  harnesses: string[];
+  /** Capped, suffix-only trace references — never a full raw id or payload. */
+  traceRefs: string[];
+  readiness: "ready" | "not_ready";
+  caveats: string[];
+}
+
+export interface PreflightOptions {
+  /** Max trace references to surface (rest are noted as capped). */
+  maxRefs?: number;
+  /** Trailing characters of each trace id to show. */
+  suffixLen?: number;
+}
+
+/** Trailing-suffix reference for one trace id (prefix elided when truncated). */
+function traceRef(id: string, suffixLen: number): string {
+  return id.length > suffixLen ? `…${id.slice(-suffixLen)}` : id;
+}
+
+export function buildPreflightSummary(
+  result: OtelMapResult,
+  opts: PreflightOptions = {},
+): PreflightSummary {
+  const maxRefs = opts.maxRefs ?? 5;
+  const suffixLen = opts.suffixLen ?? 8;
+  const { traces, summary } = result;
+
+  const harnesses = [...new Set(traces.map((t) => t.harness.name).filter(Boolean))];
+  // run_id is the raw OTel trace id; show only a capped suffix, never the full set.
+  const refs = traces.map((t) => traceRef(t.run_id ?? t.trace_id, suffixLen));
+  const traceRefs = refs.slice(0, maxRefs);
+
+  const caveats: string[] = [];
+  if (summary.traces === 0) {
+    caveats.push(
+      "No traces mapped — payload has no resourceSpans[].scopeSpans[].spans with gen_ai.* attributes.",
+    );
+  }
+  if (summary.models.length === 0 && summary.traces > 0) {
+    caveats.push("No gen_ai.request.model / gen_ai.response.model found on any span.");
+  }
+  if (summary.requestMissing > 0) {
+    caveats.push(`${summary.requestMissing} span(s) had no request/prompt body.`);
+  }
+  if (summary.responseMissing > 0) {
+    caveats.push(`${summary.responseMissing} span(s) had no response/completion body.`);
+  }
+  if (refs.length > maxRefs) {
+    caveats.push(`Showing first ${maxRefs} of ${refs.length} trace references.`);
+  }
+
+  return {
+    traces: summary.traces,
+    spans: summary.spans,
+    steps: summary.steps,
+    requestMissing: summary.requestMissing,
+    responseMissing: summary.responseMissing,
+    models: summary.models,
+    harnesses,
+    traceRefs,
+    readiness: summary.traces > 0 ? "ready" : "not_ready",
+    caveats,
+  };
+}
+
+/** Human-readable summary — same fields as the JSON form, no raw payload. */
+export function renderPreflightText(s: PreflightSummary): string {
+  const list = (xs: string[]) => (xs.length ? xs.join(", ") : "—");
+  return [
+    `OTLP trace preflight — ${s.readiness === "ready" ? "READY" : "NOT READY"}`,
+    ``,
+    `  traces:          ${s.traces}`,
+    `  spans:           ${s.spans}`,
+    `  steps:           ${s.steps}`,
+    `  requestMissing:  ${s.requestMissing}`,
+    `  responseMissing: ${s.responseMissing}`,
+    `  models:          ${list(s.models)}`,
+    `  harnesses:       ${list(s.harnesses)}`,
+    `  trace refs:      ${list(s.traceRefs)}`,
+    ``,
+    s.caveats.length ? `Caveats:` : `Caveats: none`,
+    ...s.caveats.map((c) => `  - ${c}`),
+  ].join("\n");
+}

--- a/convex/tests/otlpPreflight.test.ts
+++ b/convex/tests/otlpPreflight.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from "vitest";
+import { mapOtlpToTraces } from "../lib/otelGenAI";
+import { buildPreflightSummary, renderPreflightText } from "../lib/otlpPreflight";
+
+const attr = (key: string, value: Record<string, unknown>) => ({ key, value });
+const span = (traceId: string, spanId: string, t: string, attrs: Array<{ key: string; value: Record<string, unknown> }>) => ({
+  traceId, spanId, startTimeUnixNano: t, attributes: attrs,
+});
+
+// Sentinels that must NEVER appear in a management-safe summary — raw prompt,
+// raw completion, a credential-like token, an account-like id.
+const RAW_PROMPT = "SENTINEL_RAW_PROMPT_do_not_leak";
+const RAW_COMPLETION = "SENTINEL_RAW_COMPLETION_do_not_leak";
+const TOKEN = "TOKEN_DO_NOT_PRINT_123456";
+const ACCOUNT = "acct_SENTINEL_ACCOUNT_1234567890";
+
+// Two spans, one trace: bodies + a tool call carrying token/account-like args.
+const payload = {
+  resourceSpans: [
+    {
+      scopeSpans: [
+        {
+          spans: [
+            span("otel-trace-preflight-xyz", "s1", "1000", [
+              attr("gen_ai.request.model", { stringValue: "gpt-4o" }),
+              attr("gen_ai.system", { stringValue: "openai" }),
+              attr("gen_ai.usage.input_tokens", { intValue: "12" }),
+              attr("gen_ai.usage.output_tokens", { intValue: "7" }),
+              attr("gen_ai.prompt", { stringValue: RAW_PROMPT }),
+              attr("gen_ai.completion_json", {
+                stringValue: JSON.stringify({
+                  role: "assistant",
+                  content: RAW_COMPLETION,
+                  tool_calls: [
+                    { id: "call_1", function: { name: "lookup", arguments: JSON.stringify({ token: TOKEN, account: ACCOUNT }) } },
+                  ],
+                }),
+              }),
+            ]),
+            // Body-optional span → contributes requestMissing/responseMissing counts.
+            span("otel-trace-preflight-xyz", "s2", "2000", [
+              attr("gen_ai.request.model", { stringValue: "gpt-4o" }),
+            ]),
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+const SENTINELS = [RAW_PROMPT, RAW_COMPLETION, TOKEN, ACCOUNT];
+
+describe("#298 OTLP preflight summary builder", () => {
+  test("counts + label-only fields; readiness ready", () => {
+    const summary = buildPreflightSummary(mapOtlpToTraces(payload));
+    expect(summary.traces).toBe(1);
+    expect(summary.spans).toBe(2);
+    expect(summary.steps).toBeGreaterThan(0);
+    expect(summary.requestMissing).toBe(1);
+    expect(summary.responseMissing).toBe(1);
+    expect(summary.models).toEqual(["gpt-4o"]);
+    expect(summary.harnesses).toEqual(["openai"]);
+    expect(summary.readiness).toBe("ready");
+    // Trace refs are suffix-only — never the full raw id.
+    expect(summary.traceRefs[0]!.startsWith("…")).toBe(true);
+    expect(summary.traceRefs[0]).not.toContain("otel-trace-preflight");
+    expect(summary.caveats.some((c) => c.includes("no request/prompt"))).toBe(true);
+  });
+
+  test("leakage guard: neither text nor JSON summary contains raw bodies/token/account", () => {
+    const summary = buildPreflightSummary(mapOtlpToTraces(payload));
+    const text = renderPreflightText(summary);
+    const json = JSON.stringify(summary);
+    for (const sentinel of SENTINELS) {
+      expect(text).not.toContain(sentinel);
+      expect(json).not.toContain(sentinel);
+    }
+    // Sanity: the safe labels DO survive, so we know we tested a populated summary.
+    expect(text).toContain("gpt-4o");
+    expect(text).toContain("openai");
+  });
+
+  test("zero mapped traces → not_ready with a clear caveat", () => {
+    const summary = buildPreflightSummary(mapOtlpToTraces({ resourceSpans: [] }));
+    expect(summary.traces).toBe(0);
+    expect(summary.readiness).toBe("not_ready");
+    expect(summary.caveats.join(" ")).toContain("No traces mapped");
+  });
+});

--- a/docs/otlp-trace-preflight.md
+++ b/docs/otlp-trace-preflight.md
@@ -1,0 +1,80 @@
+# OTLP trace payload preflight
+
+A local-only sanity check for an OTLP/OpenTelemetry Gen-AI JSON payload **before**
+you point a live exporter at BlindBench's ingest endpoint. It reuses the exact
+`mapOtlpToTraces` mapper the `/otlp/v1/traces` importer runs, so "does my payload
+map to trajectories?" is answered by the real code path — not a second parser.
+
+It does **not** send anything, import into Convex, or read ingest tokens. It only
+reads a file and prints counts + label-only fields.
+
+## Usage
+
+```bash
+# Text summary
+npm run preflight:otlp -- path/to/otlp-export.json
+# or directly:
+npx tsx scripts/otlp-trace-preflight.ts path/to/otlp-export.json
+
+# Machine-readable (same safe fields as JSON)
+npx tsx scripts/otlp-trace-preflight.ts path/to/otlp-export.json --json
+```
+
+Get the payload by capturing what your exporter would POST — e.g. write your
+OTLP/HTTP exporter's request body to a file, or export a batch to JSON.
+
+## Output
+
+```
+OTLP trace preflight — READY
+
+  traces:          1
+  spans:           2
+  steps:           4
+  requestMissing:  1
+  responseMissing: 1
+  models:          gpt-4o
+  harnesses:       openai
+  trace refs:      …ight-xyz
+
+Caveats:
+  - 1 span(s) had no request/prompt body.
+  - 1 span(s) had no response/completion body.
+```
+
+- **traces / spans / steps** — how many trajectories, spans, and trajectory steps
+  the mapper produced.
+- **requestMissing / responseMissing** — spans with no prompt / no completion body
+  (these still map; the gateway importer counts them the same way).
+- **models / harnesses** — `gen_ai.request.model|response.model` and
+  `gen_ai.system|provider` names, if present.
+- **trace refs** — capped, suffix-only references (never full ids or raw payload).
+- **readiness / caveats** — `READY` when at least one trace mapped; caveats flag
+  missing bodies, missing model attributes, and capped reference lists.
+
+The summary is built only from counts and label-only fields — it never prints raw
+prompts, completions, span bodies, tool arguments, account ids, credentials, or the
+invalid JSON itself.
+
+## Exit codes
+
+| Code | Meaning |
+| ---- | ------- |
+| 0 | At least one trace mapped |
+| 1 | Zero traces mapped (payload has no `resourceSpans[].scopeSpans[].spans` with `gen_ai.*` attributes) |
+| 2 | Bad input — missing path argument, unreadable file, or invalid JSON |
+
+## Mapping to Ingest Endpoint setup
+
+In the app, **Settings → Ingest Endpoint** issues a token and shows the
+`/otlp/v1/traces` URL for your OTLP/HTTP exporter. Run this preflight against a
+captured payload first:
+
+1. **READY with the models/harness you expect** → your exporter's attributes match
+   the Gen-AI conventions the importer reads; safe to configure the live exporter.
+2. **NOT READY (zero traces)** → the exporter isn't emitting
+   `resourceSpans[].scopeSpans[].spans` with `gen_ai.*` attributes; fix the
+   exporter/instrumentation before wiring up the endpoint.
+3. **High requestMissing / responseMissing** → spans are arriving without
+   prompt/completion bodies; expected if you strip bodies, otherwise check your
+   `gen_ai.prompt*` / `gen_ai.completion*` attribute emission.

--- a/package.json
+++ b/package.json
@@ -12,11 +12,11 @@
     "test:convex": "vitest run --config convex/vitest.config.ts",
     "test:ct": "playwright test -c playwright-ct.config.ts",
     "scorecard:demo": "npx tsx src/lib/evals/scorecard.ts",
+    "preflight:otlp": "npx tsx scripts/otlp-trace-preflight.ts",
     "dataset:demo": "npx tsx src/lib/evals/trainingDataset.ts",
     "compare:demo": "npx tsx src/lib/evals/modelComparison.ts",
     "compare:endpoints": "npx tsx src/lib/evals/compareEndpoints.ts",
     "prototype:fireworks-gateway": "npx tsx src/lib/evals/fireworksGatewayPrototype.ts",
-    "preflight:otlp": "npx tsx scripts/otlp-trace-preflight.ts",
     "smoke:fireworks-gateway": "npx tsx scripts/fireworks-gateway-smoke.ts"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "compare:demo": "npx tsx src/lib/evals/modelComparison.ts",
     "compare:endpoints": "npx tsx src/lib/evals/compareEndpoints.ts",
     "prototype:fireworks-gateway": "npx tsx src/lib/evals/fireworksGatewayPrototype.ts",
+    "preflight:otlp": "npx tsx scripts/otlp-trace-preflight.ts",
     "smoke:fireworks-gateway": "npx tsx scripts/fireworks-gateway-smoke.ts",
     "preflight:otlp": "npx tsx scripts/otlp-trace-preflight.ts"
   },

--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
     "compare:endpoints": "npx tsx src/lib/evals/compareEndpoints.ts",
     "prototype:fireworks-gateway": "npx tsx src/lib/evals/fireworksGatewayPrototype.ts",
     "preflight:otlp": "npx tsx scripts/otlp-trace-preflight.ts",
-    "smoke:fireworks-gateway": "npx tsx scripts/fireworks-gateway-smoke.ts",
-    "preflight:otlp": "npx tsx scripts/otlp-trace-preflight.ts"
+    "smoke:fireworks-gateway": "npx tsx scripts/fireworks-gateway-smoke.ts"
   },
   "dependencies": {
     "@auth/core": "^0.37.4",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "compare:demo": "npx tsx src/lib/evals/modelComparison.ts",
     "compare:endpoints": "npx tsx src/lib/evals/compareEndpoints.ts",
     "prototype:fireworks-gateway": "npx tsx src/lib/evals/fireworksGatewayPrototype.ts",
-    "smoke:fireworks-gateway": "npx tsx scripts/fireworks-gateway-smoke.ts"
+    "smoke:fireworks-gateway": "npx tsx scripts/fireworks-gateway-smoke.ts",
+    "preflight:otlp": "npx tsx scripts/otlp-trace-preflight.ts"
   },
   "dependencies": {
     "@auth/core": "^0.37.4",

--- a/scripts/otlp-trace-preflight.ts
+++ b/scripts/otlp-trace-preflight.ts
@@ -1,0 +1,96 @@
+/**
+ * #298: local-only OTLP/Gen-AI payload preflight (no network, no ingest).
+ *
+ *   npx tsx scripts/otlp-trace-preflight.ts <payload.json>
+ *   npx tsx scripts/otlp-trace-preflight.ts <payload.json> --json
+ *
+ * Reads a captured/exported OTLP JSON payload from disk, runs it through the SAME
+ * `mapOtlpToTraces` used by the live `/otlp/v1/traces` importer, and prints a
+ * management-safe summary (counts, model/harness names, capped trace-id suffixes,
+ * readiness + caveats). It NEVER POSTs anywhere, imports into Convex, reads/prints
+ * ingest tokens, or echoes raw prompts/completions/span bodies/account ids/invalid
+ * JSON — the summary is built only from counts and label-only fields.
+ *
+ * Exit codes: 0 = traces mapped; 1 = zero traces mapped; 2 = bad input (missing
+ * arg, missing file, invalid JSON).
+ */
+import { readFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+import { mapOtlpToTraces } from "../convex/lib/otelGenAI";
+import {
+  buildPreflightSummary,
+  renderPreflightText,
+  type PreflightSummary,
+} from "../convex/lib/otlpPreflight";
+
+export interface CliArgs {
+  path?: string;
+  json: boolean;
+}
+
+export function parseArgs(argv: string[]): CliArgs {
+  const json = argv.includes("--json");
+  const path = argv.find((a) => a !== "--json" && !a.startsWith("-"));
+  return { path, json };
+}
+
+const USAGE = "usage: npx tsx scripts/otlp-trace-preflight.ts <payload.json> [--json]";
+
+/** Result of turning a file into a summary — or a safe error (no raw content). */
+type PreflightOutcome =
+  | { ok: true; summary: PreflightSummary }
+  | { ok: false; code: 1 | 2; message: string };
+
+/**
+ * Pure core: path → outcome. Injectable reader so it stays testable without disk.
+ * Parse/read failures return generic messages — never the file bytes or parser
+ * snippet, which can echo the payload (and thus sentinels/credentials).
+ */
+export function runPreflight(
+  path: string,
+  read: (p: string) => string = (p) => readFileSync(p, "utf8"),
+): PreflightOutcome {
+  let raw: string;
+  try {
+    raw = read(path);
+  } catch {
+    return { ok: false, code: 2, message: `Cannot read file: ${path}` };
+  }
+  let payload: unknown;
+  try {
+    payload = JSON.parse(raw);
+  } catch {
+    // Intentionally omit the parser message — it can contain payload bytes.
+    return { ok: false, code: 2, message: `Invalid JSON: ${path}` };
+  }
+  const summary = buildPreflightSummary(mapOtlpToTraces(payload));
+  if (summary.traces === 0) {
+    return {
+      ok: false,
+      code: 1,
+      message: `No traces mapped from ${path}. ${summary.caveats.join(" ")}`,
+    };
+  }
+  return { ok: true, summary };
+}
+
+export function main(argv: string[]): number {
+  const { path, json } = parseArgs(argv);
+  if (!path) {
+    process.stderr.write(`${USAGE}\n`);
+    return 2;
+  }
+  const outcome = runPreflight(path);
+  if (!outcome.ok) {
+    process.stderr.write(`${outcome.message}\n`);
+    return outcome.code;
+  }
+  process.stdout.write(
+    (json ? JSON.stringify(outcome.summary, null, 2) : renderPreflightText(outcome.summary)) + "\n",
+  );
+  return 0;
+}
+
+const invokedDirectly =
+  process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (invokedDirectly) process.exit(main(process.argv.slice(2)));


### PR DESCRIPTION
## Summary

Closes #298. Adds a local-only OTLP/OpenTelemetry payload preflight so operators can validate a captured/exported OTLP JSON payload before configuring or testing a live exporter against BlindBench.

What changed:
- Added `npm run preflight:otlp -- <payload.json> [--json]`.
- Reuses existing `mapOtlpToTraces` from `convex/lib/otelGenAI.ts` instead of adding another mapper.
- Reports only management-safe fields: traces/spans/steps counts, request/response-missing counts, model/harness labels, suffix-only trace references, readiness, and caveats.
- Added leakage-guard tests proving raw prompt/completion/token/account-like sentinels do not appear in text or JSON summaries.
- Added docs mapping the preflight to the app's OTLP exporter setup flow.

## Verification

- `NODE_ENV=development npm ci --include=dev`
  - passed; npm reports existing dependency audit findings
- `npx vitest run convex/tests/otlpPreflight.test.ts`
  - passed: 1 file, 3 tests
- Synthetic CLI smoke:
  - `npm run preflight:otlp -- /tmp/blindbench-otlp-preflight.json`
  - `npm run preflight:otlp -- /tmp/blindbench-otlp-preflight.json --json`
  - missing-file and invalid-JSON cases exit non-zero as expected
- `env -u NODE_ENV npm run test:evals`
  - passed: 14 files, 139 tests
- `npx convex dev --once --typecheck disable && env -u NODE_ENV npm run test:convex`
  - passed: 27 files, 235 tests
  - known non-fatal `convex-test` scheduled-function teardown stderr still appears
- `env -u NODE_ENV npm run build`
  - passed with existing Vite chunk-size warnings
- `git diff --check`
  - passed

## Guardrails

- No POST to `/otlp/v1/traces` from the CLI.
- No Convex import or mutation.
- No ingest token required or printed.
- No Cloudflare, Fireworks, model-provider, or other live network calls.
- No customer/design-partner data or credentials added.
- Summary output does not print raw prompts, completions, span bodies, invalid JSON, account IDs, or sentinels.

## Epic

Part of #287.
