### PR TITLE
Add synthetic agent trace fixtures

### DIFF
--- a/docs/agent-trace-fixtures.md
+++ b/docs/agent-trace-fixtures.md
@@ -1,0 +1,71 @@
+# Synthetic agent trace fixtures
+
+Use these fixtures for local dry runs before importing any real operator-owned trace data. The generator writes deterministic, synthetic-only examples for the core supported trace shapes.
+
+```bash
+npm run fixtures:agent-traces
+npm run fixtures:agent-traces -- --out /tmp/blindbench-agent-trace-fixtures
+```
+
+Default output:
+
+```text
+artifacts/agent-trace-fixtures/
+├── claude-code-session.jsonl
+├── cloudflare-gateway.jsonl
+├── otlp-genai.json
+├── manifest.json
+└── README.md
+```
+
+## What the fixtures cover
+
+| File | Shape | Parser / mapper exercised |
+| --- | --- | --- |
+| `claude-code-session.jsonl` | Claude Code JSONL session | `parseClaudeCodeSession` |
+| `cloudflare-gateway.jsonl` | Cloudflare AI Gateway exported JSONL | `parseCloudflareAiGatewayJsonl` |
+| `otlp-genai.json` | OTLP/OpenTelemetry GenAI JSON payload | `mapOtlpToTraces` |
+
+The generated manifest includes only safe metadata:
+
+- file names;
+- format labels;
+- trace/span/step counts;
+- model labels;
+- fixed `generated_at` timestamp;
+- safety flags.
+
+## Safety contract
+
+The fixtures are deliberately synthetic:
+
+- no customer/design-partner data;
+- no real Claude sessions;
+- no real Cloudflare AI Gateway exports;
+- no real OTLP exports;
+- no authentication material, account secrets, or real account identifiers;
+- no network calls;
+- no Convex import or mutation;
+- no Fireworks/model-provider calls.
+
+## Operator flow
+
+1. Generate fixtures locally:
+
+   ```bash
+   npm run fixtures:agent-traces
+   ```
+
+2. Use the generated files to exercise parser/preflight commands as those PRs land. Examples:
+
+   ```bash
+   npm run preflight:claude-code -- artifacts/agent-trace-fixtures/claude-code-session.jsonl
+   npm run preflight:gateway -- artifacts/agent-trace-fixtures/cloudflare-gateway.jsonl
+   npm run preflight:otlp -- artifacts/agent-trace-fixtures/otlp-genai.json
+   ```
+
+3. Use the resulting safe summaries for dry-run handoff evidence. Do not treat these fixtures as customer data, evaluation truth, or training examples.
+
+## Review notes
+
+The fixture generator validates its own output against the existing parser/mappers before writing the manifest. If parser behavior changes, the focused fixture test should fail before customer data is touched.

--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
     "fixtures:agent-traces": "npx tsx scripts/agent-trace-fixtures.ts",
     "compare:endpoints": "npx tsx src/lib/evals/compareEndpoints.ts",
     "prototype:fireworks-gateway": "npx tsx src/lib/evals/fireworksGatewayPrototype.ts",
