### PR TITLE
Add training export artifact verifier

### DIFF
--- a/docs/training-export-verifier.md
+++ b/docs/training-export-verifier.md
@@ -1,0 +1,79 @@
+# Training export artifact verifier
+
+Use this local verifier before handing Fireworks-ready JSONL artifacts to Fireworks or to a customer. It checks that the compiler output is internally consistent and preserves the data-boundary contract.
+
+```bash
+npm run dataset:demo
+npm run verify:training-export -- artifacts
+npm run verify:training-export -- artifacts --json
+```
+
+Optional leakage guard:
+
+```bash
+npm run verify:training-export -- artifacts --block-substring FORBIDDEN_SENTINEL
+```
+
+The verifier is local-only:
+
+- no Fireworks API calls;
+- no Convex import or mutation;
+- no Cloudflare or model-provider calls;
+- no credentials required.
+
+## Expected files
+
+The artifact directory must contain the compiler output names:
+
+- `training-dataset.train.jsonl`
+- `training-dataset.validation.jsonl`
+- `training-dataset.test.jsonl`
+- `training-dataset.manifest.json`
+
+## Checks
+
+The verifier validates:
+
+1. Every JSONL line parses as JSON.
+2. Every row has the Fireworks chat/SFT shape:
+
+   ```json
+   {"messages":[{"role":"user","content":"…"},{"role":"assistant","content":"…"}]}
+   ```
+
+3. Message roles and content are non-empty strings.
+4. Manifest `split_counts` match actual JSONL line counts.
+5. Manifest `row_entries[*].hash` values match each messages-only JSONL row.
+6. Manifest `dataset_hash` matches the row-entry hash structure.
+7. Optional `--block-substring` sentinels do not appear in any JSONL row.
+
+## Safe output
+
+Text mode prints only management-safe fields:
+
+```text
+Training export verification — READY
+
+  dataset:       training-dataset
+  hash suffix:   …27a9583a60f1
+  files checked: 4
+  rows:          train=4 validation=0 test=1
+  excluded:      0
+```
+
+Error mode prints reason codes like `train:manifest_count_mismatch` or `test:line_2:invalid_json`. It does **not** print row contents, prompts, completions, account IDs, invalid JSON text, or blocked substring values.
+
+## Exit codes
+
+| Code | Meaning |
+| --- | --- |
+| 0 | Artifacts are ready. |
+| 1 | Artifacts were readable but failed verification. |
+| 2 | Bad invocation or missing artifact directory. |
+
+## Operator flow
+
+1. Generate or receive training artifacts.
+2. Run this verifier locally.
+3. Only hand off JSONL if the verifier reports `READY` and the manifest/excluded counts match the intended data boundary.
+4. Keep the manifest with the JSONL handoff; it is the safe sidecar for hashes, split counts, filters, and exclusions.

--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
     "compare:demo": "npx tsx src/lib/evals/modelComparison.ts",
     "compare:endpoints": "npx tsx src/lib/evals/compareEndpoints.ts",
     "prototype:fireworks-gateway": "npx tsx src/lib/evals/fireworksGatewayPrototype.ts",
