### PR TITLE
Add customer-test launch packet generator

### DIFF
--- a/docs/customer-test-launch-packet.md
+++ b/docs/customer-test-launch-packet.md
@@ -1,0 +1,71 @@
+# Customer-test launch packet
+
+Use this command to generate a single local handoff packet before the first customer testing session.
+
+```bash
+npm run launch:customer-test-packet
+npm run launch:customer-test-packet -- --customer-label customer-test-01
+npm run launch:customer-test-packet -- --customer-label customer-test-01 --json
+```
+
+Default artifacts:
+
+```text
+artifacts/customer-test-launch-packet/
+├── customer-test-launch-packet.md
+└── customer-test-launch-packet.json
+```
+
+## What the packet includes
+
+The packet is generated from existing repo runbooks and docs. It includes:
+
+- source docs checked;
+- launch objective;
+- first-session agenda;
+- data-boundary commitments;
+- operator/customer prerequisites;
+- runbook links;
+- go/no-go checklist;
+- post-session follow-up checklist;
+- caveats about approvals and local preflight.
+
+## Source docs checked
+
+- `docs/customer-pilot-sow.md`
+- `docs/customer-ai-quality-scorecard-handoff.md`
+- `docs/tenancy-consent-data-isolation.md`
+- `docs/cloudflare-gateway-live-import.md`
+- `docs/native-ingest.md`
+- `docs/training-dataset-compiler.md`
+- `docs/gateway-onboarding.md`
+
+If any required source doc is missing, the packet reports `blocked_missing_sources` and exits non-zero.
+
+## Customer label
+
+`--customer-label` is sanitized, capped, and used only as a local packet label.
+
+It is **not** approval evidence. Do not use a label to imply consent, vendor approval, or permission to import real logs.
+
+## Safety contract
+
+This command is local-only:
+
+- no network calls;
+- no Convex import or mutation;
+- no Cloudflare calls;
+- no Fireworks/model-provider calls;
+- no customer trace content required or printed;
+- no credentials required or printed.
+
+The packet deliberately does not create or fake any approval record.
+
+## Recommended operator flow
+
+1. Run the packet generator with a neutral label.
+2. Review the packet with the operator/customer team.
+3. Confirm the legal/customer data boundary, reviewer scope, retention/deletion posture, and training-use posture outside committed source control.
+4. Run local preflight on only approved operator-owned trace files.
+5. Import only approved/redacted data into the scoped customer workspace.
+6. Record imported counts, redaction caveats, review outcomes, and follow-up blockers.

--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
     "compare:demo": "npx tsx src/lib/evals/modelComparison.ts",
     "compare:endpoints": "npx tsx src/lib/evals/compareEndpoints.ts",
     "prototype:fireworks-gateway": "npx tsx src/lib/evals/fireworksGatewayPrototype.ts",
