### PR TITLE
Add EvaluationRow compatibility export

### DIFF
--- a/docs/evaluation-row-export.md
+++ b/docs/evaluation-row-export.md
@@ -1,0 +1,64 @@
+# EvaluationRow compatibility export
+
+Blind Bench does **not** adopt Eval Protocol, the Python SDK, Fireworks-hosted tracing, or Fireworks proxy credentials. This export is only a local compatibility hedge for a future customer who explicitly wants Blind Bench review/training rows serialized into an EvaluationRow-style JSONL shape.
+
+## Command
+
+```bash
+npm run export:evaluation-rows
+npm run export:evaluation-rows -- --json
+npm run export:evaluation-rows -- --out /tmp/evaluation-row-export
+npm run export:evaluation-rows -- --generated-at 2026-01-01T00:00:00Z
+```
+
+Default output:
+
+```text
+artifacts/evaluation-row-export/
+├── evaluation-rows.jsonl
+├── evaluation-rows.manifest.json
+└── evaluation-rows.report.md
+```
+
+## What it writes
+
+`evaluation-rows.jsonl` contains one JSON object per line with the EvaluationRow-style fields:
+
+- `messages`
+- `tools`
+- `input_metadata`
+- `rollout_status`
+- `ground_truth`
+- `evaluation_result`
+- `execution_metadata`
+- `created_at`
+- `eval_metadata`
+
+The manifest/report contain only management-safe summary fields:
+
+- format/schema family
+- generated timestamp
+- dataset name
+- row count
+- split counts
+- row hashes
+- dataset hash
+- caveats
+
+The console output intentionally omits raw prompts, completions, tool arguments, and row JSON.
+
+## Data boundary
+
+The default command compiles from Blind Bench's synthetic demo training rows only. Real operator/customer rows must pass the existing Blind Bench data-boundary controls before serialization:
+
+1. consent and tenancy boundary approved;
+2. privacy classification set honestly;
+3. training export approval granted;
+4. forbidden-substring / leak guards applied where relevant;
+5. local artifact verification completed before handoff.
+
+Do not use this command as approval evidence. It is a serializer/reporting tool, not a policy decision engine.
+
+## Why this exists
+
+Issue #275 concluded that Blind Bench should not adopt Eval Protocol as a runtime dependency because it does not match the BYOK/no-vendor-creds and TypeScript-first architecture. The useful hedge is a small serializer: Blind Bench can manufacture human judgment and later serialize it for a customer-owned Fireworks RFT/Eval Protocol pipeline if explicitly requested.

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "tsc -b && vite build",
     "build:deploy": "node scripts/vercel-build.mjs",
     "preview": "vite preview",
+    "export:evaluation-rows": "npx tsx scripts/evaluation-row-export.ts",
     "test:evals": "vitest run src/lib/evals/",
     "test:convex": "vitest run --config convex/vitest.config.ts",
     "test:ct": "playwright test -c playwright-ct.config.ts",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "compare:demo": "npx tsx src/lib/evals/modelComparison.ts",
     "compare:endpoints": "npx tsx src/lib/evals/compareEndpoints.ts",
     "prototype:fireworks-gateway": "npx tsx src/lib/evals/fireworksGatewayPrototype.ts",
