### PR TITLE
Fix landing page + sign-in audit findings

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Blind Bench</title>
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <style>
+      html {
+        background: oklch(1 0 0);
+      }
+    </style>
   </head>
   <body>
     <div id="root"></div>

--- a/landing/astro.config.mjs
+++ b/landing/astro.config.mjs
@@ -1,10 +1,12 @@
 // @ts-check
 import { defineConfig } from 'astro/config';
 import tailwindcss from '@tailwindcss/vite';
+import sitemap from '@astrojs/sitemap';
 
 export default defineConfig({
   site: 'https://blindbench.dev',
   output: 'static',
+  integrations: [sitemap()],
   vite: {
     plugins: [tailwindcss()],
   },

--- a/landing/package-lock.json
+++ b/landing/package-lock.json
@@ -8,6 +8,7 @@
       "name": "landing",
       "version": "0.0.1",
       "dependencies": {
+        "@astrojs/sitemap": "^3.7.3",
         "@sentry/browser": "^10.58.0",
         "@tailwindcss/vite": "^4.2.2",
         "@vercel/analytics": "^2.0.1",
@@ -80,6 +81,17 @@
       },
       "engines": {
         "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@astrojs/sitemap": {
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/@astrojs/sitemap/-/sitemap-3.7.3.tgz",
+      "integrity": "sha512-f8euLVsyeAmAkSm/1M2Kb8sL8byQmfgbvBNaHFItCheTj/IpiJYSEWVcqDHZ/yEHxiS7+w87mQkzwZaPHmk5GA==",
+      "license": "MIT",
+      "dependencies": {
+        "sitemap": "^9.0.0",
+        "stream-replace-string": "^2.0.0",
+        "zod": "^4.3.6"
       }
     },
     "node_modules/@astrojs/telemetry": {
@@ -2740,6 +2752,15 @@
         "undici-types": "~7.19.0"
       }
     },
+    "node_modules/@types/sax": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/sax/-/sax-1.2.7.tgz",
+      "integrity": "sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
@@ -2825,6 +2846,12 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -6044,6 +6071,40 @@
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "license": "MIT"
     },
+    "node_modules/sitemap": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-9.0.1.tgz",
+      "integrity": "sha512-S6hzjGJSG3d6if0YoF5kTyeRJvia6FSTBroE5fQ0bu1QNxyJqhhinfUsXi9fH3MgtXODWvwo2BDyQSnhPQ88uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^24.9.2",
+        "@types/sax": "^1.2.1",
+        "arg": "^5.0.0",
+        "sax": "^1.4.1"
+      },
+      "bin": {
+        "sitemap": "dist/esm/cli.js"
+      },
+      "engines": {
+        "node": ">=20.19.5",
+        "npm": ">=10.8.2"
+      }
+    },
+    "node_modules/sitemap/node_modules/@types/node": {
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/sitemap/node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "license": "MIT"
+    },
     "node_modules/smol-toml": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