-    "smoke:fireworks-gateway": "npx tsx scripts/fireworks-gateway-smoke.ts",
-    "launch:customer-test-packet": "npx tsx scripts/customer-test-launch-packet.ts"
+    "smoke:fireworks-gateway": "npx tsx scripts/fireworks-gateway-smoke.ts"
   },
   "dependencies": {
     "@auth/core": "^0.37.4",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
+    "launch:customer-test-packet": "npx tsx scripts/customer-test-launch-packet.ts",
     "build:deploy": "node scripts/vercel-build.mjs",
     "preview": "vite preview",
     "test:evals": "vitest run src/lib/evals/",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "compare:demo": "npx tsx src/lib/evals/modelComparison.ts",
     "compare:endpoints": "npx tsx src/lib/evals/compareEndpoints.ts",
     "prototype:fireworks-gateway": "npx tsx src/lib/evals/fireworksGatewayPrototype.ts",
-    "smoke:fireworks-gateway": "npx tsx scripts/fireworks-gateway-smoke.ts"
+    "smoke:fireworks-gateway": "npx tsx scripts/fireworks-gateway-smoke.ts",
+    "launch:customer-test-packet": "npx tsx scripts/customer-test-launch-packet.ts"
   },
   "dependencies": {
     "@auth/core": "^0.37.4",

--- a/scripts/customer-test-launch-packet.ts
+++ b/scripts/customer-test-launch-packet.ts
@@ -1,0 +1,64 @@
+import { pathToFileURL } from "node:url";
+import {
+  buildCustomerTestLaunchPacket,
+  formatCustomerTestLaunchPacketJson,
+  formatCustomerTestLaunchPacketMarkdown,
+  writeCustomerTestLaunchPacket,
+} from "../src/lib/evals/customerTestLaunchPacket";
+
+interface Args {
+  customerLabel?: string;
+  outDir: string;
+  json: boolean;
+}
+
+function usage(): string {
+  return [
+    "usage: customer-test-launch-packet [--customer-label <safe-label>] [--out <dir>] [--json]",
+    "",
+    "Local-only launch packet generator for customer testing handoff review.",
+  ].join("\n");
+}
+
+export function parseArgs(argv: string[]): Args {
+  const args: Args = { outDir: "artifacts/customer-test-launch-packet", json: false };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--json") args.json = true;
+    else if (arg === "--customer-label") {
+      const value = argv[++i];
+      if (!value) throw new Error("--customer-label requires a value");
+      args.customerLabel = value;
+    } else if (arg === "--out") {
+      const value = argv[++i];
+      if (!value) throw new Error("--out requires a directory");
+      args.outDir = value;
+    } else if (arg === "--help" || arg === "-h") {
+      throw new Error(usage());
+    } else {
+      throw new Error(`Unexpected argument: ${arg}`);
+    }
+  }
+  return args;
+}
+
+export async function main(argv: string[]): Promise<number> {
+  let args: Args;
+  try {
+    args = parseArgs(argv);
+  } catch (err) {
+    process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`);
+    return 2;
+  }
+  const packet = buildCustomerTestLaunchPacket({
+    outDir: args.outDir,
+    customerLabel: args.customerLabel,
+  });
+  writeCustomerTestLaunchPacket(packet);
+  process.stdout.write(args.json ? formatCustomerTestLaunchPacketJson(packet) : formatCustomerTestLaunchPacketMarkdown(packet));
+  return packet.status === "ready_to_review" ? 0 : 1;
+}
+
+const invokedDirectly =
+  process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (invokedDirectly) main(process.argv.slice(2)).then((code) => process.exit(code));

--- a/src/lib/evals/customerTestLaunchPacket.test.ts
+++ b/src/lib/evals/customerTestLaunchPacket.test.ts
@@ -1,0 +1,52 @@
+import { mkdirSync, mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, test } from "vitest";
+import {
+  CUSTOMER_TEST_LAUNCH_SOURCE_DOCS,
+  buildCustomerTestLaunchPacket,
+  formatCustomerTestLaunchPacketJson,
+  formatCustomerTestLaunchPacketMarkdown,
+  sanitizeCustomerTestLabel,
+  writeCustomerTestLaunchPacket,
+} from "./customerTestLaunchPacket";
+
+describe("customer test launch packet", () => {
+  test("builds a review-ready packet from existing source docs", () => {
+    const packet = buildCustomerTestLaunchPacket({ repoRoot: process.cwd(), customerLabel: "Customer Test 01" });
+    expect(packet.status).toBe("ready_to_review");
+    expect(packet.customer_label).toBe("customer-test-01");
+    expect(packet.customer_label_is_approval_evidence).toBe(false);
+    expect(packet.counts.source_docs_present).toBe(CUSTOMER_TEST_LAUNCH_SOURCE_DOCS.length);
+    expect(packet.go_no_go_checklist.some((item) => item.requiredBeforeLiveLogs)).toBe(true);
+  });
+
+  test("detects missing source docs", () => {
+    const dir = mkdtempSync(join(tmpdir(), "launch-packet-empty-"));
+    mkdirSync(join(dir, "docs"));
+    const packet = buildCustomerTestLaunchPacket({ repoRoot: dir });
+    expect(packet.status).toBe("blocked_missing_sources");
+    expect(packet.counts.source_docs_present).toBe(0);
+    expect(packet.caveats).toContain("One or more required source documents are missing.");
+  });
+
+  test("sanitizes and caps the customer label", () => {
+    expect(sanitizeCustomerTestLabel("  ACME Pilot!! East Region  ")).toBe("acme-pilot-east-region");
+    expect(sanitizeCustomerTestLabel("!!!")).toBe("customer-test");
+    expect(sanitizeCustomerTestLabel("a".repeat(80))).toHaveLength(48);
+  });
+
+  test("writes safe artifacts without leaking unsafe raw label text", () => {
+    const dir = mkdtempSync(join(tmpdir(), "launch-packet-"));
+    const unsafe = "Raw Secret Customer Name<script>alert(1)</script>";
+    const packet = buildCustomerTestLaunchPacket({ repoRoot: process.cwd(), outDir: dir, customerLabel: unsafe });
+    writeCustomerTestLaunchPacket(packet);
+    const markdown = readFileSync(packet.artifact_paths.markdown, "utf8");
+    const json = readFileSync(packet.artifact_paths.json, "utf8");
+    const formatted = formatCustomerTestLaunchPacketMarkdown(packet) + formatCustomerTestLaunchPacketJson(packet);
+    expect(markdown).toContain("Customer-test launch packet");
+    expect(JSON.parse(json).customer_label).toBe("raw-secret-customer-name-script-alert-1-script");
+    expect(formatted).not.toContain(unsafe);
+    expect(formatted).not.toContain("<script>");
+  });
+});

--- a/src/lib/evals/customerTestLaunchPacket.ts
+++ b/src/lib/evals/customerTestLaunchPacket.ts
@@ -1,0 +1,214 @@
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+export type CustomerTestLaunchPacketStatus = "ready_to_review" | "blocked_missing_sources";
+
+export interface LaunchPacketSourceDoc {
+  path: string;
+  present: boolean;
+  purpose: string;
+}
+
+export interface LaunchPacketChecklistItem {
+  id: string;
+  label: string;
+  requiredBeforeLiveLogs: boolean;
+}
+
+export interface CustomerTestLaunchPacket {
+  generated_at: string;
+  status: CustomerTestLaunchPacketStatus;
+  customer_label: string;
+  customer_label_is_approval_evidence: false;
+  source_docs: LaunchPacketSourceDoc[];
+  counts: {
+    source_docs: number;
+    source_docs_present: number;
+    go_no_go_items: number;
+    prerequisites: number;
+  };
+  launch_objective: string;
+  first_session_agenda: string[];
+  data_boundary_commitments: string[];
+  operator_customer_prerequisites: string[];
+  runbook_links: string[];
+  go_no_go_checklist: LaunchPacketChecklistItem[];
+  post_session_follow_up: string[];
+  caveats: string[];
+  artifact_paths: {
+    markdown: string;
+    json: string;
+  };
+}
+
+const GENERATED_AT = "2026-01-01T00:00:00Z";
+const DEFAULT_OUT_DIR = join("artifacts", "customer-test-launch-packet");
+
+export const CUSTOMER_TEST_LAUNCH_SOURCE_DOCS: Array<{ path: string; purpose: string }> = [
+  { path: "docs/customer-pilot-sow.md", purpose: "Pilot scope, deliverables, and success criteria" },
+  { path: "docs/customer-ai-quality-scorecard-handoff.md", purpose: "Customer-facing scorecard and payment handoff" },
+  { path: "docs/tenancy-consent-data-isolation.md", purpose: "Consent, tenancy, retention, and training-use boundary" },
+  { path: "docs/cloudflare-gateway-live-import.md", purpose: "Cloudflare AI Gateway customer-export import path" },
+  { path: "docs/native-ingest.md", purpose: "Native eval-record ingest and redaction boundary" },
+  { path: "docs/training-dataset-compiler.md", purpose: "Training export guardrails and approval gate" },
+  { path: "docs/gateway-onboarding.md", purpose: "Operator onboarding checklist and metadata conventions" },
+];
+
+export function sanitizeCustomerTestLabel(input?: string): string {
+  const raw = (input ?? "customer-test").toLowerCase();
+  const cleaned = raw
+    .replace(/[^a-z0-9_-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 48);
+  return cleaned || "customer-test";
+}
+
+export function buildCustomerTestLaunchPacket(options: {
+  repoRoot?: string;
+  outDir?: string;
+  customerLabel?: string;
+  generatedAt?: string;
+} = {}): CustomerTestLaunchPacket {
+  const repoRoot = options.repoRoot ?? process.cwd();
+  const outDir = options.outDir ?? DEFAULT_OUT_DIR;
+  const sourceDocs = CUSTOMER_TEST_LAUNCH_SOURCE_DOCS.map((doc) => ({
+    ...doc,
+    present: existsSync(join(repoRoot, doc.path)),
+  }));
+  const presentCount = sourceDocs.filter((doc) => doc.present).length;
+  const status: CustomerTestLaunchPacketStatus =
+    presentCount === sourceDocs.length ? "ready_to_review" : "blocked_missing_sources";
+  const customerLabel = sanitizeCustomerTestLabel(options.customerLabel);
+
+  const goNoGoChecklist: LaunchPacketChecklistItem[] = [
+    { id: "scope-confirmed", label: "Pilot scope and success questions confirmed", requiredBeforeLiveLogs: false },
+    { id: "data-boundary-approved", label: "Customer/legal data boundary and approval record confirmed", requiredBeforeLiveLogs: true },
+    { id: "operator-export", label: "Operator-owned export path confirmed for logs/files", requiredBeforeLiveLogs: true },
+    { id: "reviewer-scope", label: "Reviewer access scope and workspace membership approved", requiredBeforeLiveLogs: true },
+    { id: "retention", label: "Retention/deletion policy accepted", requiredBeforeLiveLogs: true },
+    { id: "preflight", label: "Local trace preflight planned before import", requiredBeforeLiveLogs: true },
+    { id: "training-use", label: "Training/fine-tuning use explicitly approved or blocked", requiredBeforeLiveLogs: true },
+    { id: "payment", label: "Manual invoice or package/payment handoff path chosen", requiredBeforeLiveLogs: false },
+  ];
+  const prerequisites = [
+    "Customer workspace and legal data boundary identified.",
+    "Customer/operator can export a small representative trace sample they are allowed to share.",
+    "Reviewer list and roles are approved before any live review session.",
+    "Retention/deletion and training-use posture are agreed before importing real logs.",
+    "Local preflight is run before any live import/upload.",
+  ];
+
+  return {
+    generated_at: options.generatedAt ?? GENERATED_AT,
+    status,
+    customer_label: customerLabel,
+    customer_label_is_approval_evidence: false,
+    source_docs: sourceDocs,
+    counts: {
+      source_docs: sourceDocs.length,
+      source_docs_present: presentCount,
+      go_no_go_items: goNoGoChecklist.length,
+      prerequisites: prerequisites.length,
+    },
+    launch_objective:
+      "Run a controlled first customer-test session that proves Blind Bench can turn approved operator-owned traces into scoped evaluation/review/training handoff artifacts without crossing the data boundary.",
+    first_session_agenda: [
+      "Confirm scope, success questions, data boundary, and reviewer roles.",
+      "Review metadata conventions and the selected ingest/import path.",
+      "Run synthetic/demo artifacts first to calibrate the review loop.",
+      "If approvals are complete, run local preflight on a small operator-owned trace export.",
+      "Import only approved/redacted data into the customer workspace and create the first review/eval handoff.",
+      "Close with go/no-go notes, blockers, and post-session follow-ups.",
+    ],
+    data_boundary_commitments: [
+      "Customer data stays scoped to the customer workspace/legal boundary.",
+      "No customer logs seed shared demos, marketing, reusable packs, or shared model training without separate written approval.",
+      "Training/fine-tuning exports require explicit approval and classification.",
+      "Credential values, raw logs, prompts, and completions are not included in this launch packet.",
+      "Synthetic/demo data remains the default until approval gates are complete.",
+    ],
+    operator_customer_prerequisites: prerequisites,
+    runbook_links: sourceDocs.map((doc) => doc.path),
+    go_no_go_checklist: goNoGoChecklist,
+    post_session_follow_up: [
+      "Save the generated packet and any approval evidence outside committed source control.",
+      "Record imported counts, dedupe counts, invalid-line counts, and redaction caveats in the customer workspace notes.",
+      "List review outcomes and any scorer/config changes needed before broader rollout.",
+      "Confirm whether training export remains blocked or has explicit approved next steps.",
+      "Turn remaining blockers into GitHub issues or customer-specific private tasks.",
+    ],
+    caveats: [
+      "This packet is not an approval record.",
+      "A sanitized customer label is an operator convenience only; it is not evidence of consent.",
+      "Do not import live customer/operator logs until approval and local preflight steps are complete.",
+      ...(status === "blocked_missing_sources" ? ["One or more required source documents are missing."] : []),
+    ],
+    artifact_paths: {
+      markdown: join(outDir, "customer-test-launch-packet.md"),
+      json: join(outDir, "customer-test-launch-packet.json"),
+    },
+  };
+}
+
+export function formatCustomerTestLaunchPacketJson(packet: CustomerTestLaunchPacket): string {
+  return JSON.stringify(packet, null, 2) + "\n";
+}
+
+export function formatCustomerTestLaunchPacketMarkdown(packet: CustomerTestLaunchPacket): string {
+  const lines = [
+    `# Customer-test launch packet — ${packet.customer_label}`,
+    "",
+    `Generated at: ${packet.generated_at}`,
+    `Status: \`${packet.status}\``,
+    "",
+    "## Objective",
+    "",
+    packet.launch_objective,
+    "",
+    "## Source docs checked",
+    "",
+    "| Document | Present | Purpose |",
+    "| --- | --- | --- |",
+    ...packet.source_docs.map((doc) => `| \`${doc.path}\` | ${doc.present ? "yes" : "no"} | ${doc.purpose} |`),
+    "",
+    "## First-session agenda",
+    "",
+    ...packet.first_session_agenda.map((item, index) => `${index + 1}. ${item}`),
+    "",
+    "## Data-boundary commitments",
+    "",
+    ...packet.data_boundary_commitments.map((item) => `- ${item}`),
+    "",
+    "## Operator/customer prerequisites",
+    "",
+    ...packet.operator_customer_prerequisites.map((item) => `- ${item}`),
+    "",
+    "## Go/no-go checklist",
+    "",
+    "| Item | Required before live logs |",
+    "| --- | --- |",
+    ...packet.go_no_go_checklist.map(
+      (item) => `| ${item.label} | ${item.requiredBeforeLiveLogs ? "yes" : "no"} |`,
+    ),
+    "",
+    "## Runbook links",
+    "",
+    ...packet.runbook_links.map((link) => `- \`${link}\``),
+    "",
+    "## Post-session follow-up",
+    "",
+    ...packet.post_session_follow_up.map((item) => `- ${item}`),
+    "",
+    "## Caveats",
+    "",
+    ...packet.caveats.map((item) => `- ${item}`),
+    "",
+  ];
+  return lines.join("\n");
+}
+
+export function writeCustomerTestLaunchPacket(packet: CustomerTestLaunchPacket): void {
+  mkdirSync(dirname(packet.artifact_paths.markdown), { recursive: true });
+  writeFileSync(packet.artifact_paths.markdown, formatCustomerTestLaunchPacketMarkdown(packet));
+  writeFileSync(packet.artifact_paths.json, formatCustomerTestLaunchPacketJson(packet));
+}