-    "smoke:fireworks-gateway": "npx tsx scripts/fireworks-gateway-smoke.ts"
+    "smoke:fireworks-gateway": "npx tsx scripts/fireworks-gateway-smoke.ts",
+    "export:evaluation-rows": "npx tsx scripts/evaluation-row-export.ts"
   },
   "dependencies": {
     "@auth/core": "^0.37.4",

--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
     "compare:demo": "npx tsx src/lib/evals/modelComparison.ts",
     "compare:endpoints": "npx tsx src/lib/evals/compareEndpoints.ts",
     "prototype:fireworks-gateway": "npx tsx src/lib/evals/fireworksGatewayPrototype.ts",
-    "smoke:fireworks-gateway": "npx tsx scripts/fireworks-gateway-smoke.ts",
-    "export:evaluation-rows": "npx tsx scripts/evaluation-row-export.ts"
+    "smoke:fireworks-gateway": "npx tsx scripts/fireworks-gateway-smoke.ts"
   },
   "dependencies": {
     "@auth/core": "^0.37.4",

--- a/scripts/evaluation-row-export.ts
+++ b/scripts/evaluation-row-export.ts
@@ -1,0 +1,61 @@
+import { pathToFileURL } from "node:url";
+import {
+  buildEvaluationRowExportBundle,
+  formatEvaluationRowExportManifest,
+  writeEvaluationRowExportBundle,
+} from "../src/lib/evals/evaluationRowExport";
+
+interface Args {
+  outDir: string;
+  json: boolean;
+  generatedAt?: string;
+}
+
+function usage(): string {
+  return [
+    "usage: evaluation-row-export [--out <dir>] [--generated-at <iso>] [--json]",
+    "",
+    "Local-only synthetic EvaluationRow-compatible JSONL export for optional Fireworks/Eval Protocol handoff.",
+  ].join("\n");
+}
+
+export function parseArgs(argv: string[]): Args {
+  const args: Args = { outDir: "artifacts/evaluation-row-export", json: false };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--json") args.json = true;
+    else if (arg === "--out") {
+      const value = argv[++i];
+      if (!value) throw new Error("--out requires a directory");
+      args.outDir = value;
+    } else if (arg === "--generated-at") {
+      const value = argv[++i];
+      if (!value) throw new Error("--generated-at requires an ISO timestamp");
+      args.generatedAt = value;
+    } else if (arg === "--help" || arg === "-h") {
+      throw new Error(usage());
+    } else {
+      throw new Error(`Unexpected argument: ${arg}`);
+    }
+  }
+  return args;
+}
+
+export async function main(argv: string[]): Promise<number> {
+  let args: Args;
+  try {
+    args = parseArgs(argv);
+  } catch (err) {
+    process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`);
+    return 2;
+  }
+
+  const bundle = buildEvaluationRowExportBundle({ generated_at: args.generatedAt });
+  writeEvaluationRowExportBundle(bundle, args.outDir);
+  process.stdout.write(args.json ? formatEvaluationRowExportManifest(bundle.manifest) : bundle.reportMarkdown);
+  return 0;
+}
+
+const invokedDirectly =
+  process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (invokedDirectly) main(process.argv.slice(2)).then((code) => process.exit(code));

--- a/src/lib/evals/evaluationRowExport.test.ts
+++ b/src/lib/evals/evaluationRowExport.test.ts
@@ -1,0 +1,49 @@
+import { mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, test } from "vitest";
+import {
+  buildEvaluationRowExportBundle,
+  formatEvaluationRowExportManifest,
+  writeEvaluationRowExportBundle,
+} from "./evaluationRowExport";
+
+describe("EvaluationRow compatibility export", () => {
+  test("builds deterministic non-empty EvaluationRow JSONL", () => {
+    const a = buildEvaluationRowExportBundle();
+    const b = buildEvaluationRowExportBundle();
+    expect(a.manifest.row_count).toBeGreaterThan(0);
+    expect(a.jsonl).toBe(b.jsonl);
+    expect(a.manifest.dataset_hash).toBe(b.manifest.dataset_hash);
+    const firstLine = a.jsonl.trim().split("\n")[0];
+    expect(firstLine).toBeDefined();
+    const first = JSON.parse(firstLine ?? "{}");
+    expect(first.messages.length).toBeGreaterThan(1);
+    expect(first.rollout_status).toBe("completed");
+    expect(first.input_metadata.case_id).toMatch(/^demo-/);
+    expect(first.eval_metadata.case_id).toBe(first.input_metadata.case_id);
+  });
+
+  test("manifest/report summary omits raw row content", () => {
+    const bundle = buildEvaluationRowExportBundle();
+    const firstRow = bundle.rows[0];
+    expect(firstRow).toBeDefined();
+    const firstMessage = firstRow === undefined ? undefined : firstRow.messages[0];
+    expect(firstMessage).toBeDefined();
+    const firstContent = firstMessage === undefined ? "" : firstMessage.content;
+    const summary = formatEvaluationRowExportManifest(bundle.manifest) + bundle.reportMarkdown;
+    expect(summary).not.toContain(firstContent);
+    expect(summary).toContain("evaluation_row_jsonl");
+    expect(summary).toContain("Eval Protocol runtime");
+  });
+
+  test("writes jsonl, manifest, and report artifacts", () => {
+    const dir = mkdtempSync(join(tmpdir(), "evaluation-row-export-"));
+    const bundle = buildEvaluationRowExportBundle();
+    writeEvaluationRowExportBundle(bundle, dir);
+    expect(readFileSync(join(dir, "evaluation-rows.jsonl"), "utf8")).toBe(bundle.jsonl);
+    const manifest = JSON.parse(readFileSync(join(dir, "evaluation-rows.manifest.json"), "utf8"));
+    expect(manifest.row_count).toBe(bundle.manifest.row_count);
+    expect(readFileSync(join(dir, "evaluation-rows.report.md"), "utf8")).toContain("EvaluationRow compatibility export");
+  });
+});

--- a/src/lib/evals/evaluationRowExport.ts
+++ b/src/lib/evals/evaluationRowExport.ts
@@ -1,0 +1,186 @@
+import { createHash } from "node:crypto";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+import { stableStringify } from "./cloudflareAiGateway";
+import {
+  SPLITS,
+  compileTrainingDataset,
+  demoTrainingSourceRows,
+  type CompiledRow,
+  type SplitName,
+  type TrainingDatasetManifest,
+} from "./trainingDataset";
+
+export interface EvaluationRowMessage {
+  role: string;
+  content: string;
+}
+
+export interface EvaluationRow {
+  messages: EvaluationRowMessage[];
+  tools: unknown[];
+  input_metadata: Record<string, unknown>;
+  rollout_status: "completed";
+  ground_truth: Record<string, unknown>;
+  evaluation_result: Record<string, unknown>;
+  execution_metadata: Record<string, unknown>;
+  created_at: string;
+  eval_metadata: Record<string, unknown>;
+}
+
+export interface EvaluationRowExportManifest {
+  format: "evaluation_row_jsonl";
+  schema_family: "eval_protocol_evaluation_row";
+  generated_at: string;
+  dataset_name: string;
+  source_dataset_hash: string;
+  row_count: number;
+  split_counts: Record<SplitName, number>;
+  row_hashes: Array<{ case_id: string; split: SplitName; hash: string }>;
+  dataset_hash: string;
+  caveats: string[];
+}
+
+export interface EvaluationRowExportBundle {
+  rows: EvaluationRow[];
+  jsonl: string;
+  manifest: EvaluationRowExportManifest;
+  reportMarkdown: string;
+}
+
+const DEFAULT_GENERATED_AT = "2026-01-01T00:00:00Z";
+const DEFAULT_DATASET = "evaluation-row-demo";
+
+function sha256hex(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function rowLine(row: EvaluationRow): string {
+  return stableStringify(row);
+}
+
+export function toEvaluationRow(row: CompiledRow, sourceManifest: TrainingDatasetManifest, generatedAt: string): EvaluationRow {
+  return {
+    messages: row.messages.map((message) => ({ role: message.role, content: message.content })),
+    tools: [],
+    input_metadata: {
+      case_id: row.metadata.case_id,
+      product: row.metadata.product,
+      source: row.metadata.source,
+      privacy_class: row.metadata.privacy_class,
+      classification: row.metadata.classification,
+      split: row.metadata.split,
+    },
+    rollout_status: "completed",
+    ground_truth: {
+      source: "blind_bench_review",
+      classification: row.metadata.classification,
+    },
+    evaluation_result: {
+      approved_for_training: row.metadata.classification === "training_approved",
+      source_dataset_hash_suffix: sourceManifest.dataset_hash.slice(0, 16),
+    },
+    execution_metadata: {
+      exporter: "blind_bench_evaluation_row_local",
+      dataset_name: sourceManifest.dataset_name,
+    },
+    created_at: generatedAt,
+    eval_metadata: {
+      case_id: row.metadata.case_id,
+      product: row.metadata.product,
+      source: row.metadata.source,
+      split: row.metadata.split,
+      approver: row.metadata.approver,
+      approved_at: row.metadata.approved_at,
+      variant: row.metadata.variant,
+      customer_scope: row.metadata.customer_scope,
+    },
+  };
+}
+
+export function toEvaluationRowJsonl(rows: EvaluationRow[]): string {
+  return rows.map(rowLine).join("\n") + (rows.length ? "\n" : "");
+}
+
+export function buildEvaluationRowExportBundle(options: {
+  generated_at?: string;
+  dataset_name?: string;
+} = {}): EvaluationRowExportBundle {
+  const generatedAt = options.generated_at ?? DEFAULT_GENERATED_AT;
+  const compiled = compileTrainingDataset(demoTrainingSourceRows(), {
+    generated_at: generatedAt,
+    dataset_name: options.dataset_name ?? DEFAULT_DATASET,
+  });
+
+  const rows: EvaluationRow[] = [];
+  const rowHashes: EvaluationRowExportManifest["row_hashes"] = [];
+  for (const split of SPLITS) {
+    for (const row of compiled.splits[split]) {
+      const evaluationRow = toEvaluationRow(row, compiled.manifest, generatedAt);
+      const line = rowLine(evaluationRow);
+      rows.push(evaluationRow);
+      rowHashes.push({ case_id: row.metadata.case_id, split, hash: sha256hex(line) });
+    }
+  }
+
+  const jsonl = toEvaluationRowJsonl(rows);
+  const manifest: EvaluationRowExportManifest = {
+    format: "evaluation_row_jsonl",
+    schema_family: "eval_protocol_evaluation_row",
+    generated_at: generatedAt,
+    dataset_name: compiled.manifest.dataset_name,
+    source_dataset_hash: compiled.manifest.dataset_hash,
+    row_count: rows.length,
+    split_counts: compiled.manifest.split_counts,
+    row_hashes: rowHashes,
+    dataset_hash: sha256hex(jsonl),
+    caveats: [
+      "Optional compatibility artifact only; this does not adopt Eval Protocol runtime, Python SDK, or Fireworks tracing proxy.",
+      "Synthetic demo rows only by default.",
+      "Real rows require existing Blind Bench consent, privacy, and training-export gates before serialization.",
+      "Summary/report output intentionally omits raw prompts, completions, and tool arguments.",
+    ],
+  };
+
+  return {
+    rows,
+    jsonl,
+    manifest,
+    reportMarkdown: formatEvaluationRowExportReport(manifest),
+  };
+}
+
+export function formatEvaluationRowExportManifest(manifest: EvaluationRowExportManifest): string {
+  return JSON.stringify(manifest, null, 2) + "\n";
+}
+
+export function formatEvaluationRowExportReport(manifest: EvaluationRowExportManifest): string {
+  return [
+    "# EvaluationRow compatibility export",
+    "",
+    "## Summary",
+    "",
+    `- Format: \`${manifest.format}\``,
+    `- Schema family: \`${manifest.schema_family}\``,
+    `- Dataset: \`${manifest.dataset_name}\``,
+    `- Rows: ${manifest.row_count}`,
+    `- Splits: train=${manifest.split_counts.train}, validation=${manifest.split_counts.validation}, test=${manifest.split_counts.test}`,
+    `- Dataset hash suffix: \`${manifest.dataset_hash.slice(0, 16)}\``,
+    `- Source dataset hash suffix: \`${manifest.source_dataset_hash.slice(0, 16)}\``,
+    "",
+    "## Caveats",
+    "",
+    ...manifest.caveats.map((caveat) => `- ${caveat}`),
+    "",
+  ].join("\n");
+}
+
+export function writeEvaluationRowExportBundle(bundle: EvaluationRowExportBundle, outDir: string): void {
+  const jsonlPath = `${outDir}/evaluation-rows.jsonl`;
+  const manifestPath = `${outDir}/evaluation-rows.manifest.json`;
+  const reportPath = `${outDir}/evaluation-rows.report.md`;
+  mkdirSync(dirname(jsonlPath), { recursive: true });
+  writeFileSync(jsonlPath, bundle.jsonl);
+  writeFileSync(manifestPath, formatEvaluationRowExportManifest(bundle.manifest));
+  writeFileSync(reportPath, bundle.reportMarkdown);
+}


