### PR TITLE
Add customer-testing readiness selfcheck

### DIFF
--- a/docs/customer-testing-readiness.md
+++ b/docs/customer-testing-readiness.md
@@ -1,0 +1,85 @@
+# Customer-testing data-boundary readiness
+
+Use this command before importing real operator/customer trace data. It turns the data-boundary approval checklist into a deterministic local report.
+
+```bash
+npm run readiness:customer-testing
+npm run readiness:customer-testing -- --json
+npm run readiness:customer-testing -- --approvals /path/to/customer-testing-approvals.json
+```
+
+Default output artifacts:
+
+```text
+artifacts/customer-testing-readiness/
+├── customer-testing-readiness.md
+└── customer-testing-readiness.json
+```
+
+## Default posture
+
+Without an approvals file, the command exits non-zero and reports:
+
+```text
+blocked_until_approved
+```
+
+This is intentional. Real logs should not be imported until all required gates are explicitly approved in a local JSON file.
+
+## Required gates
+
+The approval file should contain booleans only for these keys:
+
+```json
+{
+  "customer_data_boundary_identified": true,
+  "operator_owns_or_exports_logs": true,
+  "reviewer_scope_approved": true,
+  "retention_deletion_policy_accepted": true,
+  "redaction_classification_path_accepted": true,
+  "training_use_explicitly_approved_or_blocked": true,
+  "shared_demos_marketing_reuse_blocked": true,
+  "credential_handling_confirmed": true,
+  "local_preflight_before_live_import": true
+}
+```
+
+The report deliberately ignores and does not echo free-text notes or additional fields from the approval file.
+
+## Required documents checked
+
+The command also verifies these guardrail documents exist:
+
+- `docs/tenancy-consent-data-isolation.md`
+- `docs/cloudflare-gateway-live-import.md`
+- `docs/native-ingest.md`
+- `docs/training-dataset-compiler.md`
+- `docs/customer-pilot-sow.md`
+
+## Safety contract
+
+The readiness command is local-only:
+
+- no network calls;
+- no Convex import or mutation;
+- no Cloudflare calls;
+- no Fireworks/model-provider calls;
+- no customer trace content required or printed;
+- no authentication material required or printed.
+
+## Operator flow
+
+1. Confirm the customer/legal data boundary and approval posture outside the repo.
+2. Create a local approvals JSON file with every required boolean set to `true` only after approval is real.
+3. Run:
+
+   ```bash
+   npm run readiness:customer-testing -- --approvals /path/to/customer-testing-approvals.json
+   ```
+
+4. Keep the Markdown/JSON report as handoff evidence.
+5. Only then run the relevant local preflight for the operator-owned file before live import.
+
+## Important caveat
+
+`ready_for_customer_testing` means the repo-side checklist is satisfied. It is not evidence that a customer granted consent unless the local approvals file was created from a real external approval record.

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "build:deploy": "node scripts/vercel-build.mjs",
+    "readiness:customer-testing": "npx tsx scripts/customer-testing-readiness.ts",
     "preview": "vite preview",
     "test:evals": "vitest run src/lib/evals/",
     "test:convex": "vitest run --config convex/vitest.config.ts",

--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
     "compare:demo": "npx tsx src/lib/evals/modelComparison.ts",
     "compare:endpoints": "npx tsx src/lib/evals/compareEndpoints.ts",
     "prototype:fireworks-gateway": "npx tsx src/lib/evals/fireworksGatewayPrototype.ts",