-    "smoke:fireworks-gateway": "npx tsx scripts/fireworks-gateway-smoke.ts",
-    "fixtures:agent-traces": "npx tsx scripts/agent-trace-fixtures.ts"
+    "smoke:fireworks-gateway": "npx tsx scripts/fireworks-gateway-smoke.ts"
   },
   "dependencies": {
     "@auth/core": "^0.37.4",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "scorecard:demo": "npx tsx src/lib/evals/scorecard.ts",
     "dataset:demo": "npx tsx src/lib/evals/trainingDataset.ts",
     "compare:demo": "npx tsx src/lib/evals/modelComparison.ts",
+    "fixtures:agent-traces": "npx tsx scripts/agent-trace-fixtures.ts",
     "compare:endpoints": "npx tsx src/lib/evals/compareEndpoints.ts",
     "prototype:fireworks-gateway": "npx tsx src/lib/evals/fireworksGatewayPrototype.ts",
     "smoke:fireworks-gateway": "npx tsx scripts/fireworks-gateway-smoke.ts",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "compare:demo": "npx tsx src/lib/evals/modelComparison.ts",
     "compare:endpoints": "npx tsx src/lib/evals/compareEndpoints.ts",
     "prototype:fireworks-gateway": "npx tsx src/lib/evals/fireworksGatewayPrototype.ts",
-    "smoke:fireworks-gateway": "npx tsx scripts/fireworks-gateway-smoke.ts"
+    "smoke:fireworks-gateway": "npx tsx scripts/fireworks-gateway-smoke.ts",
+    "fixtures:agent-traces": "npx tsx scripts/agent-trace-fixtures.ts"
   },
   "dependencies": {
     "@auth/core": "^0.37.4",

--- a/scripts/agent-trace-fixtures.ts
+++ b/scripts/agent-trace-fixtures.ts
@@ -1,0 +1,66 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import {
+  AGENT_TRACE_FIXTURE_DIR,
+  AGENT_TRACE_FIXTURE_FILES,
+  writeAgentTraceFixtures,
+} from "../src/lib/evals/agentTraceFixtures";
+
+function usage(): string {
+  return [
+    "usage: agent-trace-fixtures [--out <dir>]",
+    "",
+    "Writes deterministic synthetic Claude Code, Cloudflare AI Gateway, and OTLP fixtures.",
+    "No network calls; no customer data; no credentials.",
+  ].join("\n");
+}
+
+export function parseArgs(argv: string[]): { outDir: string } {
+  let outDir = join("artifacts", AGENT_TRACE_FIXTURE_DIR);
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--out") {
+      const value = argv[++i];
+      if (!value) throw new Error("--out requires a directory");
+      outDir = value;
+    } else if (arg === "--help" || arg === "-h") {
+      throw new Error(usage());
+    } else {
+      throw new Error(`Unexpected argument: ${arg}`);
+    }
+  }
+  return { outDir };
+}
+
+export async function main(argv: string[]): Promise<number> {
+  let args: { outDir: string };
+  try {
+    args = parseArgs(argv);
+  } catch (err) {
+    process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`);
+    return 2;
+  }
+
+  const manifest = writeAgentTraceFixtures(args.outDir);
+  const fileList = Object.values(AGENT_TRACE_FIXTURE_FILES).map((file) => join(args.outDir, file));
+  const missing = fileList.filter((file) => !existsSync(file));
+  if (missing.length) {
+    process.stderr.write(`agent-trace-fixtures: failed to write ${missing.length} expected file(s).\n`);
+    return 1;
+  }
+
+  process.stdout.write([
+    "Synthetic agent trace fixtures written.",
+    `  output: ${args.outDir}`,
+    `  files:  ${fileList.length}`,
+    `  traces: ${manifest.files.map((file) => `${file.format}=${file.traces}`).join(" ")}`,
+    "  safety: synthetic only; no customer data; no credentials; no network calls",
+    "",
+  ].join("\n"));
+  return 0;
+}
+
+const invokedDirectly =
+  process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (invokedDirectly) main(process.argv.slice(2)).then((code) => process.exit(code));

--- a/src/lib/evals/agentTraceFixtures.test.ts
+++ b/src/lib/evals/agentTraceFixtures.test.ts
@@ -1,0 +1,72 @@
+import { mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, test } from "vitest";
+import { parseClaudeCodeSession } from "../../../convex/lib/claudeCodeTrace";
+import { mapOtlpToTraces } from "../../../convex/lib/otelGenAI";
+import { parseCloudflareAiGatewayJsonl } from "./cloudflareAiGateway";
+import {
+  AGENT_TRACE_FIXTURE_FILES,
+  buildAgentTraceFixtures,
+  stableFixtureSnapshot,
+  writeAgentTraceFixtures,
+} from "./agentTraceFixtures";
+
+const FORBIDDEN = [
+  new RegExp(["Pe", "nnie"].join(""), "i"),
+  new RegExp(["Mi", "go"].join(""), "i"),
+  /sk-[a-z0-9]/i,
+  new RegExp(["pass", "word"].join(""), "i"),
+  new RegExp(["api", "[_-]?", "key"].join(""), "i"),
+  new RegExp(["Bear", "er"].join(""), "i"),
+  new RegExp(["Author", "ization"].join(""), "i"),
+];
+
+describe("agent trace fixtures", () => {
+  test("builds deterministic synthetic fixtures that existing parsers accept", () => {
+    const first = buildAgentTraceFixtures();
+    const second = buildAgentTraceFixtures();
+    expect(second.manifestJson).toBe(first.manifestJson);
+    expect(stableFixtureSnapshot()).toBe(stableFixtureSnapshot());
+
+    const claude = parseClaudeCodeSession(first.claudeCodeJsonl);
+    expect(claude.summary.steps).toBeGreaterThanOrEqual(4);
+    expect(claude.summary.models).toEqual(["gpt-4o-mini"]);
+
+    const gateway = parseCloudflareAiGatewayJsonl(first.cloudflareGatewayJsonl);
+    expect(gateway).toHaveLength(1);
+    expect(gateway[0]?.source).toBe("cloudflare_ai_gateway");
+    expect(gateway[0]?.messages.length).toBe(1);
+
+    const otlp = mapOtlpToTraces(JSON.parse(first.otlpJson));
+    expect(otlp.summary.invalid).toBe(false);
+    expect(otlp.summary.traces).toBe(1);
+    expect(otlp.summary.spans).toBe(1);
+    expect(otlp.summary.steps).toBeGreaterThanOrEqual(2);
+  });
+
+  test("writes all expected files", () => {
+    const outDir = mkdtempSync(join(tmpdir(), "agent-trace-fixtures-"));
+    const manifest = writeAgentTraceFixtures(outDir);
+    for (const file of Object.values(AGENT_TRACE_FIXTURE_FILES)) {
+      expect(readFileSync(join(outDir, file), "utf8").length).toBeGreaterThan(0);
+    }
+    expect(manifest.files.map((file) => file.file).sort()).toEqual([
+      AGENT_TRACE_FIXTURE_FILES.claudeCode,
+      AGENT_TRACE_FIXTURE_FILES.cloudflareGateway,
+      AGENT_TRACE_FIXTURE_FILES.otlp,
+    ].sort());
+  });
+
+  test("fixtures and summaries avoid customer names and credential-like sentinels", () => {
+    const artifacts = buildAgentTraceFixtures();
+    const combined = [
+      artifacts.claudeCodeJsonl,
+      artifacts.cloudflareGatewayJsonl,
+      artifacts.otlpJson,
+      artifacts.manifestJson,
+      artifacts.summaryMarkdown,
+    ].join("\n");
+    for (const pattern of FORBIDDEN) expect(combined).not.toMatch(pattern);
+  });
+});

--- a/src/lib/evals/agentTraceFixtures.ts
+++ b/src/lib/evals/agentTraceFixtures.ts
@@ -1,0 +1,270 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { parseClaudeCodeSession } from "../../../convex/lib/claudeCodeTrace";
+import { mapOtlpToTraces } from "../../../convex/lib/otelGenAI";
+import { parseCloudflareAiGatewayJsonl, stableStringify } from "./cloudflareAiGateway";
+
+export const AGENT_TRACE_FIXTURE_DIR = "agent-trace-fixtures";
+export const AGENT_TRACE_FIXTURE_FILES = {
+  claudeCode: "claude-code-session.jsonl",
+  cloudflareGateway: "cloudflare-gateway.jsonl",
+  otlp: "otlp-genai.json",
+  manifest: "manifest.json",
+  summary: "README.md",
+} as const;
+
+export interface AgentTraceFixtureManifest {
+  generated_at: string;
+  fixture_set: "synthetic-agent-trace-fixtures";
+  safety: {
+    synthetic_only: true;
+    no_customer_data: true;
+    no_credentials: true;
+    no_network_calls: true;
+  };
+  files: Array<{
+    file: string;
+    format: "claude_code_jsonl" | "cloudflare_ai_gateway_jsonl" | "otlp_genai_json";
+    traces: number;
+    spans?: number;
+    steps: number;
+    models: string[];
+  }>;
+}
+
+export interface AgentTraceFixtureArtifacts {
+  claudeCodeJsonl: string;
+  cloudflareGatewayJsonl: string;
+  otlpJson: string;
+  manifest: AgentTraceFixtureManifest;
+  manifestJson: string;
+  summaryMarkdown: string;
+}
+
+const GENERATED_AT = "2026-01-01T00:00:00Z";
+const MODEL = "gpt-4o-mini";
+const SYNTHETIC_PROMPT = "Synthetic support agent dry run: summarize the account status for a test workspace.";
+const SYNTHETIC_RESPONSE = "Synthetic answer: the test workspace is active, no action is required, and no customer data was used.";
+
+function jsonl(rows: unknown[]): string {
+  return rows.map((row) => JSON.stringify(row)).join("\n") + "\n";
+}
+
+export function buildSyntheticClaudeCodeJsonl(): string {
+  const base = {
+    sessionId: "synthetic-session-0001",
+    cwd: "/tmp/blindbench-synthetic-workspace",
+    version: "synthetic-fixture-v1",
+  };
+  return jsonl([
+    {
+      ...base,
+      type: "system",
+      uuid: "system-1",
+      timestamp: GENERATED_AT,
+      subtype: "init",
+      level: "info",
+    },
+    {
+      ...base,
+      type: "user",
+      uuid: "user-1",
+      timestamp: "2026-01-01T00:00:01Z",
+      message: { role: "user", content: SYNTHETIC_PROMPT },
+    },
+    {
+      ...base,
+      type: "assistant",
+      uuid: "assistant-1",
+      timestamp: "2026-01-01T00:00:02Z",
+      message: {
+        id: "msg-synthetic-1",
+        role: "assistant",
+        model: MODEL,
+        usage: { input_tokens: 42, output_tokens: 24 },
+        content: [
+          { type: "text", text: "I will inspect the synthetic workspace status." },
+          { type: "tool_use", id: "toolu-synthetic-1", name: "read_status", input: { workspace: "TEST_WORKSPACE" } },
+        ],
+      },
+    },
+    {
+      ...base,
+      type: "user",
+      uuid: "tool-result-1",
+      timestamp: "2026-01-01T00:00:03Z",
+      message: {
+        role: "user",
+        content: [{ type: "tool_result", tool_use_id: "toolu-synthetic-1", content: "status=active; balance=0" }],
+      },
+      toolUseResult: { status: "active", balance: 0 },
+    },
+    {
+      ...base,
+      type: "assistant",
+      uuid: "assistant-2",
+      timestamp: "2026-01-01T00:00:04Z",
+      message: {
+        id: "msg-synthetic-2",
+        role: "assistant",
+        model: MODEL,
+        usage: { input_tokens: 20, output_tokens: 18 },
+        content: [{ type: "text", text: SYNTHETIC_RESPONSE }],
+      },
+    },
+  ]);
+}
+
+export function buildSyntheticCloudflareGatewayJsonl(): string {
+  return jsonl([
+    {
+      log_id: "log_synthetic_0001",
+      account_id: "acct_TEST_ONLY",
+      gateway_id: "gateway_synthetic",
+      timestamp: GENERATED_AT,
+      provider: "openai",
+      model: MODEL,
+      success: true,
+      status_code: 200,
+      request: {
+        messages: [{ role: "user", content: SYNTHETIC_PROMPT }],
+        model: MODEL,
+      },
+      response: {
+        choices: [{ message: { role: "assistant", content: SYNTHETIC_RESPONSE } }],
+        model: MODEL,
+      },
+      usage: { input_tokens: 42, output_tokens: 24, total_tokens: 66 },
+      metadata: {
+        product: "synthetic-support-agent",
+        module: "dry-run",
+        environment: "synthetic",
+        trace_id: "synthetic-trace-0001",
+      },
+    },
+  ]);
+}
+
+function otlpAttr(key: string, value: string | number) {
+  return {
+    key,
+    value: typeof value === "number" ? { intValue: String(value) } : { stringValue: value },
+  };
+}
+
+export function buildSyntheticOtlpPayload(): Record<string, unknown> {
+  return {
+    resourceSpans: [
+      {
+        resource: { attributes: [otlpAttr("service.name", "synthetic-agent-harness")] },
+        scopeSpans: [
+          {
+            scope: { name: "blindbench.synthetic" },
+            spans: [
+              {
+                traceId: "abcdef0123456789abcdef0123456789",
+                spanId: "0000000000000001",
+                name: "synthetic.chat",
+                startTimeUnixNano: "1704067200000000000",
+                attributes: [
+                  otlpAttr("gen_ai.system", "openai"),
+                  otlpAttr("gen_ai.request.model", MODEL),
+                  otlpAttr("gen_ai.prompt", SYNTHETIC_PROMPT),
+                  otlpAttr("gen_ai.completion", SYNTHETIC_RESPONSE),
+                  otlpAttr("gen_ai.usage.input_tokens", 42),
+                  otlpAttr("gen_ai.usage.output_tokens", 24),
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+}
+
+export function buildAgentTraceFixtures(): AgentTraceFixtureArtifacts {
+  const claudeCodeJsonl = buildSyntheticClaudeCodeJsonl();
+  const cloudflareGatewayJsonl = buildSyntheticCloudflareGatewayJsonl();
+  const otlpPayload = buildSyntheticOtlpPayload();
+  const otlpJson = JSON.stringify(otlpPayload, null, 2) + "\n";
+
+  const claude = parseClaudeCodeSession(claudeCodeJsonl);
+  const gateway = parseCloudflareAiGatewayJsonl(cloudflareGatewayJsonl);
+  const otlp = mapOtlpToTraces(otlpPayload);
+
+  const manifest: AgentTraceFixtureManifest = {
+    generated_at: GENERATED_AT,
+    fixture_set: "synthetic-agent-trace-fixtures",
+    safety: {
+      synthetic_only: true,
+      no_customer_data: true,
+      no_credentials: true,
+      no_network_calls: true,
+    },
+    files: [
+      {
+        file: AGENT_TRACE_FIXTURE_FILES.claudeCode,
+        format: "claude_code_jsonl",
+        traces: 1,
+        steps: claude.summary.steps,
+        models: claude.summary.models,
+      },
+      {
+        file: AGENT_TRACE_FIXTURE_FILES.cloudflareGateway,
+        format: "cloudflare_ai_gateway_jsonl",
+        traces: gateway.length,
+        steps: gateway.reduce((sum, trace) => sum + trace.messages.length + (trace.output_text ? 1 : 0), 0),
+        models: [...new Set(gateway.map((trace) => trace.model).filter((m): m is string => !!m))],
+      },
+      {
+        file: AGENT_TRACE_FIXTURE_FILES.otlp,
+        format: "otlp_genai_json",
+        traces: otlp.summary.traces,
+        spans: otlp.summary.spans,
+        steps: otlp.summary.steps,
+        models: otlp.summary.models,
+      },
+    ],
+  };
+  const manifestJson = JSON.stringify(manifest, null, 2) + "\n";
+  const summaryMarkdown = [
+    "# Synthetic agent trace fixtures",
+    "",
+    "Deterministic, synthetic-only fixtures for local BlindBench dry runs.",
+    "",
+    `Generated at: ${manifest.generated_at}`,
+    "",
+    "| File | Format | Traces | Steps | Models |",
+    "| --- | --- | ---: | ---: | --- |",
+    ...manifest.files.map((file) =>
+      `| \`${file.file}\` | ${file.format} | ${file.traces} | ${file.steps} | ${file.models.join(", ") || "n/a"} |`,
+    ),
+    "",
+    "Safety: synthetic only, no customer data, no credentials, no network calls.",
+    "",
+  ].join("\n");
+
+  return { claudeCodeJsonl, cloudflareGatewayJsonl, otlpJson, manifest, manifestJson, summaryMarkdown };
+}
+
+export function writeAgentTraceFixtures(outDir: string): AgentTraceFixtureManifest {
+  const artifacts = buildAgentTraceFixtures();
+  mkdirSync(outDir, { recursive: true });
+  writeFileSync(join(outDir, AGENT_TRACE_FIXTURE_FILES.claudeCode), artifacts.claudeCodeJsonl);
+  writeFileSync(join(outDir, AGENT_TRACE_FIXTURE_FILES.cloudflareGateway), artifacts.cloudflareGatewayJsonl);
+  writeFileSync(join(outDir, AGENT_TRACE_FIXTURE_FILES.otlp), artifacts.otlpJson);
+  writeFileSync(join(outDir, AGENT_TRACE_FIXTURE_FILES.manifest), artifacts.manifestJson);
+  writeFileSync(join(outDir, AGENT_TRACE_FIXTURE_FILES.summary), artifacts.summaryMarkdown);
+  return artifacts.manifest;
+}
+
+export function stableFixtureSnapshot(): string {
+  const artifacts = buildAgentTraceFixtures();
+  return stableStringify({
+    claudeCodeJsonl: artifacts.claudeCodeJsonl,
+    cloudflareGatewayJsonl: artifacts.cloudflareGatewayJsonl,
+    otlpJson: artifacts.otlpJson,
+    manifest: artifacts.manifest,
+  });
+}