### PR DESCRIPTION
## Summary

Closes #275. Adds a narrow, local-only EvaluationRow-compatible JSONL export hedge without adopting Eval Protocol, the Python SDK, Fireworks-hosted tracing, or Fireworks proxy credentials.

What changed:
- Added `npm run export:evaluation-rows`.
- Added `src/lib/evals/evaluationRowExport.ts` to convert the existing synthetic demo training dataset rows into EvaluationRow-style JSONL.
- Writes local artifacts under `artifacts/evaluation-row-export/` by default:
  - `evaluation-rows.jsonl`
  - `evaluation-rows.manifest.json`
  - `evaluation-rows.report.md`
- Added focused tests for deterministic non-empty rows, expected EvaluationRow fields, artifact writes, and summary/report no-raw-content behavior.
- Added docs/runbook at `docs/evaluation-row-export.md` explaining this is optional compatibility only and not runtime adoption.

## Verification

- `NODE_ENV=development npm ci --include=dev`
  - passed; npm reports existing audit findings
- `npx vitest run src/lib/evals/evaluationRowExport.test.ts`
  - 1 file, 3 tests passed
- CLI smoke:
  - `npm run --silent export:evaluation-rows -- --out /tmp/evaluation-row-export-smoke`
  - `npm run --silent export:evaluation-rows -- --out /tmp/evaluation-row-export-smoke-json --json`
  - verified manifest shape with `jq`
  - verified JSONL first row has `messages`, `input_metadata`, and `rollout_status=completed`
  - verified raw prompt sentinel did not appear in stdout/report/manifest
  - output: `evaluation_row_export rows=50 hash=ae11b227e4a4d973`
- `env -u NODE_ENV npm run test:evals`
  - 15 files, 142 tests passed
- `npx convex dev --once --typecheck disable && env -u NODE_ENV npm run test:convex`
  - 26 files, 232 tests passed
  - existing non-fatal `convex-test` scheduled-function teardown stderr still appears
- `env -u NODE_ENV npm run build`
  - passed with existing Vite chunk-size warnings
- `git diff --check`
  - passed
- Changed-file safety grep returned no customer/design-partner names or credential-like markers.

## Data / vendor boundary

- No network calls.
- No Fireworks API call.
- No Eval Protocol runtime adoption.
- No Python SDK dependency.
- Synthetic demo rows only by default.
- Summary/report output omits raw prompts, completions, and tool arguments.
- Real rows still require existing Blind Bench consent/privacy/training-export gates before serialization.

## Notes

This implements the issue #275 hedge: Blind Bench can manufacture human judgment and serialize it into a customer-owned EvaluationRow/RFT pipeline if explicitly requested, while preserving the product decision not to adopt Eval Protocol as the runtime.