-    "smoke:fireworks-gateway": "npx tsx scripts/fireworks-gateway-smoke.ts",
-    "readiness:customer-testing": "npx tsx scripts/customer-testing-readiness.ts"
+    "smoke:fireworks-gateway": "npx tsx scripts/fireworks-gateway-smoke.ts"
   },
   "dependencies": {
     "@auth/core": "^0.37.4",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "compare:demo": "npx tsx src/lib/evals/modelComparison.ts",
     "compare:endpoints": "npx tsx src/lib/evals/compareEndpoints.ts",
     "prototype:fireworks-gateway": "npx tsx src/lib/evals/fireworksGatewayPrototype.ts",
-    "smoke:fireworks-gateway": "npx tsx scripts/fireworks-gateway-smoke.ts"
+    "smoke:fireworks-gateway": "npx tsx scripts/fireworks-gateway-smoke.ts",
+    "readiness:customer-testing": "npx tsx scripts/customer-testing-readiness.ts"
   },
   "dependencies": {
     "@auth/core": "^0.37.4",

--- a/scripts/customer-testing-readiness.ts
+++ b/scripts/customer-testing-readiness.ts
@@ -1,0 +1,79 @@
+import { existsSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+import {
+  buildCustomerTestingReadinessReport,
+  formatCustomerTestingReadinessJson,
+  formatCustomerTestingReadinessMarkdown,
+  readApprovalsFile,
+  writeCustomerTestingReadinessReport,
+} from "../src/lib/evals/customerTestingReadiness";
+
+interface Args {
+  approvalsPath?: string;
+  json: boolean;
+  outDir: string;
+}
+
+function usage(): string {
+  return [
+    "usage: customer-testing-readiness [--approvals <file>] [--out <dir>] [--json]",
+    "",
+    "Local-only readiness gate for real operator/customer trace imports.",
+    "Defaults to blocked until an approvals JSON file sets every required gate to true.",
+  ].join("\n");
+}
+
+export function parseArgs(argv: string[]): Args {
+  const args: Args = { json: false, outDir: "artifacts/customer-testing-readiness" };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--json") args.json = true;
+    else if (arg === "--approvals") {
+      const value = argv[++i];
+      if (!value) throw new Error("--approvals requires a local JSON file");
+      args.approvalsPath = value;
+    } else if (arg === "--out") {
+      const value = argv[++i];
+      if (!value) throw new Error("--out requires a directory");
+      args.outDir = value;
+    } else if (arg === "--help" || arg === "-h") {
+      throw new Error(usage());
+    } else {
+      throw new Error(`Unexpected argument: ${arg}`);
+    }
+  }
+  return args;
+}
+
+export async function main(argv: string[]): Promise<number> {
+  let args: Args;
+  try {
+    args = parseArgs(argv);
+  } catch (err) {
+    process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`);
+    return 2;
+  }
+
+  let approvals;
+  if (args.approvalsPath) {
+    if (!existsSync(args.approvalsPath)) {
+      process.stderr.write("customer-testing-readiness: approvals file not found.\n");
+      return 2;
+    }
+    try {
+      approvals = readApprovalsFile(args.approvalsPath);
+    } catch {
+      process.stderr.write("customer-testing-readiness: approvals file must be valid JSON.\n");
+      return 2;
+    }
+  }
+
+  const report = buildCustomerTestingReadinessReport({ approvals, outDir: args.outDir });
+  writeCustomerTestingReadinessReport(report);
+  process.stdout.write(args.json ? formatCustomerTestingReadinessJson(report) : formatCustomerTestingReadinessMarkdown(report));
+  return report.status === "ready_for_customer_testing" ? 0 : 1;
+}
+
+const invokedDirectly =
+  process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (invokedDirectly) main(process.argv.slice(2)).then((code) => process.exit(code));

--- a/src/lib/evals/customerTestingReadiness.test.ts
+++ b/src/lib/evals/customerTestingReadiness.test.ts
@@ -1,0 +1,59 @@
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, test } from "vitest";
+import {
+  CUSTOMER_TESTING_GATE_DEFINITIONS,
+  buildCustomerTestingReadinessReport,
+  formatCustomerTestingReadinessJson,
+  formatCustomerTestingReadinessMarkdown,
+  readApprovalsFile,
+  writeCustomerTestingReadinessReport,
+  type CustomerTestingApprovals,
+} from "./customerTestingReadiness";
+
+function allApprovals(): CustomerTestingApprovals {
+  return Object.fromEntries(CUSTOMER_TESTING_GATE_DEFINITIONS.map((gate) => [gate.key, true]));
+}
+
+describe("customer testing readiness", () => {
+  test("defaults to blocked without a local approvals file", () => {
+    const report = buildCustomerTestingReadinessReport({ repoRoot: process.cwd() });
+    expect(report.status).toBe("blocked_until_approved");
+    expect(report.counts.docs_present).toBe(report.counts.required_docs);
+    expect(report.counts.gates_approved).toBe(0);
+    expect(report.caveats).toContain("no_local_approvals_file_supplied");
+  });
+
+  test("passes when required docs exist and every gate is approved", () => {
+    const report = buildCustomerTestingReadinessReport({ repoRoot: process.cwd(), approvals: allApprovals() });
+    expect(report.status).toBe("ready_for_customer_testing");
+    expect(report.counts.gates_approved).toBe(report.counts.required_gates);
+    expect(report.caveats).not.toContain("explicit_approvals_missing_or_incomplete");
+  });
+
+  test("blocks incomplete approval files", () => {
+    const approvals = allApprovals();
+    approvals.reviewer_scope_approved = false;
+    const report = buildCustomerTestingReadinessReport({ repoRoot: process.cwd(), approvals });
+    expect(report.status).toBe("blocked_until_approved");
+    expect(report.caveats).toContain("explicit_approvals_missing_or_incomplete");
+  });
+
+  test("reads only boolean gates and does not leak raw approval notes", () => {
+    const dir = mkdtempSync(join(tmpdir(), "customer-testing-readiness-"));
+    const approvalPath = join(dir, "approvals.json");
+    const rawNote = "RAW APPROVAL NOTE SHOULD NOT PRINT";
+    writeFileSync(approvalPath, JSON.stringify({ ...allApprovals(), notes: rawNote }, null, 2));
+    const report = buildCustomerTestingReadinessReport({
+      repoRoot: process.cwd(),
+      approvals: readApprovalsFile(approvalPath),
+      outDir: dir,
+    });
+    writeCustomerTestingReadinessReport(report);
+    const text = formatCustomerTestingReadinessMarkdown(report) + formatCustomerTestingReadinessJson(report);
+    expect(text).not.toContain(rawNote);
+    expect(readFileSync(report.artifact_paths.markdown, "utf8")).toContain("Customer-testing readiness");
+    expect(JSON.parse(readFileSync(report.artifact_paths.json, "utf8")).status).toBe("ready_for_customer_testing");
+  });
+});

--- a/src/lib/evals/customerTestingReadiness.ts
+++ b/src/lib/evals/customerTestingReadiness.ts
@@ -1,0 +1,173 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+export type CustomerTestingReadinessStatus = "ready_for_customer_testing" | "blocked_until_approved";
+
+export interface ApprovalGate {
+  key: string;
+  label: string;
+  required: boolean;
+  approved: boolean;
+}
+
+export interface RequiredDocumentCheck {
+  path: string;
+  present: boolean;
+}
+
+export interface CustomerTestingApprovals {
+  customer_data_boundary_identified?: boolean;
+  operator_owns_or_exports_logs?: boolean;
+  reviewer_scope_approved?: boolean;
+  retention_deletion_policy_accepted?: boolean;
+  redaction_classification_path_accepted?: boolean;
+  training_use_explicitly_approved_or_blocked?: boolean;
+  shared_demos_marketing_reuse_blocked?: boolean;
+  credential_handling_confirmed?: boolean;
+  local_preflight_before_live_import?: boolean;
+}
+
+export interface CustomerTestingReadinessReport {
+  generated_at: string;
+  status: CustomerTestingReadinessStatus;
+  required_docs: RequiredDocumentCheck[];
+  gates: ApprovalGate[];
+  counts: {
+    required_docs: number;
+    docs_present: number;
+    required_gates: number;
+    gates_approved: number;
+  };
+  caveats: string[];
+  artifact_paths: {
+    markdown: string;
+    json: string;
+  };
+}
+
+const GENERATED_AT = "2026-01-01T00:00:00Z";
+
+export const REQUIRED_CUSTOMER_TESTING_DOCS = [
+  "docs/tenancy-consent-data-isolation.md",
+  "docs/cloudflare-gateway-live-import.md",
+  "docs/native-ingest.md",
+  "docs/training-dataset-compiler.md",
+  "docs/customer-pilot-sow.md",
+] as const;
+
+export const CUSTOMER_TESTING_GATE_DEFINITIONS: Array<{ key: keyof CustomerTestingApprovals; label: string }> = [
+  { key: "customer_data_boundary_identified", label: "Customer/legal data boundary identified" },
+  { key: "operator_owns_or_exports_logs", label: "Operator owns or exports the logs" },
+  { key: "reviewer_scope_approved", label: "Reviewer scope approved" },
+  { key: "retention_deletion_policy_accepted", label: "Retention/deletion policy accepted" },
+  { key: "redaction_classification_path_accepted", label: "Redaction/classification path accepted" },
+  { key: "training_use_explicitly_approved_or_blocked", label: "Training/fine-tuning use explicitly approved or blocked" },
+  { key: "shared_demos_marketing_reuse_blocked", label: "Shared demos/marketing/reusable datasets blocked unless separately approved" },
+  { key: "credential_handling_confirmed", label: "Credential handling path confirmed" },
+  { key: "local_preflight_before_live_import", label: "Local preflight required before live import" },
+];
+
+export function readApprovalsFile(path: string): CustomerTestingApprovals {
+  const text = readFileSync(path, "utf8");
+  const parsed = JSON.parse(text) as Record<string, unknown>;
+  const approvals: CustomerTestingApprovals = {};
+  for (const { key } of CUSTOMER_TESTING_GATE_DEFINITIONS) {
+    approvals[key] = parsed[key] === true;
+  }
+  return approvals;
+}
+
+export function buildCustomerTestingReadinessReport(options: {
+  repoRoot?: string;
+  approvals?: CustomerTestingApprovals;
+  outDir?: string;
+  generatedAt?: string;
+} = {}): CustomerTestingReadinessReport {
+  const repoRoot = options.repoRoot ?? process.cwd();
+  const outDir = options.outDir ?? join("artifacts", "customer-testing-readiness");
+  const requiredDocs = REQUIRED_CUSTOMER_TESTING_DOCS.map((path) => ({
+    path,
+    present: existsSync(join(repoRoot, path)),
+  }));
+  const gates = CUSTOMER_TESTING_GATE_DEFINITIONS.map(({ key, label }) => ({
+    key,
+    label,
+    required: true,
+    approved: options.approvals?.[key] === true,
+  }));
+  const docsPresent = requiredDocs.filter((doc) => doc.present).length;
+  const gatesApproved = gates.filter((gate) => gate.approved).length;
+  const caveats: string[] = [];
+  if (docsPresent !== requiredDocs.length) caveats.push("required_docs_missing");
+  if (gatesApproved !== gates.length) caveats.push("explicit_approvals_missing_or_incomplete");
+  if (options.approvals === undefined) caveats.push("no_local_approvals_file_supplied");
+  caveats.push("do_not_import_customer_or_operator_logs_until_status_is_ready");
+
+  const status: CustomerTestingReadinessStatus =
+    docsPresent === requiredDocs.length && gatesApproved === gates.length
+      ? "ready_for_customer_testing"
+      : "blocked_until_approved";
+
+  return {
+    generated_at: options.generatedAt ?? GENERATED_AT,
+    status,
+    required_docs: requiredDocs,
+    gates,
+    counts: {
+      required_docs: requiredDocs.length,
+      docs_present: docsPresent,
+      required_gates: gates.length,
+      gates_approved: gatesApproved,
+    },
+    caveats,
+    artifact_paths: {
+      markdown: join(outDir, "customer-testing-readiness.md"),
+      json: join(outDir, "customer-testing-readiness.json"),
+    },
+  };
+}
+
+export function formatCustomerTestingReadinessJson(report: CustomerTestingReadinessReport): string {
+  return JSON.stringify(report, null, 2) + "\n";
+}
+
+export function formatCustomerTestingReadinessMarkdown(report: CustomerTestingReadinessReport): string {
+  const lines = [
+    `# Customer-testing readiness — ${report.status === "ready_for_customer_testing" ? "READY" : "BLOCKED"}`,
+    "",
+    `Generated at: ${report.generated_at}`,
+    "",
+    "## Summary",
+    "",
+    `- Status: \`${report.status}\``,
+    `- Required docs present: ${report.counts.docs_present}/${report.counts.required_docs}`,
+    `- Approval gates complete: ${report.counts.gates_approved}/${report.counts.required_gates}`,
+    "",
+    "## Required documents",
+    "",
+    "| Document | Present |",
+    "| --- | --- |",
+    ...report.required_docs.map((doc) => `| \`${doc.path}\` | ${doc.present ? "yes" : "no"} |`),
+    "",
+    "## Approval gates",
+    "",
+    "| Gate | Approved |",
+    "| --- | --- |",
+    ...report.gates.map((gate) => `| ${gate.label} | ${gate.approved ? "yes" : "no"} |`),
+    "",
+    "## Caveats",
+    "",
+    ...report.caveats.map((caveat) => `- \`${caveat}\``),
+    "",
+    "This report intentionally omits customer trace content, approval notes, credential values, and raw logs.",
+    "",
+  ];
+  return lines.join("\n");
+}
+
+export function writeCustomerTestingReadinessReport(report: CustomerTestingReadinessReport): void {
+  const outDir = dirname(report.artifact_paths.markdown);
+  mkdirSync(outDir, { recursive: true });
+  writeFileSync(report.artifact_paths.markdown, formatCustomerTestingReadinessMarkdown(report));
+  writeFileSync(report.artifact_paths.json, formatCustomerTestingReadinessJson(report));
+}


### PR DESCRIPTION
## Summary

Closes #304. Adds a local-only customer-testing data-boundary readiness selfcheck before any real operator/customer trace import.

What changed:
- Added `npm run readiness:customer-testing -- [--approvals <file>] [--out <dir>] [--json]`.
- Writes management-safe reports under `artifacts/customer-testing-readiness/` by default:
  - `customer-testing-readiness.md`
  - `customer-testing-readiness.json`
- Verifies required guardrail docs exist:
  - `docs/tenancy-consent-data-isolation.md`
  - `docs/cloudflare-gateway-live-import.md`
  - `docs/native-ingest.md`
  - `docs/training-dataset-compiler.md`
  - `docs/customer-pilot-sow.md`
- Encodes required real-data cutover gates as machine-readable booleans.
- Defaults to `blocked_until_approved` unless a local approvals JSON file sets every required gate to `true`.
- Ignores and does not echo free-text approval notes or extra approval-file fields.
- Added runbook docs and focused tests.

## Verification

- `NODE_ENV=development npm ci --include=dev`
  - passed; npm reports existing dependency audit findings
- `npx vitest run src/lib/evals/customerTestingReadiness.test.ts`
  - passed: 1 file, 4 tests
- CLI smoke:
  - missing approvals exits non-zero and reports `blocked_until_approved`
  - complete approvals file exits zero and reports `ready_for_customer_testing`
  - report artifacts written under `/tmp/customer-testing-readiness-smoke`
  - raw approval note sentinel did not appear in text/JSON artifacts
- `env -u NODE_ENV npm run test:evals`
  - passed: 15 files, 143 tests
- `npx convex dev --once --typecheck disable && env -u NODE_ENV npm run test:convex`
  - passed: 26 files, 232 tests
  - known non-fatal `convex-test` scheduled-function teardown stderr still appears
- `env -u NODE_ENV npm run build`
  - passed with existing Vite chunk-size warnings
- `git diff --check`
  - passed
- Changed-file safety grep for customer/design-partner names and credential-like markers returned no matches.

## Guardrails

- No network calls.
- No Convex import or mutation.
- No Cloudflare calls.
- No Fireworks/model-provider calls.
- No customer/design-partner data.
- No credential values or raw logs.
- Readiness output is safe labels/counts/status/caveats only.

## Epic

Part of #287.