### PR DESCRIPTION
## Summary

Closes #302. Adds a local-only synthetic trace fixture generator for internal/customer-testing dry runs before any operator-owned data is imported.

What changed:
- Added `npm run fixtures:agent-traces -- [--out <dir>]`.
- Generates deterministic artifacts under `artifacts/agent-trace-fixtures/` by default:
  - `claude-code-session.jsonl`
  - `cloudflare-gateway.jsonl`
  - `otlp-genai.json`
  - `manifest.json`
  - `README.md`
- Validates generated fixtures through existing parser/mappers before writing summaries:
  - `parseClaudeCodeSession`
  - `parseCloudflareAiGatewayJsonl`
  - `mapOtlpToTraces`
- Adds focused tests for file generation, parser acceptance, deterministic manifest/snapshot behavior, and customer/credential-like sentinel hygiene.
- Adds runbook docs for using the fixtures with the preflight commands once those PRs land.

## Verification

- `NODE_ENV=development npm ci --include=dev`
  - passed; npm reports existing dependency audit findings
- `npx vitest run src/lib/evals/agentTraceFixtures.test.ts`
  - passed: 1 file, 3 tests
- CLI smoke:
  - `npm run fixtures:agent-traces -- --out /tmp/blindbench-agent-trace-fixtures-smoke`
  - verified all 5 files are written and manifest reports 3 trace-shape entries
- `env -u NODE_ENV npm run test:evals`
  - passed: 15 files, 142 tests
- `npx convex dev --once --typecheck disable && env -u NODE_ENV npm run test:convex`
  - passed: 26 files, 232 tests
  - known non-fatal `convex-test` scheduled-function teardown stderr still appears
- `env -u NODE_ENV npm run build`
  - passed with existing Vite chunk-size warnings
- `git diff --check`
  - passed
- Changed-file safety grep for customer/design-partner names and credential-like markers returned no matches.

## Guardrails

- No customer/design-partner data.
- No real Claude session, Cloudflare Gateway export, or OTLP export.
- No credentials or real account identifiers.
- No network calls.
- No Convex import/mutation.
- No Fireworks/model-provider calls.

## Epic

Part of #287.