-    "smoke:fireworks-gateway": "npx tsx scripts/fireworks-gateway-smoke.ts",
-    "verify:training-export": "npx tsx scripts/training-export-verify.ts"
+    "smoke:fireworks-gateway": "npx tsx scripts/fireworks-gateway-smoke.ts"
   },
   "dependencies": {
     "@auth/core": "^0.37.4",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "compare:demo": "npx tsx src/lib/evals/modelComparison.ts",
     "compare:endpoints": "npx tsx src/lib/evals/compareEndpoints.ts",
     "prototype:fireworks-gateway": "npx tsx src/lib/evals/fireworksGatewayPrototype.ts",
-    "smoke:fireworks-gateway": "npx tsx scripts/fireworks-gateway-smoke.ts"
+    "smoke:fireworks-gateway": "npx tsx scripts/fireworks-gateway-smoke.ts",
+    "verify:training-export": "npx tsx scripts/training-export-verify.ts"
   },
   "dependencies": {
     "@auth/core": "^0.37.4",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test:ct": "playwright test -c playwright-ct.config.ts",
     "scorecard:demo": "npx tsx src/lib/evals/scorecard.ts",
     "dataset:demo": "npx tsx src/lib/evals/trainingDataset.ts",
+    "verify:training-export": "npx tsx scripts/training-export-verify.ts",
     "compare:demo": "npx tsx src/lib/evals/modelComparison.ts",
     "compare:endpoints": "npx tsx src/lib/evals/compareEndpoints.ts",
     "prototype:fireworks-gateway": "npx tsx src/lib/evals/fireworksGatewayPrototype.ts",

--- a/scripts/training-export-verify.ts
+++ b/scripts/training-export-verify.ts
@@ -1,0 +1,74 @@
+import { existsSync, statSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+import {
+  formatTrainingExportVerificationJson,
+  formatTrainingExportVerificationText,
+  verifyTrainingExportArtifacts,
+} from "../src/lib/evals/trainingExportVerifier";
+
+interface Args {
+  artifactDir?: string;
+  json: boolean;
+  blockedSubstrings: string[];
+}
+
+function usage(): string {
+  return [
+    "usage: training-export-verify <artifact-dir> [--json] [--block-substring <value> ...]",
+    "",
+    "Validates training-dataset.{train,validation,test}.jsonl plus training-dataset.manifest.json.",
+    "No network calls; never prints raw row content or blocked substring values.",
+  ].join("\n");
+}
+
+export function parseArgs(argv: string[]): Args {
+  const args: Args = { json: false, blockedSubstrings: [] };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--json") {
+      args.json = true;
+    } else if (arg === "--block-substring") {
+      const value = argv[++i];
+      if (!value) throw new Error("--block-substring requires a value");
+      args.blockedSubstrings.push(value);
+    } else if (arg === "--help" || arg === "-h") {
+      throw new Error(usage());
+    } else if (!args.artifactDir) {
+      args.artifactDir = arg;
+    } else {
+      throw new Error(`Unexpected argument: ${arg}`);
+    }
+  }
+  return args;
+}
+
+export async function main(argv: string[]): Promise<number> {
+  let args: Args;
+  try {
+    args = parseArgs(argv);
+  } catch (err) {
+    process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`);
+    return 2;
+  }
+  if (!args.artifactDir) {
+    process.stderr.write(`${usage()}\n`);
+    return 2;
+  }
+  if (!existsSync(args.artifactDir) || !statSync(args.artifactDir).isDirectory()) {
+    process.stderr.write("training-export-verify: artifact directory not found or not a directory.\n");
+    return 2;
+  }
+
+  const summary = verifyTrainingExportArtifacts({
+    artifactDir: args.artifactDir,
+    blockedSubstrings: args.blockedSubstrings,
+  });
+  process.stdout.write(args.json ? formatTrainingExportVerificationJson(summary) : formatTrainingExportVerificationText(summary));
+  return summary.readiness === "ready" ? 0 : 1;
+}
+
+const invokedDirectly =
+  process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (invokedDirectly) {
+  main(process.argv.slice(2)).then((code) => process.exit(code));
+}

--- a/src/lib/evals/trainingExportVerifier.test.ts
+++ b/src/lib/evals/trainingExportVerifier.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "vitest";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  SPLITS,
+  compileTrainingDataset,
+  demoTrainingSourceRows,
+  formatManifest,
+  toJsonl,
+} from "./trainingDataset";
+import {
+  formatTrainingExportVerificationJson,
+  formatTrainingExportVerificationText,
+  verifyTrainingExportArtifacts,
+} from "./trainingExportVerifier";
+
+function writeExportDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "training-export-verifier-"));
+  mkdirSync(dir, { recursive: true });
+  const { splits, manifest } = compileTrainingDataset(demoTrainingSourceRows(), {
+    generated_at: "2026-01-01T00:00:00Z",
+    dataset_name: "training-dataset",
+  });
+  for (const split of SPLITS) writeFileSync(join(dir, `training-dataset.${split}.jsonl`), toJsonl(splits[split]));
+  writeFileSync(join(dir, "training-dataset.manifest.json"), formatManifest(manifest));
+  return dir;
+}
+
+describe("training export verifier", () => {
+  test("accepts compiler-generated artifacts and prints safe summaries", () => {
+    const dir = writeExportDir();
+    const summary = verifyTrainingExportArtifacts({ artifactDir: dir });
+    expect(summary.readiness).toBe("ready");
+    expect(summary.errors).toEqual([]);
+    expect(summary.rows.train + summary.rows.validation + summary.rows.test).toBeGreaterThan(0);
+    expect(summary.datasetName).toBe("training-dataset");
+    expect(summary.datasetHashSuffix?.startsWith("…")).toBe(true);
+    expect(formatTrainingExportVerificationText(summary)).toContain("Training export verification — READY");
+  });
+
+  test("fails count and hash mismatches without printing row content", () => {
+    const dir = writeExportDir();
+    const manifestPath = join(dir, "training-dataset.manifest.json");
+    const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+    manifest.split_counts.train += 1;
+    manifest.row_entries.validation[0].hash = "0".repeat(64);
+    writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
+
+    const summary = verifyTrainingExportArtifacts({ artifactDir: dir });
+    expect(summary.readiness).toBe("not_ready");
+    expect(summary.errors).toContain("train:manifest_count_mismatch");
+    expect(summary.errors).toContain("validation:entry_1:hash_mismatch");
+    const text = formatTrainingExportVerificationText(summary);
+    expect(text).not.toContain("Synthetic safe completion");
+    expect(text).not.toContain("messages");
+  });
+
+  test("fails invalid JSONL and empty message content", () => {
+    const dir = writeExportDir();
+    writeFileSync(join(dir, "training-dataset.test.jsonl"), `{"messages":[{"role":"user","content":""}]}\n{bad json}\n`);
+    const summary = verifyTrainingExportArtifacts({ artifactDir: dir });
+    expect(summary.readiness).toBe("not_ready");
+    expect(summary.errors).toContain("test:line_1:message_content_empty");
+    expect(summary.errors).toContain("test:line_2:invalid_json");
+  });
+
+  test("blocks forbidden substrings without echoing the substring in text or JSON", () => {
+    const dir = writeExportDir();
+    const forbidden = "TOKEN_DO_NOT_PRINT_123456";
+    writeFileSync(join(dir, "training-dataset.train.jsonl"), `{"messages":[{"role":"user","content":"${forbidden}"}]}\n`);
+    const summary = verifyTrainingExportArtifacts({ artifactDir: dir, blockedSubstrings: [forbidden] });
+    expect(summary.readiness).toBe("not_ready");
+    expect(summary.errors).toContain("train:line_1:blocked_substring_present");
+    expect(formatTrainingExportVerificationText(summary)).not.toContain(forbidden);
+    expect(formatTrainingExportVerificationJson(summary)).not.toContain(forbidden);
+  });
+});

--- a/src/lib/evals/trainingExportVerifier.ts
+++ b/src/lib/evals/trainingExportVerifier.ts
@@ -1,0 +1,201 @@
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { stableStringify } from "./cloudflareAiGateway";
+import { SPLITS, type SplitName } from "./trainingDataset";
+
+type ReadFile = (path: string) => string;
+
+export interface VerifyTrainingExportOptions {
+  artifactDir: string;
+  blockedSubstrings?: string[];
+  readFile?: ReadFile;
+}
+
+export type TrainingExportReadiness = "ready" | "not_ready";
+
+export interface VerifyTrainingExportSummary {
+  readiness: TrainingExportReadiness;
+  filesChecked: string[];
+  datasetName?: string;
+  datasetHashSuffix?: string;
+  rows: Record<SplitName, number>;
+  excludedCount: number;
+  errors: string[];
+  caveats: string[];
+}
+
+interface ManifestRowEntry {
+  case_id?: string;
+  hash?: string;
+}
+
+interface ManifestShape {
+  dataset_name?: string;
+  dataset_hash?: string;
+  split_counts?: Partial<Record<SplitName, number>>;
+  row_entries?: Partial<Record<SplitName, ManifestRowEntry[]>>;
+  excluded?: unknown[];
+}
+
+const DATASET_BASENAME = "training-dataset";
+const MANIFEST_FILE = `${DATASET_BASENAME}.manifest.json`;
+const SPLIT_FILE = (split: SplitName) => `${DATASET_BASENAME}.${split}.jsonl`;
+
+const sha256hex = (value: string) => createHash("sha256").update(value).digest("hex");
+
+function safeSuffix(value: unknown, chars = 12): string | undefined {
+  if (typeof value !== "string" || value.length === 0) return undefined;
+  return value.length <= chars ? value : `…${value.slice(-chars)}`;
+}
+
+function hasBlockedSubstring(value: string, blocked: string[]): boolean {
+  return blocked.some((s) => s.length > 0 && value.includes(s));
+}
+
+function validateMessagesRow(value: unknown): string | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return "row_not_object";
+  const row = value as Record<string, unknown>;
+  if (!Array.isArray(row.messages)) return "messages_missing";
+  if (row.messages.length === 0) return "messages_empty";
+  for (const message of row.messages) {
+    if (!message || typeof message !== "object" || Array.isArray(message)) return "message_not_object";
+    const m = message as Record<string, unknown>;
+    if (typeof m.role !== "string" || m.role.length === 0) return "message_role_invalid";
+    if (typeof m.content !== "string" || m.content.length === 0) return "message_content_empty";
+  }
+  return null;
+}
+
+function readText(path: string, readFile?: ReadFile): string {
+  return readFile ? readFile(path) : readFileSync(path, "utf8");
+}
+
+function parseManifest(text: string): { manifest?: ManifestShape; error?: string } {
+  try {
+    const parsed = JSON.parse(text) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return { error: "manifest_not_object" };
+    return { manifest: parsed as ManifestShape };
+  } catch {
+    return { error: "manifest_invalid_json" };
+  }
+}
+
+export function verifyTrainingExportArtifacts(
+  options: VerifyTrainingExportOptions,
+): VerifyTrainingExportSummary {
+  const read = options.readFile;
+  const blocked = options.blockedSubstrings ?? [];
+  const filesChecked: string[] = [];
+  const errors: string[] = [];
+  const caveats: string[] = [];
+  const rows: Record<SplitName, number> = { train: 0, validation: 0, test: 0 };
+  const rowHashes: Record<SplitName, string[]> = { train: [], validation: [], test: [] };
+  let manifest: ManifestShape | undefined;
+
+  try {
+    const manifestPath = join(options.artifactDir, MANIFEST_FILE);
+    filesChecked.push(MANIFEST_FILE);
+    const parsed = parseManifest(readText(manifestPath, read));
+    if (parsed.error) errors.push(parsed.error);
+    manifest = parsed.manifest;
+  } catch {
+    errors.push("manifest_missing_or_unreadable");
+  }
+
+  for (const split of SPLITS) {
+    const file = SPLIT_FILE(split);
+    filesChecked.push(file);
+    let text = "";
+    try {
+      text = readText(join(options.artifactDir, file), read);
+    } catch {
+      errors.push(`${split}:jsonl_missing_or_unreadable`);
+      continue;
+    }
+    const lines = text.split("\n").filter((line) => line.length > 0);
+    rows[split] = lines.length;
+    lines.forEach((line, i) => {
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(line);
+      } catch {
+        errors.push(`${split}:line_${i + 1}:invalid_json`);
+        return;
+      }
+      const shapeError = validateMessagesRow(parsed);
+      if (shapeError) errors.push(`${split}:line_${i + 1}:${shapeError}`);
+      if (hasBlockedSubstring(line, blocked)) errors.push(`${split}:line_${i + 1}:blocked_substring_present`);
+      rowHashes[split].push(sha256hex(stableStringify(parsed)));
+    });
+  }
+
+  if (manifest?.split_counts) {
+    for (const split of SPLITS) {
+      const expected = manifest.split_counts[split];
+      if (typeof expected === "number" && expected !== rows[split]) {
+        errors.push(`${split}:manifest_count_mismatch`);
+      }
+    }
+  } else if (manifest) {
+    caveats.push("Manifest has no split_counts object.");
+  }
+
+  if (manifest?.row_entries) {
+    for (const split of SPLITS) {
+      const entries = manifest.row_entries[split] ?? [];
+      if (entries.length !== rows[split]) {
+        errors.push(`${split}:manifest_row_entries_count_mismatch`);
+        continue;
+      }
+      entries.forEach((entry, i) => {
+        if (typeof entry.hash !== "string") {
+          errors.push(`${split}:entry_${i + 1}:hash_missing`);
+        } else if (entry.hash !== rowHashes[split][i]) {
+          errors.push(`${split}:entry_${i + 1}:hash_mismatch`);
+        }
+      });
+    }
+    const computedDatasetHash = sha256hex(stableStringify(manifest.row_entries));
+    if (typeof manifest.dataset_hash === "string" && manifest.dataset_hash !== computedDatasetHash) {
+      errors.push("manifest_dataset_hash_mismatch");
+    }
+  } else if (manifest) {
+    caveats.push("Manifest has no row_entries object; row-level hashes were not checked.");
+  }
+
+  const excludedCount = Array.isArray(manifest?.excluded) ? manifest!.excluded!.length : 0;
+  return {
+    readiness: errors.length === 0 ? "ready" : "not_ready",
+    filesChecked,
+    datasetName: typeof manifest?.dataset_name === "string" ? manifest.dataset_name : undefined,
+    datasetHashSuffix: safeSuffix(manifest?.dataset_hash),
+    rows,
+    excludedCount,
+    errors,
+    caveats,
+  };
+}
+
+export function formatTrainingExportVerificationText(summary: VerifyTrainingExportSummary): string {
+  const lines = [
+    `Training export verification — ${summary.readiness === "ready" ? "READY" : "NOT READY"}`,
+    "",
+    `  dataset:       ${summary.datasetName ?? "unknown"}`,
+    `  hash suffix:   ${summary.datasetHashSuffix ?? "n/a"}`,
+    `  files checked: ${summary.filesChecked.length}`,
+    `  rows:          train=${summary.rows.train} validation=${summary.rows.validation} test=${summary.rows.test}`,
+    `  excluded:      ${summary.excludedCount}`,
+  ];
+  if (summary.errors.length) {
+    lines.push("", "Errors:", ...summary.errors.map((e) => `  - ${e}`));
+  }
+  if (summary.caveats.length) {
+    lines.push("", "Caveats:", ...summary.caveats.map((c) => `  - ${c}`));
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+export function formatTrainingExportVerificationJson(summary: VerifyTrainingExportSummary): string {
+  return `${JSON.stringify(summary, null, 2)}\n`;
+}


### PR DESCRIPTION
## Summary

Closes #300. Adds a local-only verifier for Fireworks-ready training export artifacts before an operator hands JSONL to Fireworks or to a customer.

What changed:
- Added `npm run verify:training-export -- <artifact-dir> [--json] [--block-substring <value> ...]`.
- Validates the existing compiler output files:
  - `training-dataset.train.jsonl`
  - `training-dataset.validation.jsonl`
  - `training-dataset.test.jsonl`
  - `training-dataset.manifest.json`
- Checks JSONL Fireworks chat/SFT shape, non-empty message content, manifest split counts, row-entry hashes, dataset hash, and optional forbidden-substring gates.
- Prints only management-safe summary fields: files checked, row counts, dataset name/hash suffix, excluded count, readiness, and reason-code caveats/errors.
- Added runbook docs and leakage-guard tests.

## Verification

- `rm -rf node_modules && NODE_ENV=development npm ci --include=dev`
  - passed; npm reports existing dependency audit findings
- `npx vitest run src/lib/evals/trainingExportVerifier.test.ts`
  - passed: 1 file, 4 tests
- CLI smoke:
  - `npm run dataset:demo`
  - `npm run verify:training-export -- artifacts`
  - `npm run verify:training-export -- artifacts --json`
  - tampered bad artifact exits non-zero as expected
- `env -u NODE_ENV npm run test:evals`
  - passed: 15 files, 143 tests
- `npx convex dev --once --typecheck disable && env -u NODE_ENV npm run test:convex`
  - passed: 26 files, 232 tests
  - known non-fatal `convex-test` scheduled-function teardown stderr still appears
- `env -u NODE_ENV npm run build`
  - passed with existing Vite chunk-size warnings
- `git diff --check`
  - passed

## Guardrails

- No Fireworks API calls or fine-tune creation.
- No Convex import/mutation.
- No Cloudflare or model-provider calls.
- No customer/design-partner data or credentials added.
- Text/JSON summaries do not print row contents, raw prompts, completions, invalid JSON text, account IDs, credentials, or blocked substring values.

## Epic

Part of #287.