### PR DESCRIPTION
## Summary

Closes #306. Adds a local-only customer-test launch packet generator so operators have one reviewable Markdown/JSON handoff before a first customer testing session.

What changed:
- Added `npm run launch:customer-test-packet -- [--customer-label <safe-label>] [--out <dir>] [--json]`.
- Writes launch packet artifacts under `artifacts/customer-test-launch-packet/` by default:
  - `customer-test-launch-packet.md`
  - `customer-test-launch-packet.json`
- Checks existing source docs on `origin/main`:
  - `docs/customer-pilot-sow.md`
  - `docs/customer-ai-quality-scorecard-handoff.md`
  - `docs/tenancy-consent-data-isolation.md`
  - `docs/cloudflare-gateway-live-import.md`
  - `docs/native-ingest.md`
  - `docs/training-dataset-compiler.md`
  - `docs/gateway-onboarding.md`
- Includes safe operational sections: objective, first-session agenda, data-boundary commitments, prerequisites, runbook links, go/no-go checklist, post-session follow-up, and caveats.
- Sanitizes/caps the optional customer label and explicitly states it is not approval evidence.
- Added runbook docs and focused tests.

## Verification

- `NODE_ENV=development npm ci --include=dev`
  - passed; npm reports existing dependency audit findings
- `npx vitest run src/lib/evals/customerTestLaunchPacket.test.ts`
  - passed: 1 file, 4 tests