@@ -6074,6 +6135,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/stream-replace-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stream-replace-string/-/stream-replace-string-2.0.0.tgz",
+      "integrity": "sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==",
+      "license": "MIT"
     },
     "node_modules/string.prototype.codepointat": {
       "version": "0.2.1",

--- a/landing/package.json
+++ b/landing/package.json
@@ -13,6 +13,7 @@
     "astro": "astro"
   },
   "dependencies": {
+    "@astrojs/sitemap": "^3.7.3",
     "@sentry/browser": "^10.58.0",
     "@tailwindcss/vite": "^4.2.2",
     "@vercel/analytics": "^2.0.1",

--- a/landing/public/robots.txt
+++ b/landing/public/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://blindbench.dev/sitemap.xml
+Sitemap: https://blindbench.dev/sitemap-index.xml

--- a/landing/src/components/journey/Journey.astro
+++ b/landing/src/components/journey/Journey.astro
@@ -66,7 +66,7 @@ const steps = [
           steps.map((s, i) => (
             <>
               <li
-                class="journey-progress-item flex flex-1 items-center justify-center gap-2 rounded-md px-2 py-1.5"
+                class="journey-progress-item flex min-w-0 flex-1 items-center justify-center gap-2 rounded-md px-2 py-1.5"
                 data-progress-item={i}
               >
                 <span class="journey-progress-dot inline-flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-full border border-border bg-card font-mono text-[10px] font-semibold text-muted-foreground transition-[color,border-color,background-color,box-shadow] duration-300">

--- a/landing/src/layouts/Base.astro
+++ b/landing/src/layouts/Base.astro
@@ -12,6 +12,8 @@ const {
   description = 'Your experts review agent runs without knowing which version, model, or harness produced them. One link, no account — and the verdict routes back.',
 } = Astro.props;
 
+const canonical = new URL(Astro.url.pathname, Astro.site);
+
 const posthogKey = import.meta.env.PUBLIC_POSTHOG_KEY;
 const posthogHost = import.meta.env.PUBLIC_POSTHOG_HOST;
 ---
@@ -28,7 +30,7 @@ const posthogHost = import.meta.env.PUBLIC_POSTHOG_HOST;
     <meta property="og:type" content="website" />
     <meta property="og:title" content="Blind Bench" />
     <meta property="og:description" content={description} />
-    <meta property="og:url" content="https://blindbench.dev" />
+    <meta property="og:url" content={canonical.href} />
     <meta property="og:image" content="https://blindbench.dev/og-image.png" />
 
     <!-- Twitter -->
@@ -39,7 +41,7 @@ const posthogHost = import.meta.env.PUBLIC_POSTHOG_HOST;
 
     <meta name="theme-color" content="#f9f9f8" media="(prefers-color-scheme: light)" />
     <meta name="theme-color" content="#1c1c22" media="(prefers-color-scheme: dark)" />
-    <link rel="canonical" href="https://blindbench.dev/" />
+    <link rel="canonical" href={canonical.href} />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link
       rel="preload"

--- a/landing/src/layouts/Base.astro
+++ b/landing/src/layouts/Base.astro
@@ -49,6 +49,25 @@ const posthogHost = import.meta.env.PUBLIC_POSTHOG_HOST;
       crossorigin
     />
 
+    <!-- Without JS the IntersectionObserver never fires, so reveal-on-scroll
+         content stays hidden. Force it visible, mirroring the reduced-motion
+         override in global.css. !important is required because the bundled
+         global.css link and Problem.astro's scoped .redacted rule both load
+         after this block and would otherwise win the cascade. -->
+    <noscript>
+      <style>
+        .reveal,
+        .reveal-scale,
+        .connector-line {
+          opacity: 1 !important;
+          transform: none !important;
+        }
+        .redacted {
+          filter: none !important;
+        }
+      </style>
+    </noscript>
+
     <!-- Dark mode: apply before paint to avoid flash -->
     <script is:inline>
       if (window.matchMedia('(prefers-color-scheme: dark)').matches) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -170,7 +170,7 @@ function AuthGatePublic() {
         <SignIn />
       </Unauthenticated>
       <AuthLoading>
-        <LoadingScreen />
+        <div className="min-h-screen" />
       </AuthLoading>
     </>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -167,7 +167,11 @@ function AuthGatePublic() {
         <Navigate to="/" replace />
       </Authenticated>
       <Unauthenticated>
-        <SignIn />
+        {/* Local fallback so the lazy chunk load doesn't suspend into the
+            app-level Suspense and flash its skeleton. */}
+        <Suspense fallback={<div className="min-h-screen" />}>
+          <SignIn />
+        </Suspense>
       </Unauthenticated>
       <AuthLoading>
         <div className="min-h-screen" />


### PR DESCRIPTION
## Summary

Fixes everything actionable from the 2026-07-10 landing page audit.

**Sign-in gray flash (app):** Clicking "Sign in" on the landing page flashed a full-screen gray skeleton for ~350ms while Convex auth resolved, between the blank first paint and the sign-in page. The public auth gate (`AuthGatePublic`) now renders a calm blank screen during `AuthLoading`; the protected gate keeps its skeleton. `index.html` also sets an explicit `html` background so the pre-React first paint is deterministic.

**Mobile horizontal overflow (landing):** The sticky journey progress pill overflowed the viewport by 82px on a 390px screen — `truncate` labels couldn't shrink because flex items default to `min-width: auto`. Fixed with `min-w-0` on `journey-progress-item`. Verified 0px overflow after the fix.

**Sitemap 404 (landing):** robots.txt advertised `sitemap.xml` which didn't exist. Added `@astrojs/sitemap`; robots.txt now points at the generated `sitemap-index.xml`.

**No-JS invisibility (landing):** Reveal-on-scroll sections and the blurred `.redacted` punchlines were permanently hidden without JavaScript (the IntersectionObserver never fires). Added a `<noscript>` override mirroring the existing reduced-motion fallback. Verified with JS disabled: all content visible.

## Verification

- `npm run build` passes at repo root and in `landing/`
- Playwright against the built landing page: 0px mobile overflow (was 82px), no-JS content visible (`opacity=1`, `filter=none`), `sitemap-index.xml` emitted with apex URLs
- App sign-in flow: paint sequence re-checked; the skeleton flash branch is gone

## Not in this PR (needs a decision from Noah)

- **Domain canonicalization:** `blindbench.dev` 307s to `www.blindbench.dev`, but canonical/OG/sitemap/robots all point at the apex. Code is consistent with apex — the fix is flipping the Vercel primary domain to apex (www → apex redirect) in the dashboard. No code change needed if you do that; say the word if you'd rather standardize on www and I'll update the code instead.
- **App dark mode:** the app never applies `.dark` (variables exist, nothing toggles them), so dark-mode users go dark landing → white app. Product decision, out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)