- CLI smoke:
  - `npm run --silent launch:customer-test-packet -- --customer-label 'Raw Secret Customer<script>' --out /tmp/customer-test-launch-packet-smoke`
  - `npm run --silent launch:customer-test-packet -- --customer-label 'Customer Test 02' --out /tmp/customer-test-launch-packet-smoke --json`
  - passed: packet status `ready_to_review`, docs `7/7`, sanitized label `customer-test-02`, and raw `<script>` sentinel did not appear in artifacts/stdout
- `env -u NODE_ENV npm run test:evals`
  - passed: 15 files, 143 tests
- `npx convex dev --once --typecheck disable && env -u NODE_ENV npm run test:convex`
  - passed: 26 files, 232 tests
  - known non-fatal `convex-test` scheduled-function teardown stderr still appears
- `env -u NODE_ENV npm run build`
  - passed with existing Vite chunk-size warnings
- `git diff --check`
  - passed
- Changed-file safety grep for customer/design-partner names and credential-like markers returned no matches.

## Guardrails

- No network calls.
- No Convex import or mutation.
- No Cloudflare calls.
- No Fireworks/model-provider calls.
- No customer/design-partner data.
- No credential values or raw logs.
- Does not create or fake approval records.
- Customer label is treated as operator convenience only, not evidence of consent.

## Epic

Part of #287.
