### PR TITLE
Pivot Blind Bench to ingestion-first blind review

### DIFF
--- a/.github/workflows/required-checks.yml
+++ b/.github/workflows/required-checks.yml
@@ -1,0 +1,45 @@
+name: Required checks
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: required-checks-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - name: Generate offline Convex type stubs
+        run: node scripts/generate-convex-stubs.mjs
+      - run: npm run build
+      - run: npm run test:evals
+      - run: npm run test:convex
+
+  browser-components:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - name: Generate offline Convex type stubs
+        run: node scripts/generate-convex-stubs.mjs
+      - run: npx playwright install --with-deps chromium
+      - run: npm run test:ct

--- a/convex/agentTraceReview.ts
+++ b/convex/agentTraceReview.ts
@@ -11,7 +11,8 @@
 import { v } from "convex/values";
 import { mutation, query } from "./_generated/server";
 import type { Id } from "./_generated/dataModel";
-import { requireProjectRole } from "./lib/auth";
+import { isBlindReviewer, requireProjectRole } from "./lib/auth";
+import { ensureMatchupSessionsForProjectReviewers } from "./lib/traceReviewSessions";
 
 const LABEL = v.union(
   v.literal("suggestion"),
@@ -48,6 +49,9 @@ async function traceForReview(
   const trace = await ctx.db.get(agentTraceId);
   if (!trace) throw new Error("Trace not found.");
   const { userId } = await requireProjectRole(ctx, trace.projectId, [...REVIEW_ROLES]);
+  if (await isBlindReviewer(ctx, trace.projectId)) {
+    throw new Error("Use an opaque review session for trajectory feedback.");
+  }
   return { trace, userId };
 }
 
@@ -183,15 +187,42 @@ export const createMatchup = mutation({
       throw new Error("Both traces must be in the same project.");
     }
     await requireProjectRole(ctx, left.projectId, ["owner", "editor"]);
-    return await ctx.db.insert("agentTraceMatchups", {
+    if (!Number.isInteger(args.divergenceStepIndex) || args.divergenceStepIndex < 0) {
+      throw new Error("Divergence step must be a non-negative integer.");
+    }
+    const [leftStep, rightStep] = await Promise.all([
+      ctx.db
+        .query("agentTraceSteps")
+        .withIndex("by_trace_and_index", (q) =>
+          q.eq("agentTraceId", args.leftTraceId).eq("stepIndex", args.divergenceStepIndex),
+        )
+        .unique(),
+      ctx.db
+        .query("agentTraceSteps")
+        .withIndex("by_trace_and_index", (q) =>
+          q.eq("agentTraceId", args.rightTraceId).eq("stepIndex", args.divergenceStepIndex),
+        )
+        .unique(),
+    ]);
+    if (!leftStep || !rightStep) {
+      throw new Error("Both traces must contain the divergence step.");
+    }
+    const comparable = leftStep.prefixHash === rightStep.prefixHash;
+    const matchupId = await ctx.db.insert("agentTraceMatchups", {
       projectId: left.projectId,
       leftTraceId: args.leftTraceId,
       rightTraceId: args.rightTraceId,
       divergenceStepIndex: args.divergenceStepIndex,
       leftBlindLabel: args.leftBlindLabel,
       rightBlindLabel: args.rightBlindLabel,
-      reasonTags: [],
+      prefixHash: comparable ? leftStep.prefixHash : undefined,
+      comparabilityStatus: comparable ? "valid" : "invalid",
+      invalidReason: comparable ? undefined : "prefix_mismatch",
     });
+    if (comparable) {
+      await ensureMatchupSessionsForProjectReviewers(ctx, matchupId, left.projectId);
+    }
+    return matchupId;
   },
 });
 
@@ -206,10 +237,32 @@ export const decideMatchup = mutation({
     const matchup = await ctx.db.get(args.matchupId);
     if (!matchup) throw new Error("Matchup not found.");
     const { userId } = await requireProjectRole(ctx, matchup.projectId, [...REVIEW_ROLES]);
-    await ctx.db.patch(args.matchupId, {
+    if (await isBlindReviewer(ctx, matchup.projectId)) {
+      throw new Error("Use an opaque review session for matchup decisions.");
+    }
+    if (matchup.comparabilityStatus !== "valid") {
+      throw new Error("This matchup is not comparable because its prefixes differ.");
+    }
+    const existing = await ctx.db
+      .query("agentTraceMatchupDecisions")
+      .withIndex("by_matchup_and_user", (q) =>
+        q.eq("matchupId", args.matchupId).eq("userId", userId),
+      )
+      .unique();
+    if (existing) {
+      await ctx.db.patch(existing._id, {
+        winner: args.winner,
+        reasonTags: args.reasonTags,
+        decidedAt: Date.now(),
+      });
+      return existing._id;
+    }
+    return await ctx.db.insert("agentTraceMatchupDecisions", {
+      matchupId: args.matchupId,
+      projectId: matchup.projectId,
+      userId,
       winner: args.winner,
       reasonTags: args.reasonTags,
-      userId,
       decidedAt: Date.now(),
     });
   },
@@ -225,8 +278,17 @@ export const getMatchup = query({
   handler: async (ctx, args) => {
     const matchup = await ctx.db.get(args.matchupId);
     if (!matchup) return null;
-    await requireProjectRole(ctx, matchup.projectId, [...REVIEW_ROLES]);
+    const { userId } = await requireProjectRole(ctx, matchup.projectId, [...REVIEW_ROLES]);
+    if (await isBlindReviewer(ctx, matchup.projectId)) {
+      throw new Error("Use an opaque review session for matchup access.");
+    }
     const project = await ctx.db.get(matchup.projectId);
+    const decision = await ctx.db
+      .query("agentTraceMatchupDecisions")
+      .withIndex("by_matchup_and_user", (q) =>
+        q.eq("matchupId", args.matchupId).eq("userId", userId),
+      )
+      .unique();
     return {
       _id: matchup._id,
       projectName: project?.name ?? "Project",
@@ -235,8 +297,10 @@ export const getMatchup = query({
       divergenceStepIndex: matchup.divergenceStepIndex,
       leftBlindLabel: matchup.leftBlindLabel,
       rightBlindLabel: matchup.rightBlindLabel,
-      winner: matchup.winner ?? null,
-      reasonTags: matchup.reasonTags,
+      comparable: matchup.comparabilityStatus === "valid",
+      invalidReason: matchup.invalidReason,
+      winner: decision?.winner ?? null,
+      reasonTags: decision?.reasonTags ?? [],
     };
   },
 });

--- a/convex/agentTraceReviewSessions.ts
+++ b/convex/agentTraceReviewSessions.ts
@@ -1,0 +1,475 @@
+/**
+ * Opaque-token boundary for blind trajectory review. Reviewer-facing clients
+ * use only these functions; raw Convex trace/matchup IDs never cross the wire.
+ */
+import { paginationOptsValidator } from "convex/server";
+import { v } from "convex/values";
+import {
+  action,
+  internalQuery,
+  mutation,
+  query,
+  type MutationCtx,
+  type QueryCtx,
+} from "./_generated/server";
+import { internal } from "./_generated/api";
+import type { Doc, Id } from "./_generated/dataModel";
+import { requireAuth } from "./lib/auth";
+import { blindStepView, blindTraceView } from "./lib/blindProjection";
+
+const LABEL = v.union(
+  v.literal("suggestion"),
+  v.literal("issue"),
+  v.literal("praise"),
+  v.literal("question"),
+  v.literal("nitpick"),
+  v.literal("thought"),
+);
+const TAG = v.union(
+  v.literal("accuracy"),
+  v.literal("tone"),
+  v.literal("length"),
+  v.literal("relevance"),
+  v.literal("safety"),
+  v.literal("format"),
+  v.literal("clarity"),
+  v.literal("other"),
+);
+const TARGET = v.union(
+  v.object({ kind: v.literal("trace") }),
+  v.object({ kind: v.literal("step"), stepIndex: v.number() }),
+  v.object({ kind: v.literal("tool_call"), stepIndex: v.number() }),
+);
+const RATING = v.union(v.literal("best"), v.literal("acceptable"), v.literal("weak"));
+const WINNER = v.union(v.literal("left"), v.literal("right"), v.literal("tie"), v.literal("skip"));
+const SIDE = v.union(v.literal("left"), v.literal("right"));
+
+type ReadCtx = QueryCtx | MutationCtx;
+
+async function sessionForUser(
+  ctx: ReadCtx,
+  token: string,
+): Promise<Doc<"agentTraceReviewSessions">> {
+  const userId = await requireAuth(ctx);
+  const session = await ctx.db
+    .query("agentTraceReviewSessions")
+    .withIndex("by_token", (q) => q.eq("token", token))
+    .unique();
+  if (!session || session.reviewerUserId !== userId) {
+    throw new Error("Review session not found or expired.");
+  }
+  const collaborator = await ctx.db
+    .query("projectCollaborators")
+    .withIndex("by_project_and_user", (q) =>
+      q.eq("projectId", session.projectId).eq("userId", userId),
+    )
+    .unique();
+  if (!collaborator || collaborator.role !== "evaluator" || collaborator.blindMode === false) {
+    throw new Error("Review session not found or expired.");
+  }
+  return session;
+}
+
+async function traceSession(
+  ctx: ReadCtx,
+  token: string,
+): Promise<{
+  readonly session: Doc<"agentTraceReviewSessions">;
+  readonly trace: Doc<"agentTraces">;
+  readonly userId: Id<"users">;
+}> {
+  const session = await sessionForUser(ctx, token);
+  if (session.kind !== "trace" || session.agentTraceId === undefined) {
+    throw new Error("This review link is not a trajectory session.");
+  }
+  const trace = await ctx.db.get(session.agentTraceId);
+  if (!trace || trace.projectId !== session.projectId) {
+    throw new Error("Review trajectory is no longer available.");
+  }
+  return { session, trace, userId: session.reviewerUserId };
+}
+
+async function matchupSession(
+  ctx: ReadCtx,
+  token: string,
+): Promise<{
+  readonly session: Doc<"agentTraceReviewSessions">;
+  readonly matchup: Doc<"agentTraceMatchups">;
+  readonly userId: Id<"users">;
+}> {
+  const session = await sessionForUser(ctx, token);
+  if (session.kind !== "matchup" || session.matchupId === undefined) {
+    throw new Error("This review link is not a matchup session.");
+  }
+  const matchup = await ctx.db.get(session.matchupId);
+  if (!matchup || matchup.projectId !== session.projectId) {
+    throw new Error("Review matchup is no longer available.");
+  }
+  return { session, matchup, userId: session.reviewerUserId };
+}
+
+/** List the caller's opaque trajectory and matchup review sessions. */
+export const listMine = query({
+  args: {},
+  handler: async (ctx) => {
+    const userId = await requireAuth(ctx);
+    const sessions = await ctx.db
+      .query("agentTraceReviewSessions")
+      .withIndex("by_reviewer", (q) => q.eq("reviewerUserId", userId))
+      .order("desc")
+      .take(200);
+    const allowedProjects = new Map<Id<"projects">, boolean>();
+    const rows: Array<{
+      readonly token: string;
+      readonly kind: "trace" | "matchup";
+      readonly projectName: string;
+      readonly status: string;
+      readonly stepCount?: number;
+      readonly createdAt: number;
+    }> = [];
+    for (const session of sessions) {
+      let allowed = allowedProjects.get(session.projectId);
+      if (allowed === undefined) {
+        const collaborator = await ctx.db
+          .query("projectCollaborators")
+          .withIndex("by_project_and_user", (q) =>
+            q.eq("projectId", session.projectId).eq("userId", userId),
+          )
+          .unique();
+        allowed = collaborator?.role === "evaluator" && collaborator.blindMode !== false;
+        allowedProjects.set(session.projectId, allowed);
+      }
+      if (!allowed) continue;
+      const project = await ctx.db.get(session.projectId);
+      if (session.kind === "trace" && session.agentTraceId !== undefined) {
+        const trace = await ctx.db.get(session.agentTraceId);
+        if (!trace || trace.status !== "ready") continue;
+        rows.push({
+          token: session.token,
+          kind: "trace",
+          projectName: project?.name ?? "Project",
+          status: trace.status,
+          stepCount: trace.stepCount,
+          createdAt: session._creationTime,
+        });
+      } else if (session.kind === "matchup" && session.matchupId !== undefined) {
+        const matchup = await ctx.db.get(session.matchupId);
+        if (!matchup || matchup.comparabilityStatus !== "valid") continue;
+        rows.push({
+          token: session.token,
+          kind: "matchup",
+          projectName: project?.name ?? "Project",
+          status: "ready",
+          createdAt: session._creationTime,
+        });
+      }
+    }
+    return rows;
+  },
+});
+
+/** Return blind-projected parent metadata for one opaque trajectory session. */
+export const getTrace = query({
+  args: { token: v.string() },
+  handler: async (ctx, args) => {
+    const { session, trace } = await traceSession(ctx, args.token);
+    const project = await ctx.db.get(session.projectId);
+    const projected = blindTraceView({
+      _id: "",
+      projectName: project?.name ?? "Project",
+      traceId: trace.traceId,
+      product: trace.product,
+      module: trace.module,
+      environment: trace.environment,
+      status: trace.status,
+      stepCount: trace.stepCount,
+      privacyClass: trace.privacyClass,
+      model: trace.model,
+      harnessName: trace.harnessName,
+      harnessVersion: trace.harnessVersion,
+      usage: {
+        costUsd: trace.costUsd,
+        durationMs: trace.durationMs,
+        totalTokens: trace.totalTokens,
+      },
+      hasFinalAnswer: trace.finalAnswerBlindStorageId !== undefined,
+    });
+    return {
+      projectName: projected.projectName,
+      status: projected.status,
+      stepCount: projected.stepCount,
+      privacyClass: projected.privacyClass,
+      usage: projected.usage,
+      hasFinalAnswer: projected.hasFinalAnswer,
+    };
+  },
+});
+
+/** Page blind-projected steps by opaque trajectory session token. */
+export const listSteps = query({
+  args: { token: v.string(), paginationOpts: paginationOptsValidator },
+  handler: async (ctx, args) => {
+    const { trace } = await traceSession(ctx, args.token);
+    const result = await ctx.db
+      .query("agentTraceSteps")
+      .withIndex("by_trace_and_index", (q) => q.eq("agentTraceId", trace._id))
+      .paginate(args.paginationOpts);
+    return {
+      ...result,
+      page: result.page.map((row) =>
+        blindStepView({
+          stepIndex: row.stepIndex,
+          kind: row.kind,
+          role: row.role,
+          toolName: row.toolName,
+          toolCallId: row.toolCallId,
+          label: row.label,
+          policy: row.policy,
+          action: row.action,
+          reason: row.reason,
+          timestamp: row.timestamp,
+          privacyClass: row.privacyClass,
+          inputTokens: row.inputTokens,
+          outputTokens: row.outputTokens,
+          durationMs: row.durationMs,
+          hasBody: row.blindBodyStorageId !== undefined,
+        }),
+      ),
+    };
+  },
+});
+
+/** Resolve only a blind-body storage pointer after token authorization. */
+export const resolveBody = internalQuery({
+  args: {
+    token: v.string(),
+    stepIndex: v.optional(v.number()),
+    matchupSide: v.optional(SIDE),
+  },
+  handler: async (ctx, args): Promise<{ storageId: Id<"_storage"> | null }> => {
+    let trace: Doc<"agentTraces">;
+    if (args.matchupSide !== undefined) {
+      const { matchup } = await matchupSession(ctx, args.token);
+      const traceId = args.matchupSide === "left" ? matchup.leftTraceId : matchup.rightTraceId;
+      const row = await ctx.db.get(traceId);
+      if (!row) return { storageId: null };
+      trace = row;
+    } else {
+      trace = (await traceSession(ctx, args.token)).trace;
+    }
+    if (args.stepIndex === undefined) {
+      return { storageId: trace.finalAnswerBlindStorageId ?? null };
+    }
+    const step = await ctx.db
+      .query("agentTraceSteps")
+      .withIndex("by_trace_and_index", (q) =>
+        q.eq("agentTraceId", trace._id).eq("stepIndex", args.stepIndex ?? -1),
+      )
+      .unique();
+    return { storageId: step?.blindBodyStorageId ?? null };
+  },
+});
+
+/** Lazy-load one blind-projected step/final body through an opaque token. */
+export const getStepBody = action({
+  args: {
+    token: v.string(),
+    stepIndex: v.optional(v.number()),
+    matchupSide: v.optional(SIDE),
+  },
+  handler: async (ctx, args): Promise<unknown> => {
+    const { storageId } = await ctx.runQuery(internal.agentTraceReviewSessions.resolveBody, args);
+    if (!storageId) return null;
+    const blob = await ctx.storage.get(storageId);
+    if (!blob) return null;
+    try {
+      return JSON.parse(await blob.text());
+    } catch {
+      return null;
+    }
+  },
+});
+
+/** List comments for one opaque trajectory session. */
+export const listComments = query({
+  args: { token: v.string() },
+  handler: async (ctx, args) => {
+    const { trace, userId } = await traceSession(ctx, args.token);
+    const rows = await ctx.db
+      .query("agentTraceComments")
+      .withIndex("by_trace", (q) => q.eq("agentTraceId", trace._id))
+      .collect();
+    return rows.filter((row) => row.userId === userId).map((row) => ({
+      _id: row._id,
+      target: row.target,
+      comment: row.comment,
+      label: row.label,
+      tags: row.tags ?? [],
+      mine: row.userId === userId,
+      createdAt: row._creationTime,
+    }));
+  },
+});
+
+/** Add a step/trace comment through an opaque trajectory session. */
+export const addComment = mutation({
+  args: {
+    token: v.string(),
+    target: TARGET,
+    comment: v.string(),
+    label: LABEL,
+    tags: v.optional(v.array(TAG)),
+  },
+  handler: async (ctx, args): Promise<Id<"agentTraceComments">> => {
+    const { trace, userId } = await traceSession(ctx, args.token);
+    const body = args.comment.trim();
+    if (!body) throw new Error("Add a comment before saving.");
+    if (
+      args.target.kind !== "trace" &&
+      (args.target.stepIndex < 0 || args.target.stepIndex >= trace.stepCount)
+    ) {
+      throw new Error("That step is not part of this trace.");
+    }
+    return await ctx.db.insert("agentTraceComments", {
+      agentTraceId: trace._id,
+      projectId: trace.projectId,
+      userId,
+      target: args.target,
+      comment: body,
+      label: args.label,
+      tags: args.tags,
+    });
+  },
+});
+
+/** Return the caller's verdict for one opaque trajectory session. */
+export const myVerdict = query({
+  args: { token: v.string() },
+  handler: async (ctx, args) => {
+    const { trace, userId } = await traceSession(ctx, args.token);
+    const verdict = await ctx.db
+      .query("agentTraceVerdicts")
+      .withIndex("by_trace_and_user", (q) =>
+        q.eq("agentTraceId", trace._id).eq("userId", userId),
+      )
+      .unique();
+    return verdict ? { rating: verdict.rating, note: verdict.note } : null;
+  },
+});
+
+/** Upsert the caller's verdict through an opaque trajectory session. */
+export const setVerdict = mutation({
+  args: { token: v.string(), rating: RATING, note: v.optional(v.string()) },
+  handler: async (ctx, args) => {
+    const { trace, userId } = await traceSession(ctx, args.token);
+    const existing = await ctx.db
+      .query("agentTraceVerdicts")
+      .withIndex("by_trace_and_user", (q) =>
+        q.eq("agentTraceId", trace._id).eq("userId", userId),
+      )
+      .unique();
+    if (existing) {
+      await ctx.db.patch(existing._id, { rating: args.rating, note: args.note });
+      return existing._id;
+    }
+    return await ctx.db.insert("agentTraceVerdicts", {
+      agentTraceId: trace._id,
+      projectId: trace.projectId,
+      userId,
+      rating: args.rating,
+      note: args.note,
+    });
+  },
+});
+
+/** Return blind matchup metadata without exposing either trace ID. */
+export const getMatchup = query({
+  args: { token: v.string() },
+  handler: async (ctx, args) => {
+    const { session, matchup, userId } = await matchupSession(ctx, args.token);
+    const project = await ctx.db.get(matchup.projectId);
+    const decision = await ctx.db
+      .query("agentTraceMatchupDecisions")
+      .withIndex("by_matchup_and_user", (q) =>
+        q.eq("matchupId", matchup._id).eq("userId", userId),
+      )
+      .unique();
+    const leftFirst = session.leftFirst ?? true;
+    return {
+      projectName: project?.name ?? "Project",
+      divergenceStepIndex: matchup.divergenceStepIndex,
+      firstSide: leftFirst ? "left" as const : "right" as const,
+      leftBlindLabel: leftFirst ? "A" : "B",
+      rightBlindLabel: leftFirst ? "B" : "A",
+      comparable: matchup.comparabilityStatus === "valid",
+      invalidReason: matchup.invalidReason,
+      winner: decision?.winner ?? null,
+      reasonTags: decision?.reasonTags ?? [],
+    };
+  },
+});
+
+/** Page one side of an opaque matchup without exposing the underlying trace ID. */
+export const listMatchupSteps = query({
+  args: { token: v.string(), side: SIDE, paginationOpts: paginationOptsValidator },
+  handler: async (ctx, args) => {
+    const { matchup } = await matchupSession(ctx, args.token);
+    const traceId = args.side === "left" ? matchup.leftTraceId : matchup.rightTraceId;
+    const result = await ctx.db
+      .query("agentTraceSteps")
+      .withIndex("by_trace_and_index", (q) => q.eq("agentTraceId", traceId))
+      .paginate(args.paginationOpts);
+    return {
+      ...result,
+      page: result.page.map((row) =>
+        blindStepView({
+          stepIndex: row.stepIndex,
+          kind: row.kind,
+          role: row.role,
+          toolName: row.toolName,
+          toolCallId: row.toolCallId,
+          label: row.label,
+          policy: row.policy,
+          action: row.action,
+          reason: row.reason,
+          timestamp: row.timestamp,
+          privacyClass: row.privacyClass,
+          hasBody: row.blindBodyStorageId !== undefined,
+        }),
+      ),
+    };
+  },
+});
+
+/** Record one independent matchup decision through an opaque session. */
+export const decideMatchup = mutation({
+  args: { token: v.string(), winner: WINNER, reasonTags: v.array(TAG) },
+  handler: async (ctx, args) => {
+    const { matchup, userId } = await matchupSession(ctx, args.token);
+    if (matchup.comparabilityStatus !== "valid") {
+      throw new Error("This matchup is not comparable because its prefixes differ.");
+    }
+    const existing = await ctx.db
+      .query("agentTraceMatchupDecisions")
+      .withIndex("by_matchup_and_user", (q) =>
+        q.eq("matchupId", matchup._id).eq("userId", userId),
+      )
+      .unique();
+    if (existing) {
+      await ctx.db.patch(existing._id, {
+        winner: args.winner,
+        reasonTags: args.reasonTags,
+        decidedAt: Date.now(),
+      });
+      return existing._id;
+    }
+    return await ctx.db.insert("agentTraceMatchupDecisions", {
+      matchupId: matchup._id,
+      projectId: matchup.projectId,
+      userId,
+      winner: args.winner,
+      reasonTags: args.reasonTags,
+      decidedAt: Date.now(),
+    });
+  },
+});

--- a/convex/agentTraces.ts
+++ b/convex/agentTraces.ts
@@ -30,6 +30,7 @@ import type { AgentRunTrace } from "./lib/agentTrace";
 import { redactValue } from "./lib/agentTrace";
 import { splitStep } from "./lib/agentTraceStorage";
 import { blindStepView, blindTraceView } from "./lib/blindProjection";
+import { ensureTraceSessionsForProjectReviewers } from "./lib/traceReviewSessions";
 
 const STEP_INSERT_CHUNK = 100;
 
@@ -51,6 +52,7 @@ const stepKindValidator = v.union(
 
 const stepInsertValidator = v.object({
   stepIndex: v.number(),
+  prefixHash: v.string(),
   kind: stepKindValidator,
   role: v.optional(v.string()),
   toolName: v.optional(v.string()),
@@ -74,7 +76,34 @@ const storeJson = (
 ): Promise<Id<"_storage">> =>
   ctx.storage.store(new Blob([JSON.stringify(body)], { type: "application/json" }));
 
+const stableStringify = (value: unknown): string => {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(",")}]`;
+  const record = value as Record<string, unknown>;
+  return `{${Object.keys(record)
+    .sort()
+    .map((key) => `${JSON.stringify(key)}:${stableStringify(record[key])}`)
+    .join(",")}}`;
+};
+
+const sha256 = async (value: string): Promise<string> => {
+  const bytes = new TextEncoder().encode(value);
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
+  return [...new Uint8Array(digest)]
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+};
+
 // --- mutations (auth + dedup + writes, transactional) -----------------------
+
+/** Cheap authorization gate for actions before parsing or touching storage. */
+export const authorizePersist = internalQuery({
+  args: { projectId: v.id("projects") },
+  handler: async (ctx, args) => {
+    await requireProjectRole(ctx, args.projectId, ["owner", "editor"]);
+    return null;
+  },
+});
 
 /**
  * Insert the parent row (status "pending"). Auth + dedup by (projectId,
@@ -211,11 +240,14 @@ export const finalizeTrace = internalMutation({
     finalAnswerBlindStorageId: v.optional(v.id("_storage")),
   },
   handler: async (ctx, args) => {
+    const trace = await ctx.db.get(args.agentTraceId);
+    if (!trace) throw new Error("Trace not found while finalizing import.");
     await ctx.db.patch(args.agentTraceId, {
       status: "ready",
       finalAnswerStorageId: args.finalAnswerStorageId,
       finalAnswerBlindStorageId: args.finalAnswerBlindStorageId,
     });
+    await ensureTraceSessionsForProjectReviewers(ctx, args.agentTraceId, trace.projectId);
   },
 });
 
@@ -262,6 +294,7 @@ export const persistTrace = action({
     ctx,
     args,
   ): Promise<{ agentTraceId: Id<"agentTraces">; deduped: boolean; stepCount: number }> => {
+    await ctx.runQuery(internal.agentTraces.authorizePersist, { projectId: args.projectId });
     const trace = args.trace as AgentRunTrace;
     const stepCount = trace.steps.length;
 
@@ -307,13 +340,15 @@ export async function storeTraceSteps(
 ): Promise<void> {
   try {
     const rows: Array<Record<string, unknown>> = [];
+    let prefixHash = await sha256("");
     for (const step of trace.steps) {
       const { row, fullBody, blindBody } = splitStep(step);
       const fullBodyStorageId =
         fullBody === undefined ? undefined : await storeJson(ctx, fullBody);
       const blindBodyStorageId =
         blindBody === undefined ? undefined : await storeJson(ctx, blindBody);
-      rows.push({ ...row, fullBodyStorageId, blindBodyStorageId });
+      rows.push({ ...row, prefixHash, fullBodyStorageId, blindBodyStorageId });
+      prefixHash = await sha256(`${prefixHash}:${stableStringify(step)}`);
     }
     for (let i = 0; i < rows.length; i += STEP_INSERT_CHUNK) {
       await ctx.runMutation(internal.agentTraces.insertSteps, {
@@ -358,6 +393,7 @@ export const getTrace = query({
     if (!trace) return null;
     await requireProjectRole(ctx, trace.projectId, ["owner", "editor", "evaluator"]);
     const blind = await isBlindReviewer(ctx, trace.projectId);
+    if (blind) throw new Error("Use an opaque review session to access this trajectory.");
     const project = await ctx.db.get(trace.projectId);
     const finalAnswerId = blind
       ? trace.finalAnswerBlindStorageId
@@ -401,6 +437,7 @@ export const resolveBodyStorage = internalQuery({
     if (!trace) return { storageId: null };
     await requireProjectRole(ctx, trace.projectId, ["owner", "editor", "evaluator"]);
     const blind = await isBlindReviewer(ctx, trace.projectId);
+    if (blind) throw new Error("Use an opaque review session to access trajectory bodies.");
     if (args.stepIndex === undefined) {
       const id = blind ? trace.finalAnswerBlindStorageId : trace.finalAnswerStorageId;
       return { storageId: id ?? null };
@@ -454,6 +491,7 @@ export const listTraces = query({
   handler: async (ctx, args) => {
     await requireProjectRole(ctx, args.projectId, ["owner", "editor", "evaluator"]);
     const blind = await isBlindReviewer(ctx, args.projectId);
+    if (blind) throw new Error("Use the opaque review-session inbox.");
     const rows = await ctx.db
       .query("agentTraces")
       .withIndex("by_project", (q) => q.eq("projectId", args.projectId))
@@ -497,6 +535,7 @@ export const listReviewableTraces = query({
     }> = [];
     for (const c of collabs) {
       const blind = await isBlindReviewer(ctx, c.projectId);
+      if (blind) continue;
       const project = await ctx.db.get(c.projectId);
       const traces = await ctx.db
         .query("agentTraces")
@@ -537,6 +576,7 @@ export const listSteps = query({
     if (!trace) throw new Error("Trace not found");
     await requireProjectRole(ctx, trace.projectId, ["owner", "editor", "evaluator"]);
     const blind = await isBlindReviewer(ctx, trace.projectId);
+    if (blind) throw new Error("Use an opaque review session to page trajectory steps.");
 
     const result = await ctx.db
       .query("agentTraceSteps")

--- a/convex/claudeCodeImport.ts
+++ b/convex/claudeCodeImport.ts
@@ -33,13 +33,18 @@ export const importClaudeCodeSession = action({
     jsonl: v.string(),
   },
   handler: async (ctx, args): Promise<ImportResult> => {
-    if (args.jsonl.length > MAX_BYTES) {
+    await ctx.runQuery(internal.agentTraces.authorizePersist, { projectId: args.projectId });
+    const inputBytes = new TextEncoder().encode(args.jsonl).byteLength;
+    if (inputBytes > MAX_BYTES) {
       throw new Error(
-        `Session too large (${args.jsonl.length} chars, limit ${MAX_BYTES}). Split the transcript or trim old turns.`,
+        `Session too large (${inputBytes} bytes, limit ${MAX_BYTES}). Split the transcript or trim old turns.`,
       );
     }
 
     const { sessionId, trace, summary } = parseClaudeCodeSession(args.jsonl);
+    if (summary.truncated) {
+      throw new Error("Session exceeds the 50,000-line parser limit. Split the transcript and retry.");
+    }
 
     // Persist through the spine first — it dedups by trace id (`cc-<sessionId>`),
     // so a re-upload short-circuits before any storage write. Auth (project

--- a/convex/csvImport.ts
+++ b/convex/csvImport.ts
@@ -1,0 +1,103 @@
+/** Authenticated mapped-CSV upload into the normalized trajectory spine. */
+import { v } from "convex/values";
+import { action } from "./_generated/server";
+import { api, internal } from "./_generated/api";
+import type { Id } from "./_generated/dataModel";
+import type { AgentRunTrace } from "./lib/agentTrace";
+import {
+  CSV_IMPORT_MAX_ROWS,
+  parseCsvTraceBatch,
+  type CsvTraceSummary,
+} from "./lib/csvTrace";
+
+const MAX_BYTES = 8 * 1024 * 1024;
+const mappingValidator = v.object({
+  inputColumn: v.string(),
+  outputColumn: v.string(),
+  idColumn: v.optional(v.string()),
+  systemColumn: v.optional(v.string()),
+  timestampColumn: v.optional(v.string()),
+  modelColumn: v.optional(v.string()),
+  providerColumn: v.optional(v.string()),
+  harnessColumn: v.optional(v.string()),
+  productColumn: v.optional(v.string()),
+  moduleColumn: v.optional(v.string()),
+  environmentColumn: v.optional(v.string()),
+  privacyClassColumn: v.optional(v.string()),
+  metadataColumns: v.array(v.string()),
+});
+
+/** Content-free result returned by mapped CSV import. */
+export interface CsvImportResult {
+  readonly imported: number;
+  readonly deduped: number;
+  readonly summary: CsvTraceSummary;
+}
+
+/** Parse a mapped CSV file and persist every valid row as one trajectory. */
+export const importMappedCsv = action({
+  args: {
+    projectId: v.id("projects"),
+    csv: v.string(),
+    mapping: mappingValidator,
+  },
+  handler: async (ctx, args): Promise<CsvImportResult> => {
+    await ctx.runQuery(internal.agentTraces.authorizePersist, { projectId: args.projectId });
+    if (new TextEncoder().encode(args.csv).byteLength > MAX_BYTES) {
+      throw new Error("CSV is over the 8 MB upload limit. Split it into smaller batches and retry.");
+    }
+    const batch = parseCsvTraceBatch(args.csv, args.mapping);
+    if (batch.summary.rows > CSV_IMPORT_MAX_ROWS) {
+      throw new Error(
+        `CSV has ${batch.summary.rows} rows; import at most ${CSV_IMPORT_MAX_ROWS} rows per batch.`,
+      );
+    }
+    if (batch.traces.length === 0) {
+      throw new Error("CSV has no valid rows with both mapped input and output values.");
+    }
+
+    const newTraces: Array<{
+      readonly agentTraceId: Id<"agentTraces">;
+      readonly sourceId: string;
+    }> = [];
+    let deduped = 0;
+    for (const item of batch.traces) {
+      const persisted = await ctx.runAction(api.agentTraces.persistTrace, {
+        projectId: args.projectId,
+        trace: item.trace as unknown as AgentRunTrace,
+      });
+      if (persisted.deduped) {
+        deduped++;
+      } else {
+        newTraces.push({
+          agentTraceId: persisted.agentTraceId,
+          sourceId: item.sourceId,
+        });
+      }
+    }
+
+    if (newTraces.length > 0) {
+      const rawPayloadStorageId: Id<"_storage"> = await ctx.storage.store(
+        new Blob([args.csv], { type: "text/csv" }),
+      );
+      for (const item of newTraces) {
+        const traceImportId = await ctx.runMutation(api.traceImports.createImport, {
+          projectId: args.projectId,
+          source: "csv",
+          sourceTraceId: item.sourceId,
+          rawPayloadStorageId,
+        });
+        await ctx.runMutation(internal.agentTraces.linkTraceImport, {
+          agentTraceId: item.agentTraceId,
+          traceImportId,
+        });
+      }
+    }
+
+    return {
+      imported: newTraces.length,
+      deduped,
+      summary: batch.summary,
+    };
+  },
+});

--- a/convex/exports.ts
+++ b/convex/exports.ts
@@ -31,6 +31,7 @@ import {
   renderTranscript,
   moreSensitive,
   type ClassifiedRow,
+  type ExcludedRow,
   type ExportFormat,
   type ExportManifest,
   type ExportSourceStats,
@@ -173,6 +174,7 @@ interface StepRef {
 interface TrajectoryPlanRow {
   privacyClass: PrivacyClass;
   metadata: Record<string, unknown>;
+  excludeReason?: ExcludedRow["reason"];
   prefix?: StepRef[];
   chosen?: StepRef;
   rejected?: StepRef;
@@ -202,26 +204,67 @@ export const gatherTrajectoryPlan = internalQuery({
         .withIndex("by_project", (q) => q.eq("projectId", args.projectId))
         .collect();
       for (const m of matchups) {
-        if (m.winner !== "left" && m.winner !== "right") continue;
-        const winnerId = m.winner === "left" ? m.leftTraceId : m.rightTraceId;
-        const loserId = m.winner === "left" ? m.rightTraceId : m.leftTraceId;
-        const [wt, lt] = [await ctx.db.get(winnerId), await ctx.db.get(loserId)];
-        if (!wt || !lt) continue;
-        const wSteps = await stepsOf(winnerId);
-        const lSteps = await stepsOf(loserId);
-        const chosen = wSteps.find((s) => s.stepIndex === m.divergenceStepIndex);
-        const rejected = lSteps.find((s) => s.stepIndex === m.divergenceStepIndex);
+        const [leftTrace, rightTrace] = await Promise.all([
+          ctx.db.get(m.leftTraceId),
+          ctx.db.get(m.rightTraceId),
+        ]);
+        if (!leftTrace || !rightTrace) continue;
+        const privacyClass = moreSensitive(leftTrace.privacyClass, rightTrace.privacyClass);
+        if (m.comparabilityStatus !== "valid") {
+          plan.push({
+            privacyClass,
+            metadata: {},
+            excludeReason: "non_comparable_prefix",
+          });
+          continue;
+        }
+        const decisions = await ctx.db
+          .query("agentTraceMatchupDecisions")
+          .withIndex("by_matchup", (q) => q.eq("matchupId", m._id))
+          .collect();
+        for (const decision of decisions) reviewerIds.add(decision.userId);
+        const directional = decisions.filter(
+          (decision) => decision.winner === "left" || decision.winner === "right",
+        );
+        if (decisions.some((decision) => decision.winner === "tie" || decision.winner === "skip")) {
+          plan.push({ privacyClass, metadata: {}, excludeReason: "no_preference" });
+          continue;
+        }
+        if (directional.length === 0) continue;
+        const winner = directional[0]?.winner;
+        if (!winner || directional.some((decision) => decision.winner !== winner)) {
+          plan.push({
+            privacyClass,
+            metadata: { reviewer_count: directional.length },
+            excludeReason: "review_disagreement",
+          });
+          continue;
+        }
+        const winnerId = winner === "left" ? m.leftTraceId : m.rightTraceId;
+        const loserId = winner === "left" ? m.rightTraceId : m.leftTraceId;
+        const winnerTrace = winner === "left" ? leftTrace : rightTrace;
+        const loserTrace = winner === "left" ? rightTrace : leftTrace;
+        const [winnerSteps, loserSteps] = await Promise.all([
+          stepsOf(winnerId),
+          stepsOf(loserId),
+        ]);
+        const chosen = winnerSteps.find((step) => step.stepIndex === m.divergenceStepIndex);
+        const rejected = loserSteps.find((step) => step.stepIndex === m.divergenceStepIndex);
         if (!chosen || !rejected) continue;
+        const reasonTags = [...new Set(directional.flatMap((decision) => decision.reasonTags))];
         plan.push({
-          privacyClass: moreSensitive(wt.privacyClass, lt.privacyClass),
-          metadata: { reason_tags: m.reasonTags },
-          prefix: wSteps
-            .filter((s) => s.stepIndex < m.divergenceStepIndex)
-            .map((s) => ({ meta: metaOf(s), storageId: s.fullBodyStorageId })),
+          privacyClass: moreSensitive(winnerTrace.privacyClass, loserTrace.privacyClass),
+          metadata: {
+            reason_tags: reasonTags,
+            reviewer_count: directional.length,
+            prefix_hash_verified: true,
+          },
+          prefix: winnerSteps
+            .filter((step) => step.stepIndex < m.divergenceStepIndex)
+            .map((step) => ({ meta: metaOf(step), storageId: step.fullBodyStorageId })),
           chosen: { meta: metaOf(chosen), storageId: chosen.fullBodyStorageId },
           rejected: { meta: metaOf(rejected), storageId: rejected.fullBodyStorageId },
         });
-        if (m.userId) reviewerIds.add(m.userId);
       }
     } else if (args.format === "sft") {
       const traces = await ctx.db
@@ -235,12 +278,21 @@ export const gatherTrajectoryPlan = internalQuery({
           .withIndex("by_trace", (q) => q.eq("agentTraceId", tr._id))
           .collect();
         if (!verdicts.some((vd) => vd.rating === "best")) continue;
+        if (verdicts.some((vd) => vd.rating === "weak")) {
+          plan.push({
+            privacyClass: tr.privacyClass,
+            metadata: {},
+            excludeReason: "review_disagreement",
+          });
+          for (const verdict of verdicts) reviewerIds.add(verdict.userId);
+          continue;
+        }
         const steps = await stepsOf(tr._id);
         plan.push({
           privacyClass: tr.privacyClass,
           metadata: { verdict: "best" },
           messages: steps
-            .filter((s) => s.kind === "message")
+            .filter((s) => s.kind === "message" && ["system", "user", "assistant"].includes(s.role ?? ""))
             .map((s) => ({ meta: metaOf(s), storageId: s.fullBodyStorageId })),
           finalAnswer: tr.finalAnswerStorageId,
         });
@@ -319,6 +371,7 @@ export const generateExport = action({
     });
 
     let classified: ClassifiedRow[];
+    let sourceExcluded: ExcludedRow[] = [];
     let stats: ExportSourceStats;
     if (args.source === "output_preference") {
       const res = await ctx.runQuery(internal.exports.gatherOutputPrefRows, {
@@ -332,13 +385,17 @@ export const generateExport = action({
         projectId: args.projectId,
         format: args.format,
       });
-      classified = await hydrateTrajectory(ctx, res.plan, args.format);
+      const hydrated = await hydrateTrajectory(ctx, res.plan, args.format);
+      classified = hydrated.rows;
+      sourceExcluded = hydrated.excluded;
       stats = res.stats;
     }
 
-    const { included, excluded } = gateRows(classified, {
+    const gated = gateRows(classified, {
       allowSensitive: args.allowSensitive,
     });
+    const included = gated.included;
+    const excluded = [...sourceExcluded, ...gated.excluded];
     const jsonl = toJsonl(args.format as ExportFormat, included);
     const createdAt = Date.now();
     const manifest = buildExportManifest({
@@ -379,7 +436,7 @@ async function hydrateTrajectory(
   ctx: { storage: { get: (id: Id<"_storage">) => Promise<Blob | null> } },
   plan: TrajectoryPlanRow[],
   format: "dpo" | "sft" | "annotated",
-): Promise<ClassifiedRow[]> {
+): Promise<{ rows: ClassifiedRow[]; excluded: ExcludedRow[] }> {
   const cache = new Map<string, unknown>();
   const read = async (id?: Id<"_storage">): Promise<unknown> => {
     if (!id) return undefined;
@@ -398,7 +455,12 @@ async function hydrateTrajectory(
   };
 
   const out: ClassifiedRow[] = [];
+  const excluded: ExcludedRow[] = [];
   for (const r of plan) {
+    if (r.excludeReason !== undefined) {
+      excluded.push({ reason: r.excludeReason, privacyClass: r.privacyClass });
+      continue;
+    }
     if (format === "dpo" && r.chosen && r.rejected) {
       const prefix = await Promise.all(
         (r.prefix ?? []).map(async (s) => ({ meta: s.meta, body: await read(s.storageId) })),
@@ -417,11 +479,17 @@ async function hydrateTrajectory(
         })),
       );
       const finalBody = (await read(r.finalAnswer)) as Record<string, unknown> | undefined;
-      if (finalBody?.text) msgs.push({ role: "assistant", content: String(finalBody.text) });
+      if (finalBody?.text) {
+        const finalText = String(finalBody.text);
+        const last = msgs[msgs.length - 1];
+        if (last?.role !== "assistant" || last.content !== finalText) {
+          msgs.push({ role: "assistant", content: finalText });
+        }
+      }
       out.push({ privacyClass: r.privacyClass, row: { kind: "sft", messages: msgs, metadata: r.metadata } });
     }
   }
-  return out;
+  return { rows: out, excluded };
 }
 
 // Actions have no ctx.db; resolve the owner/editor caller via an internal query.

--- a/convex/gatewayImport.ts
+++ b/convex/gatewayImport.ts
@@ -134,11 +134,11 @@ export const importGatewayLogs = action({
     sidecarJson: v.optional(v.string()),
   },
   handler: async (ctx, args): Promise<ImportGatewayLogsResult> => {
-    // UTF-16 char length, not exact bytes — a cheap upper-bound guard before
-    // we do any work.
-    if (args.jsonl.length > DEFAULT_LIMITS.maxBytes) {
+    await ctx.runQuery(internal.agentTraces.authorizePersist, { projectId: args.projectId });
+    const inputBytes = new TextEncoder().encode(args.jsonl).byteLength;
+    if (inputBytes > DEFAULT_LIMITS.maxBytes) {
       throw new Error(
-        `Payload too large (${args.jsonl.length} chars, limit ${DEFAULT_LIMITS.maxBytes}). Split the export into smaller batches.`,
+        `Payload too large (${inputBytes} bytes, limit ${DEFAULT_LIMITS.maxBytes}). Split the export into smaller batches.`,
       );
     }
 
@@ -158,6 +158,9 @@ export const importGatewayLogs = action({
       DEFAULT_LIMITS,
       sidecarMap,
     );
+    if (truncated) {
+      throw new Error(`Payload exceeds the ${DEFAULT_LIMITS.maxLines}-line parser limit. Split the export and retry.`);
+    }
 
     const { imported, deduped, newRows }: InsertImportRowsResult =
       await ctx.runMutation(internal.gatewayImport.insertImportRows, {

--- a/convex/invitations.ts
+++ b/convex/invitations.ts
@@ -55,6 +55,7 @@ import { internal } from "./_generated/api";
 import type { Doc, Id } from "./_generated/dataModel";
 import { requireAuth, requireOrgRole, requireProjectRole } from "./lib/auth";
 import { generateToken } from "./lib/crypto";
+import { ensureReviewSessionsForReviewer } from "./lib/traceReviewSessions";
 
 const ORG_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 const PROJECT_TTL_MS = 7 * 24 * 60 * 60 * 1000;
@@ -728,6 +729,9 @@ async function acceptProjectInvite(
     invitedAt: invite.invitedAt,
     acceptedAt: Date.now(),
   });
+  if (projectRole === "evaluator" && (invite.blindMode ?? true)) {
+    await ensureReviewSessionsForReviewer(ctx, projectId, userId);
+  }
 }
 
 async function acceptCycleInvite(
@@ -760,6 +764,12 @@ async function acceptCycleInvite(
       invitedAt: invite.invitedAt,
       acceptedAt: now,
     });
+  }
+  const isBlindEvaluator = existingCollab
+    ? existingCollab.role === "evaluator" && existingCollab.blindMode !== false
+    : (invite.blindMode ?? true);
+  if (isBlindEvaluator) {
+    await ensureReviewSessionsForReviewer(ctx, cycle.projectId, userId);
   }
 
   // Per-cycle workflow status (NOT a membership ring). Tracks the

--- a/convex/lib/claudeCodePreflight.test.ts
+++ b/convex/lib/claudeCodePreflight.test.ts
@@ -91,5 +91,21 @@ describe("Claude Code preflight summary", () => {
     expect(summary.status).toBe("blocked");
     expect(summary.steps).toBe(0);
     expect(summary.caveats.join(" ")).toContain("No reviewable steps");
+    expect(formatClaudeCodePreflightText(summary)).not.toContain("safe_to_upload");
+  });
+
+  test("blocks files over the real 8 MiB importer limit", () => {
+    const summary = summarizeClaudeCodePreflight("x".repeat(8 * 1024 * 1024 + 1));
+    expect(summary.status).toBe("blocked");
+    expect(summary.caveats.join(" ")).toMatch(/8 MiB.*limit/i);
+    expect(formatClaudeCodePreflightText(summary)).toContain("no_data_sent");
+  });
+
+  test("reports when parser line limits truncate the file", () => {
+    const line = JSON.stringify({ type: "mode", mode: "normal", sessionId: SID });
+    const summary = summarizeClaudeCodePreflight(Array.from({ length: 50_001 }, () => line).join("\n"));
+    expect(summary.truncated).toBe(true);
+    expect(summary.status).toBe("blocked");
+    expect(summary.caveats.join(" ")).toMatch(/line limit.*split/i);
   });
 });

--- a/convex/lib/claudeCodePreflight.ts
+++ b/convex/lib/claudeCodePreflight.ts
@@ -11,6 +11,9 @@ export interface ClaudeCodePreflightSummary {
   steps: number;
   invalid: number;
   invalid_lines: number[];
+  truncated: boolean;
+  over_size: boolean;
+  input_bytes: number;
   dropped_meta: number;
   compactions: number;
   merged_messages: number;
@@ -24,6 +27,7 @@ export interface ClaudeCodePreflightSummary {
 }
 
 const MAX_INVALID_LINES = 20;
+export const CLAUDE_CODE_IMPORT_MAX_BYTES = 8 * 1024 * 1024;
 
 function safeRef(value: string | undefined, prefix: string): string | undefined {
   if (!value) return undefined;
@@ -49,6 +53,9 @@ function caveatsFor(summary: ClaudeCodeSummary, trace: AgentRunTrace): string[] 
   if (summary.invalid > 0) {
     caveats.push("Malformed JSONL lines were skipped; inspect the source transcript if counts look wrong.");
   }
+  if (summary.truncated) {
+    caveats.push("Input exceeded the parser line limit; split the transcript before import so no events are silently omitted.");
+  }
   if (summary.droppedMeta > 0) {
     caveats.push("Claude Code sidecar metadata records were dropped because they are not trajectory steps.");
   }
@@ -62,8 +69,30 @@ function caveatsFor(summary: ClaudeCodeSummary, trace: AgentRunTrace): string[] 
 }
 
 export function summarizeClaudeCodePreflight(jsonl: string): ClaudeCodePreflightSummary {
+  const inputBytes = new TextEncoder().encode(jsonl).byteLength;
+  if (inputBytes > CLAUDE_CODE_IMPORT_MAX_BYTES) {
+    return {
+      status: "blocked",
+      trace_ref: "trace-unknown",
+      events: 0,
+      steps: 0,
+      invalid: 0,
+      invalid_lines: [],
+      truncated: false,
+      over_size: true,
+      input_bytes: inputBytes,
+      dropped_meta: 0,
+      compactions: 0,
+      merged_messages: 0,
+      models: [],
+      privacy_class: "unknown",
+      redaction_detected: false,
+      step_kind_counts: {},
+      caveats: ["Input exceeds the authenticated importer's 8 MiB file limit; split the transcript before import."],
+    };
+  }
   const { sessionId, trace, summary } = parseClaudeCodeSession(jsonl);
-  const status: ClaudeCodePreflightStatus = trace.steps.length > 0 ? "ready" : "blocked";
+  const status: ClaudeCodePreflightStatus = trace.steps.length > 0 && !summary.truncated ? "ready" : "blocked";
 
   return {
     status,
@@ -73,6 +102,9 @@ export function summarizeClaudeCodePreflight(jsonl: string): ClaudeCodePreflight
     steps: summary.steps,
     invalid: summary.invalid,
     invalid_lines: summary.invalidLines.slice(0, MAX_INVALID_LINES),
+    truncated: summary.truncated,
+    over_size: false,
+    input_bytes: inputBytes,
     dropped_meta: summary.droppedMeta,
     compactions: summary.compactions,
     merged_messages: summary.mergedMessages,
@@ -97,6 +129,9 @@ export function formatClaudeCodePreflightText(summary: ClaudeCodePreflightSummar
   lines.push(`models: ${summary.models.length ? summary.models.join(", ") : "unknown"}`);
   lines.push(`time_bounds: ${summary.earliest ?? "unknown"} → ${summary.latest ?? "unknown"}`);
   lines.push(`invalid_lines: ${summary.invalid}${summary.invalid_lines.length ? ` (${summary.invalid_lines.join(", ")})` : ""}`);
+  lines.push(`truncated: ${summary.truncated}`);
+  lines.push(`over_size: ${summary.over_size}`);
+  lines.push(`input_bytes: ${summary.input_bytes}`);
   lines.push(`dropped_meta: ${summary.dropped_meta}`);
   lines.push(`compactions: ${summary.compactions}`);
   lines.push(`merged_messages: ${summary.merged_messages}`);
@@ -111,7 +146,9 @@ export function formatClaudeCodePreflightText(summary: ClaudeCodePreflightSummar
     lines.push("caveats:");
     for (const caveat of summary.caveats) lines.push(`- ${caveat}`);
   }
-  lines.push("safe_to_upload: use the authenticated app import next; this preflight did not send data anywhere.");
+  lines.push(summary.status === "ready"
+    ? "safe_to_upload: use the authenticated app import next; this preflight did not send data anywhere."
+    : "no_data_sent: preflight is blocked; resolve the caveats before using authenticated import.");
   return lines.join("\n") + "\n";
 }
 

--- a/convex/lib/claudeCodeTrace.ts
+++ b/convex/lib/claudeCodeTrace.ts
@@ -30,6 +30,7 @@ export interface ClaudeCodeSummary {
   events: number;
   steps: number;
   invalid: number;
+  truncated: boolean;
   invalidLines: number[];
   droppedMeta: number;
   compactions: number;
@@ -207,6 +208,7 @@ export function parseClaudeCodeSession(
       events: events.length,
       steps: steps.length,
       invalid: invalidLines.length,
+      truncated: lines.length > maxLines,
       invalidLines: invalidLines.slice(0, 100),
       droppedMeta,
       compactions,

--- a/convex/lib/csvTrace.ts
+++ b/convex/lib/csvTrace.ts
@@ -1,0 +1,2 @@
+/** Convex bundle entry point for the shared mapped-CSV trajectory adapter. */
+export * from "../../src/lib/evals/csvTrace.core";

--- a/convex/lib/otelGenAI.ts
+++ b/convex/lib/otelGenAI.ts
@@ -20,6 +20,7 @@ import { redactValue } from "./agentTrace";
 export interface OtelIngestSummary {
   traces: number;
   spans: number;
+  ignoredSpans: number;
   steps: number;
   requestMissing: number;
   responseMissing: number;
@@ -152,6 +153,7 @@ export function mapOtlpToTraces(payload: unknown): OtelMapResult {
   const summary: OtelIngestSummary = {
     traces: 0,
     spans: 0,
+    ignoredSpans: 0,
     steps: 0,
     requestMissing: 0,
     responseMissing: 0,
@@ -166,6 +168,12 @@ export function mapOtlpToTraces(payload: unknown): OtelMapResult {
       for (const s of arr(rec(ss)?.spans)) {
         const span = rec(s);
         if (!span) continue;
+        const attrs = flattenAttrs(span.attributes);
+        const isGenAiSpan = Object.keys(attrs).some((key) => key.startsWith("gen_ai."));
+        if (!isGenAiSpan) {
+          summary.ignoredSpans++;
+          continue;
+        }
         summary.spans++;
         const traceId = str(span.traceId) ?? str(span.trace_id) ?? `otlp-${summary.spans}`;
         (byTrace.get(traceId) ?? byTrace.set(traceId, []).get(traceId)!).push(span);
@@ -252,5 +260,6 @@ export function mapOtlpToTraces(payload: unknown): OtelMapResult {
   }
 
   summary.models = [...models];
+  summary.invalid = summary.traces === 0;
   return { traces, summary };
 }

--- a/convex/lib/piTrace.ts
+++ b/convex/lib/piTrace.ts
@@ -1,0 +1,449 @@
+/**
+ * Pi session JSONL → normalized trajectory parser.
+ *
+ * Pi v3 sessions are trees, not flat transcripts. The active session is the
+ * path from the last tree entry back to `parentId: null`; abandoned branches
+ * are deliberately excluded so one uploaded file becomes one coherent run.
+ */
+import type {
+  AgentRunTrace,
+  AgentTraceStep,
+  PrivacyClass,
+} from "./agentTrace";
+import { redactValue } from "./agentTrace";
+
+/** Management-safe import summary; never contains message or tool content. */
+export interface PiSessionSummary {
+  readonly entries: number;
+  readonly activeEntries: number;
+  readonly branchesExcluded: number;
+  readonly steps: number;
+  readonly invalid: number;
+  readonly truncated: boolean;
+  readonly invalidLines: ReadonlyArray<number>;
+  readonly compactions: number;
+  readonly models: ReadonlyArray<string>;
+  readonly earliest?: string;
+  readonly latest?: string;
+}
+
+/** Parsed Pi session plus the normalized trajectory ready for persistence. */
+export interface PiSessionParseResult {
+  readonly sessionId: string;
+  readonly trace: AgentRunTrace;
+  readonly summary: PiSessionSummary;
+}
+
+type JsonRecord = Record<string, unknown>;
+
+type PartialStep = AgentTraceStep extends infer Step
+  ? Step extends AgentTraceStep
+    ? Omit<Step, "index">
+    : never
+  : never;
+
+type ParsedEntry = {
+  readonly id: string;
+  readonly parentId: string | null;
+  readonly type: string;
+  readonly timestamp?: string;
+  readonly raw: JsonRecord;
+};
+
+const asRecord = (value: unknown): JsonRecord | undefined =>
+  value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as JsonRecord)
+    : undefined;
+
+const asString = (value: unknown): string | undefined =>
+  typeof value === "string" && value.length > 0 ? value : undefined;
+
+const asFiniteNumber = (value: unknown): number | undefined =>
+  typeof value === "number" && Number.isFinite(value) ? value : undefined;
+
+const privacyClassOf = (value: unknown): PrivacyClass =>
+  JSON.stringify(value ?? null).includes("[REDACTED]") ? "pii" : "internal";
+
+const contentText = (content: unknown): string | undefined => {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return undefined;
+  const parts: string[] = [];
+  for (const item of content) {
+    const block = asRecord(item);
+    if (block?.type === "text" && typeof block.text === "string") {
+      parts.push(block.text);
+    }
+  }
+  return parts.length > 0 ? parts.join("\n") : undefined;
+};
+
+const toTimestamp = (entry: ParsedEntry, message: JsonRecord | undefined): string | undefined => {
+  if (entry.timestamp !== undefined) return entry.timestamp;
+  const timestampMs = asFiniteNumber(message?.timestamp);
+  return timestampMs === undefined ? undefined : new Date(timestampMs).toISOString();
+};
+
+/**
+ * Parse one saved Pi v3 session JSONL file into a single active-path trace.
+ * Malformed unrelated lines are counted, while a malformed active tree is
+ * rejected because silently splicing branches would corrupt review evidence.
+ */
+export function parsePiSession(
+  jsonl: string,
+  options: { readonly maxLines?: number } = {},
+): PiSessionParseResult {
+  const maxLines = options.maxLines ?? 50_000;
+  const lines = jsonl.split("\n");
+  const invalidLines: number[] = [];
+  const entries: ParsedEntry[] = [];
+  const entriesById = new Map<string, ParsedEntry>();
+  let header: JsonRecord | undefined;
+
+  for (let index = 0; index < lines.length && index < maxLines; index++) {
+    const line = lines[index]?.trim();
+    if (!line) continue;
+    let rawValue: unknown;
+    try {
+      rawValue = JSON.parse(line);
+    } catch {
+      invalidLines.push(index + 1);
+      continue;
+    }
+    const raw = asRecord(rawValue);
+    if (!raw) {
+      invalidLines.push(index + 1);
+      continue;
+    }
+    if (raw.type === "session") {
+      header ??= raw;
+      continue;
+    }
+    const id = asString(raw.id);
+    const type = asString(raw.type);
+    const parentValue = raw.parentId;
+    let parentId: string | null;
+    if (parentValue === null) {
+      parentId = null;
+    } else {
+      const parsedParentId = asString(parentValue);
+      if (parsedParentId === undefined) {
+        invalidLines.push(index + 1);
+        continue;
+      }
+      parentId = parsedParentId;
+    }
+    if (!id || !type) {
+      invalidLines.push(index + 1);
+      continue;
+    }
+    if (entriesById.has(id)) {
+      invalidLines.push(index + 1);
+      continue;
+    }
+    const entry: ParsedEntry = {
+      id,
+      parentId,
+      type,
+      timestamp: asString(raw.timestamp),
+      raw,
+    };
+    entries.push(entry);
+    entriesById.set(id, entry);
+  }
+
+  const sessionId = asString(header?.id);
+  if (!header || !sessionId) {
+    throw new Error("Pi session is missing a valid session header and id.");
+  }
+  const leaf = entries[entries.length - 1];
+  if (!leaf) {
+    throw new Error("Pi session contains no tree entries.");
+  }
+
+  const reversePath: ParsedEntry[] = [];
+  const visited = new Set<string>();
+  let cursor: ParsedEntry | undefined = leaf;
+  while (cursor) {
+    if (visited.has(cursor.id)) {
+      throw new Error("Pi session active path contains a parent cycle.");
+    }
+    visited.add(cursor.id);
+    reversePath.push(cursor);
+    if (cursor.parentId === null) break;
+    const parent = entriesById.get(cursor.parentId);
+    if (!parent) {
+      throw new Error(`Pi session active path has missing parent for entry ${cursor.id}.`);
+    }
+    cursor = parent;
+  }
+  const activeEntries = reversePath.reverse();
+
+  const steps: AgentTraceStep[] = [];
+  const models = new Set<string>();
+  let currentModel: string | undefined;
+  let totalTokens = 0;
+  let costUsd = 0;
+  let compactions = 0;
+  let earliest: string | undefined;
+  let latest: string | undefined;
+  let finalAnswer: string | undefined;
+
+  const append = (step: PartialStep): void => {
+    steps.push({ ...step, index: steps.length } as AgentTraceStep);
+  };
+
+  for (const entry of activeEntries) {
+    if (entry.timestamp !== undefined) {
+      if (earliest === undefined || entry.timestamp < earliest) earliest = entry.timestamp;
+      if (latest === undefined || entry.timestamp > latest) latest = entry.timestamp;
+    }
+
+    if (entry.type === "model_change") {
+      const provider = asString(entry.raw.provider);
+      const model = asString(entry.raw.modelId);
+      if (model !== undefined) {
+        models.add(model);
+        currentModel = model;
+      }
+      append({
+        type: "state",
+        timestamp: entry.timestamp,
+        label: "model_change",
+        snapshot: { provider, model },
+        redacted_snapshot: { changed: true },
+        privacy_class: "internal",
+      });
+      continue;
+    }
+
+    if (entry.type === "compaction") {
+      compactions++;
+      append({
+        type: "policy_event",
+        timestamp: entry.timestamp,
+        policy: "context",
+        action: "compact",
+        reason: "session_compaction",
+      });
+      continue;
+    }
+
+    if (entry.type === "branch_summary") {
+      append({
+        type: "policy_event",
+        timestamp: entry.timestamp,
+        policy: "context",
+        action: "branch_summary",
+        reason: "tree_navigation",
+      });
+      continue;
+    }
+
+    if (entry.type === "thinking_level_change") {
+      append({
+        type: "state",
+        timestamp: entry.timestamp,
+        label: "thinking_level_change",
+        snapshot: { thinkingLevel: asString(entry.raw.thinkingLevel) },
+        redacted_snapshot: { changed: true },
+        privacy_class: "internal",
+      });
+      continue;
+    }
+
+    if (entry.type === "custom_message") {
+      const content = contentText(entry.raw.content);
+      if (content !== undefined) {
+        append({
+          type: "message",
+          timestamp: entry.timestamp,
+          message: { role: "custom", content },
+        });
+      }
+      continue;
+    }
+
+    if (entry.type !== "message") continue;
+    const message = asRecord(entry.raw.message);
+    const role = asString(message?.role);
+    const timestamp = toTimestamp(entry, message);
+    if (!message || !role) continue;
+
+    if (role === "assistant") {
+      const model = asString(message.model);
+      if (model !== undefined) {
+        models.add(model);
+        currentModel = model;
+      }
+      const usage = asRecord(message.usage);
+      totalTokens +=
+        asFiniteNumber(usage?.totalTokens) ??
+        ((asFiniteNumber(usage?.input) ?? 0) + (asFiniteNumber(usage?.output) ?? 0));
+      costUsd += asFiniteNumber(asRecord(usage?.cost)?.total) ?? 0;
+
+      const content = message.content;
+      if (Array.isArray(content)) {
+        const thinkingParts: string[] = [];
+        const textParts: string[] = [];
+        const toolCalls: Array<{
+          readonly timestamp?: string;
+          readonly toolCallId: string;
+          readonly name: string;
+          readonly args: JsonRecord;
+          readonly redactedArgs: JsonRecord;
+          readonly privacyClass: PrivacyClass;
+        }> = [];
+        for (const rawBlock of content) {
+          const block = asRecord(rawBlock);
+          const blockType = asString(block?.type);
+          if (blockType === "thinking" && typeof block?.thinking === "string") {
+            thinkingParts.push(block.thinking);
+          } else if (blockType === "text" && typeof block?.text === "string") {
+            textParts.push(block.text);
+          } else if (blockType === "toolCall") {
+            const args = asRecord(block?.arguments) ?? {};
+            const redacted = (redactValue(args, "blind_view") as JsonRecord | undefined) ?? {};
+            toolCalls.push({
+              timestamp,
+              toolCallId: asString(block?.id) ?? `tool-${steps.length}`,
+              name: asString(block?.name) ?? "unknown_tool",
+              args,
+              redactedArgs: redacted,
+              privacyClass: privacyClassOf(redacted),
+            });
+          }
+        }
+        if (thinkingParts.length > 0) {
+          append({
+            type: "message",
+            timestamp,
+            message: { role: "thinking", content: thinkingParts.join("\n") },
+          });
+        }
+        if (textParts.length > 0) {
+          const text = textParts.join("\n");
+          append({ type: "message", timestamp, message: { role, content: text } });
+          finalAnswer = text;
+        }
+        for (const toolCall of toolCalls) {
+          append({
+            type: "tool_call",
+            timestamp: toolCall.timestamp,
+            tool_call_id: toolCall.toolCallId,
+            name: toolCall.name,
+            args: toolCall.args,
+            redacted_args: toolCall.redactedArgs,
+            privacy_class: toolCall.privacyClass,
+          });
+        }
+      }
+      if (message.stopReason === "error" && typeof message.errorMessage === "string") {
+        const snapshot = { errorMessage: message.errorMessage };
+        append({
+          type: "state",
+          timestamp,
+          label: "assistant_error",
+          snapshot,
+          redacted_snapshot: redactValue(snapshot, "blind_view") as JsonRecord,
+          privacy_class: privacyClassOf(redactValue(snapshot, "blind_view")),
+        });
+      }
+      continue;
+    }
+
+    if (role === "toolResult") {
+      const result = message.content;
+      const redacted = redactValue(result, "blind_view");
+      append({
+        type: "tool_result",
+        timestamp,
+        tool_call_id: asString(message.toolCallId) ?? `tool-${steps.length}`,
+        name: asString(message.toolName),
+        result,
+        redacted_result: redacted,
+        privacy_class: privacyClassOf(redacted),
+      });
+      continue;
+    }
+
+    if (role === "bashExecution") {
+      const callId = `bash-${entry.id}`;
+      const command = asString(message.command) ?? "";
+      const output = asString(message.output) ?? "";
+      append({
+        type: "tool_call",
+        timestamp,
+        tool_call_id: callId,
+        name: "bash",
+        args: { command },
+        redacted_args: redactValue({ command }, "blind_view") as JsonRecord,
+        privacy_class: privacyClassOf(redactValue({ command }, "blind_view")),
+      });
+      append({
+        type: "tool_result",
+        timestamp,
+        tool_call_id: callId,
+        name: "bash",
+        result: { output, exitCode: message.exitCode, cancelled: message.cancelled },
+        redacted_result: redactValue(
+          { output, exitCode: message.exitCode, cancelled: message.cancelled },
+          "blind_view",
+        ),
+        privacy_class: privacyClassOf(output),
+      });
+      continue;
+    }
+
+    const text = contentText(message.content);
+    if (text !== undefined) {
+      append({ type: "message", timestamp, message: { role, content: text } });
+    }
+  }
+
+  const anyPii = steps.some(
+    (step) => "privacy_class" in step && step.privacy_class === "pii",
+  );
+  const cwd = asString(header.cwd);
+  const version = header.version === undefined ? undefined : String(header.version);
+
+  return {
+    sessionId,
+    trace: {
+      trace_id: `pi-${sessionId}`,
+      source: "agent_harness",
+      harness: { name: "pi", version, sdk: "pi_session_jsonl" },
+      product: cwd?.split("/").filter((part) => part.length > 0).pop() ?? "pi",
+      module: "pi_session",
+      model: currentModel,
+      run_id: sessionId,
+      source_ids: { sessionId },
+      messages: [],
+      steps,
+      final_answer: finalAnswer,
+      usage: {
+        total_tokens: totalTokens || undefined,
+        cost_usd: costUsd || undefined,
+      },
+      privacy: {
+        class: anyPii ? "pii" : "internal",
+        redaction_notes: anyPii
+          ? ["sensitive Pi tool and result fields redacted for blind/reviewer views"]
+          : [],
+      },
+      metadata: { sessionId, cwd, version, format: "pi_session_v3" },
+    },
+    summary: {
+      entries: entries.length,
+      activeEntries: activeEntries.length,
+      branchesExcluded: entries.length - activeEntries.length,
+      steps: steps.length,
+      invalid: invalidLines.length,
+      truncated: lines.length > maxLines,
+      invalidLines: invalidLines.slice(0, 100),
+      compactions,
+      models: [...models],
+      earliest,
+      latest,
+    },
+  };
+}

--- a/convex/lib/traceReviewSessions.ts
+++ b/convex/lib/traceReviewSessions.ts
@@ -1,0 +1,112 @@
+/** Stored opaque review-session creation for trace and matchup reviewer routes. */
+import type { Doc, Id } from "../_generated/dataModel";
+import type { MutationCtx } from "../_generated/server";
+import { generateToken } from "./crypto";
+
+const isBlindEvaluator = (collaborator: Doc<"projectCollaborators">): boolean =>
+  collaborator.role === "evaluator" && collaborator.blindMode !== false;
+
+/** Ensure one opaque trace-review session exists for one blind reviewer. */
+export async function ensureTraceReviewSession(
+  ctx: MutationCtx,
+  agentTraceId: Id<"agentTraces">,
+  projectId: Id<"projects">,
+  reviewerUserId: Id<"users">,
+): Promise<Id<"agentTraceReviewSessions">> {
+  const existing = await ctx.db
+    .query("agentTraceReviewSessions")
+    .withIndex("by_trace_and_reviewer", (q) =>
+      q.eq("agentTraceId", agentTraceId).eq("reviewerUserId", reviewerUserId),
+    )
+    .unique();
+  if (existing) return existing._id;
+  return await ctx.db.insert("agentTraceReviewSessions", {
+    projectId,
+    reviewerUserId,
+    token: generateToken(),
+    kind: "trace",
+    agentTraceId,
+  });
+}
+
+/** Ensure one opaque matchup-review session exists for one blind reviewer. */
+export async function ensureMatchupReviewSession(
+  ctx: MutationCtx,
+  matchupId: Id<"agentTraceMatchups">,
+  projectId: Id<"projects">,
+  reviewerUserId: Id<"users">,
+): Promise<Id<"agentTraceReviewSessions">> {
+  const existing = await ctx.db
+    .query("agentTraceReviewSessions")
+    .withIndex("by_matchup_and_reviewer", (q) =>
+      q.eq("matchupId", matchupId).eq("reviewerUserId", reviewerUserId),
+    )
+    .unique();
+  if (existing) return existing._id;
+  const token = generateToken();
+  return await ctx.db.insert("agentTraceReviewSessions", {
+    projectId,
+    reviewerUserId,
+    token,
+    kind: "matchup",
+    leftFirst: token.charCodeAt(token.length - 1) % 2 === 0,
+    matchupId,
+  });
+}
+
+/** Create sessions for every current blind reviewer when a trace becomes ready. */
+export async function ensureTraceSessionsForProjectReviewers(
+  ctx: MutationCtx,
+  agentTraceId: Id<"agentTraces">,
+  projectId: Id<"projects">,
+): Promise<void> {
+  const collaborators = await ctx.db
+    .query("projectCollaborators")
+    .withIndex("by_project", (q) => q.eq("projectId", projectId))
+    .collect();
+  for (const collaborator of collaborators) {
+    if (!isBlindEvaluator(collaborator)) continue;
+    await ensureTraceReviewSession(ctx, agentTraceId, projectId, collaborator.userId);
+  }
+}
+
+/** Create sessions for every current blind reviewer when a valid matchup is created. */
+export async function ensureMatchupSessionsForProjectReviewers(
+  ctx: MutationCtx,
+  matchupId: Id<"agentTraceMatchups">,
+  projectId: Id<"projects">,
+): Promise<void> {
+  const collaborators = await ctx.db
+    .query("projectCollaborators")
+    .withIndex("by_project", (q) => q.eq("projectId", projectId))
+    .collect();
+  for (const collaborator of collaborators) {
+    if (!isBlindEvaluator(collaborator)) continue;
+    await ensureMatchupReviewSession(ctx, matchupId, projectId, collaborator.userId);
+  }
+}
+
+/** Backfill sessions for existing ready artifacts when a new blind reviewer joins. */
+export async function ensureReviewSessionsForReviewer(
+  ctx: MutationCtx,
+  projectId: Id<"projects">,
+  reviewerUserId: Id<"users">,
+): Promise<void> {
+  const traces = await ctx.db
+    .query("agentTraces")
+    .withIndex("by_project_and_status", (q) =>
+      q.eq("projectId", projectId).eq("status", "ready"),
+    )
+    .collect();
+  for (const trace of traces) {
+    await ensureTraceReviewSession(ctx, trace._id, projectId, reviewerUserId);
+  }
+  const matchups = await ctx.db
+    .query("agentTraceMatchups")
+    .withIndex("by_project", (q) => q.eq("projectId", projectId))
+    .collect();
+  for (const matchup of matchups) {
+    if (matchup.comparabilityStatus !== "valid") continue;
+    await ensureMatchupReviewSession(ctx, matchup._id, projectId, reviewerUserId);
+  }
+}

--- a/convex/lib/trainingExport.ts
+++ b/convex/lib/trainingExport.ts
@@ -70,7 +70,15 @@ export interface ClassifiedRow {
 }
 
 export interface ExcludedRow {
-  reason: "prod_sensitive" | "pii_leak" | "empty" | "degenerate";
+  reason:
+    | "prod_sensitive"
+    | "pii_leak"
+    | "empty"
+    | "degenerate"
+    | "non_comparable_prefix"
+    | "review_disagreement"
+    | "no_preference"
+    | "invalid_sft_shape";
   privacyClass: PrivacyClass;
 }
 
@@ -124,6 +132,14 @@ export function gateRows(
   for (const { row, privacyClass } of rows) {
     if (isEmptyRow(row)) {
       excluded.push({ reason: "empty", privacyClass });
+      continue;
+    }
+    if (
+      row.kind === "sft" &&
+      (row.messages.some((message) => !["system", "user", "assistant"].includes(message.role)) ||
+        row.messages[row.messages.length - 1]?.role !== "assistant")
+    ) {
+      excluded.push({ reason: "invalid_sft_shape", privacyClass });
       continue;
     }
     if (SENSITIVE_CLASSES.has(privacyClass) && !opts.allowSensitive) {
@@ -253,7 +269,7 @@ export function buildExportManifest(input: {
   const notes: string[] = [];
   if (format === "dpo") {
     notes.push(
-      "DPO rows are emitted only for comparable chosen/rejected pairs; a pair whose chosen and rejected text are identical carries no preference signal and is excluded (degenerate) rather than written.",
+      "Trajectory DPO rows require a persisted SHA-256 shared-prefix proof and an unambiguous directional reviewer decision. Prefix mismatches, reviewer disagreement, ties/skips, and identical chosen/rejected text are excluded with explicit reasons.",
     );
     if (included.length === 0)
       notes.push(
@@ -262,8 +278,11 @@ export function buildExportManifest(input: {
   }
   if (format === "sft") {
     notes.push(
-      "SFT rows use the OpenAI/Fireworks chat shape { messages: [{ role, content }] }; only best-rated outputs/trajectories are included.",
+      "SFT rows use the OpenAI/Fireworks chat shape { messages: [{ role, content }] }; roles are limited to system/user/assistant, the final turn is assistant, and only unambiguously best-rated outputs/trajectories are included.",
     );
+    if ((byReason.invalid_sft_shape ?? 0) > 0) {
+      notes.push(`${byReason.invalid_sft_shape} row(s) excluded because the chat roles or final assistant turn were invalid.`);
+    }
   }
   if ((byReason.prod_sensitive ?? 0) > 0 && !allowSensitive)
     notes.push(
@@ -272,6 +291,18 @@ export function buildExportManifest(input: {
   if ((byReason.pii_leak ?? 0) > 0)
     notes.push(
       `${byReason.pii_leak} row(s) excluded by the PII/secret leak scan even though their privacy class was allowed.`,
+    );
+  if ((byReason.non_comparable_prefix ?? 0) > 0)
+    notes.push(
+      `${byReason.non_comparable_prefix} trajectory matchup(s) excluded because the chosen/rejected prefixes did not share the same persisted hash.`,
+    );
+  if ((byReason.review_disagreement ?? 0) > 0)
+    notes.push(
+      `${byReason.review_disagreement} trajectory matchup(s) excluded because reviewers selected different winners.`,
+    );
+  if ((byReason.no_preference ?? 0) > 0)
+    notes.push(
+      `${byReason.no_preference} trajectory matchup(s) excluded because reviewers only tied or skipped the pair.`,
     );
   notes.push(
     "Source trace/run ids are omitted by design — exports are anonymized by construction; source_units and reviewers are aggregate counts only.",

--- a/convex/otlpFileImport.ts
+++ b/convex/otlpFileImport.ts
@@ -1,0 +1,84 @@
+/** Authenticated OTLP/HTTP JSON file upload using the live endpoint's mapper. */
+import { v } from "convex/values";
+import { action } from "./_generated/server";
+import { api, internal } from "./_generated/api";
+import type { Id } from "./_generated/dataModel";
+import type { AgentRunTrace } from "./lib/agentTrace";
+import {
+  mapOtlpToTraces,
+  type OtelIngestSummary,
+} from "./lib/otelGenAI";
+import { MAX_BYTES } from "./otlpIngest";
+
+/** Content-free result returned by authenticated OTLP file import. */
+export interface OtlpFileImportResult {
+  readonly imported: number;
+  readonly deduped: number;
+  readonly summary: OtelIngestSummary;
+}
+
+/** Parse one captured OTLP JSON request and persist its GenAI trajectories. */
+export const importOtlpJson = action({
+  args: {
+    projectId: v.id("projects"),
+    json: v.string(),
+  },
+  handler: async (ctx, args): Promise<OtlpFileImportResult> => {
+    await ctx.runQuery(internal.agentTraces.authorizePersist, { projectId: args.projectId });
+    if (new TextEncoder().encode(args.json).byteLength > MAX_BYTES) {
+      throw new Error("OTLP file is over the 8 MB upload limit. Split the captured batch and retry.");
+    }
+    let payload: unknown;
+    try {
+      payload = JSON.parse(args.json);
+    } catch {
+      throw new Error("OTLP file is not valid JSON.");
+    }
+    const { traces, summary } = mapOtlpToTraces(payload);
+    if (traces.length === 0) {
+      throw new Error(
+        "OTLP file contains no GenAI spans. Check that the exporter includes gen_ai.* attributes.",
+      );
+    }
+
+    const newTraces: Array<{
+      readonly agentTraceId: Id<"agentTraces">;
+      readonly sourceId: string;
+    }> = [];
+    let deduped = 0;
+    for (const trace of traces) {
+      const persisted = await ctx.runAction(api.agentTraces.persistTrace, {
+        projectId: args.projectId,
+        trace: trace as unknown as AgentRunTrace,
+      });
+      if (persisted.deduped) {
+        deduped++;
+      } else {
+        newTraces.push({
+          agentTraceId: persisted.agentTraceId,
+          sourceId: trace.run_id ?? trace.trace_id,
+        });
+      }
+    }
+
+    if (newTraces.length > 0) {
+      const rawPayloadStorageId: Id<"_storage"> = await ctx.storage.store(
+        new Blob([args.json], { type: "application/json" }),
+      );
+      for (const item of newTraces) {
+        const traceImportId = await ctx.runMutation(api.traceImports.createImport, {
+          projectId: args.projectId,
+          source: "otlp",
+          sourceTraceId: item.sourceId,
+          rawPayloadStorageId,
+        });
+        await ctx.runMutation(internal.agentTraces.linkTraceImport, {
+          agentTraceId: item.agentTraceId,
+          traceImportId,
+        });
+      }
+    }
+
+    return { imported: newTraces.length, deduped, summary };
+  },
+});

--- a/convex/otlpIngest.ts
+++ b/convex/otlpIngest.ts
@@ -101,7 +101,7 @@ export const otlpIngestHandler = httpAction(async (ctx, req) => {
   if (!resolved) return json({ error: "Invalid or revoked ingest token" }, 401);
 
   const body = await req.text();
-  if (body.length > MAX_BYTES) return json({ error: "Payload too large" }, 413);
+  if (new TextEncoder().encode(body).byteLength > MAX_BYTES) return json({ error: "Payload too large" }, 413);
   let payload: unknown;
   try {
     payload = JSON.parse(body);

--- a/convex/piImport.ts
+++ b/convex/piImport.ts
@@ -1,0 +1,61 @@
+/**
+ * Authenticated Pi session JSONL import. Blind Bench reads Pi's saved session
+ * artifact; it never launches Pi or receives model-provider credentials.
+ */
+import { v } from "convex/values";
+import { action } from "./_generated/server";
+import { api, internal } from "./_generated/api";
+import type { Id } from "./_generated/dataModel";
+import type { AgentRunTrace } from "./lib/agentTrace";
+import { parsePiSession, type PiSessionSummary } from "./lib/piTrace";
+
+const MAX_BYTES = 8 * 1024 * 1024;
+
+/** Safe result returned after importing a Pi session file. */
+export interface PiImportResult {
+  readonly deduped: boolean;
+  readonly summary: PiSessionSummary;
+}
+
+/** Parse and persist one saved Pi session as one normalized trajectory. */
+export const importPiSession = action({
+  args: {
+    projectId: v.id("projects"),
+    jsonl: v.string(),
+  },
+  handler: async (ctx, args): Promise<PiImportResult> => {
+    await ctx.runQuery(internal.agentTraces.authorizePersist, { projectId: args.projectId });
+    const inputBytes = new TextEncoder().encode(args.jsonl).byteLength;
+    if (inputBytes > MAX_BYTES) {
+      throw new Error(
+        `Pi session is too large (${inputBytes} bytes, limit ${MAX_BYTES}). Trim old branches and retry.`,
+      );
+    }
+
+    const { sessionId, trace, summary } = parsePiSession(args.jsonl);
+    if (summary.truncated) {
+      throw new Error("Pi session exceeds the 50,000-line parser limit. Split the session and retry.");
+    }
+    const persisted = await ctx.runAction(api.agentTraces.persistTrace, {
+      projectId: args.projectId,
+      trace: trace as unknown as AgentRunTrace,
+    });
+    if (persisted.deduped) return { deduped: true, summary };
+
+    const rawPayloadStorageId: Id<"_storage"> = await ctx.storage.store(
+      new Blob([args.jsonl], { type: "application/x-ndjson" }),
+    );
+    const traceImportId = await ctx.runMutation(api.traceImports.createImport, {
+      projectId: args.projectId,
+      source: "pi",
+      sourceTraceId: sessionId,
+      rawPayloadStorageId,
+    });
+    await ctx.runMutation(internal.agentTraces.linkTraceImport, {
+      agentTraceId: persisted.agentTraceId,
+      traceImportId,
+    });
+
+    return { deduped: false, summary };
+  },
+});

--- a/convex/projects.ts
+++ b/convex/projects.ts
@@ -8,6 +8,7 @@ import {
 } from "./lib/auth";
 import { safeDeleteTestCaseBlob } from "./lib/storageCleanup";
 import { genMessageId } from "./lib/messages";
+import { ensureReviewSessionsForReviewer } from "./lib/traceReviewSessions";
 import {
   createPersonalOrg,
   findUserOwnedOrg,
@@ -236,7 +237,40 @@ export const createWithPrompt = mutation({
   },
 });
 
-// ===== M29.4: Welcome-screen entrypoints =====
+// ===== Welcome-screen entrypoints =====
+
+/**
+ * Ingestion-first welcome path. Creates a personal workspace and an empty
+ * project without manufacturing a prompt version, then routes the user to the
+ * completed-run import surface.
+ */
+export const createForImport = mutation({
+  args: { name: v.optional(v.string()) },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx);
+    const { org, orgId } = await ensurePersonalOrgFor(ctx, userId);
+    const name = args.name?.trim() || "Agent evaluations";
+    const projectId = await ctx.db.insert("projects", {
+      organizationId: orgId,
+      name,
+      createdById: userId,
+    });
+    await ctx.db.insert("projectCollaborators", {
+      projectId,
+      userId,
+      role: "owner",
+      invitedById: userId,
+      invitedAt: Date.now(),
+      acceptedAt: Date.now(),
+    });
+    await ctx.scheduler.runAfter(0, internal.analyticsActions.track, {
+      event: "welcome create for import",
+      distinctId: userId as string,
+      properties: { project_id: projectId as string, org_id: orgId as string },
+    });
+    return { orgSlug: org.slug, projectId };
+  },
+});
 
 const WELCOME_VARIABLE_REGEX = /\{\{(\w+)\}\}/g;
 
@@ -576,6 +610,9 @@ export const inviteCollaborator = mutation({
       invitedAt: Date.now(),
       acceptedAt: Date.now(), // Instant invite for M1
     });
+    if (args.role === "evaluator") {
+      await ensureReviewSessionsForReviewer(ctx, args.projectId, args.userId);
+    }
   },
 });
 
@@ -615,6 +652,9 @@ export const updateCollaboratorRole = mutation({
     }
 
     await ctx.db.patch(collab._id, { role: args.role });
+    if (args.role === "evaluator") {
+      await ensureReviewSessionsForReviewer(ctx, args.projectId, args.userId);
+    }
   },
 });
 

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -636,8 +636,12 @@ const schema = defineSchema({
       v.literal("promptlayer"),
       v.literal("manual_paste"),
       v.literal("cloudflare_ai_gateway"),
-      // #265: Claude Code session .jsonl upload — first trajectory ingestion.
+      // Coding-harness session JSONL uploads — imported artifacts only; Blind
+      // Bench does not execute either harness.
       v.literal("claude_code"),
+      v.literal("pi"),
+      // Flat mapped CSV rows normalize into the same trajectory spine.
+      v.literal("csv"),
       // #263: OTLP Gen-AI span push (Cloudflare AI Gateway + any OTel source).
       v.literal("otlp"),
       // Native `eval-record` v1 JSON push — Blind Bench's own public ingest schema.
@@ -792,6 +796,10 @@ const schema = defineSchema({
   agentTraceSteps: defineTable({
     agentTraceId: v.id("agentTraces"),
     stepIndex: v.number(),
+    // SHA-256 chain of every normalized step before this one. Matchup
+    // creation compares this value at the declared divergence to prove both
+    // candidates share an identical prompt/trajectory prefix.
+    prefixHash: v.string(),
     kind: v.union(
       v.literal("message"),
       v.literal("tool_call"),
@@ -895,14 +903,40 @@ const schema = defineSchema({
     divergenceStepIndex: v.number(),
     leftBlindLabel: v.string(),
     rightBlindLabel: v.string(),
-    userId: v.optional(v.id("users")),
-    winner: v.optional(
-      v.union(
-        v.literal("left"),
-        v.literal("right"),
-        v.literal("tie"),
-        v.literal("skip"),
-      ),
+    prefixHash: v.optional(v.string()),
+    comparabilityStatus: v.union(v.literal("valid"), v.literal("invalid")),
+    invalidReason: v.optional(v.literal("prefix_mismatch")),
+  })
+    .index("by_project", ["projectId"])
+    .index("by_left", ["leftTraceId"]),
+
+  // One immutable logical decision per (matchup, reviewer). Reviewers can
+  // revise their own row, but never overwrite another reviewer's judgment.
+  agentTraceReviewSessions: defineTable({
+    projectId: v.id("projects"),
+    reviewerUserId: v.id("users"),
+    token: v.string(),
+    kind: v.union(v.literal("trace"), v.literal("matchup")),
+    // Session-scoped randomized presentation order prevents one global
+    // left/right ordering from biasing every reviewer.
+    leftFirst: v.optional(v.boolean()),
+    agentTraceId: v.optional(v.id("agentTraces")),
+    matchupId: v.optional(v.id("agentTraceMatchups")),
+  })
+    .index("by_token", ["token"])
+    .index("by_reviewer", ["reviewerUserId"])
+    .index("by_trace_and_reviewer", ["agentTraceId", "reviewerUserId"])
+    .index("by_matchup_and_reviewer", ["matchupId", "reviewerUserId"]),
+
+  agentTraceMatchupDecisions: defineTable({
+    matchupId: v.id("agentTraceMatchups"),
+    projectId: v.id("projects"),
+    userId: v.id("users"),
+    winner: v.union(
+      v.literal("left"),
+      v.literal("right"),
+      v.literal("tie"),
+      v.literal("skip"),
     ),
     reasonTags: v.array(
       v.union(
@@ -916,10 +950,10 @@ const schema = defineSchema({
         v.literal("other"),
       ),
     ),
-    decidedAt: v.optional(v.number()),
+    decidedAt: v.number(),
   })
-    .index("by_project", ["projectId"])
-    .index("by_left", ["leftTraceId"]),
+    .index("by_matchup", ["matchupId"])
+    .index("by_matchup_and_user", ["matchupId", "userId"]),
 
   // #53 (export bridge): a generated training-data export. The JSONL is in
   // storage; this row tracks provenance + counts and gates the download to a

--- a/convex/tests/agentTrace.test.ts
+++ b/convex/tests/agentTrace.test.ts
@@ -133,7 +133,7 @@ describe("agentTraces persistence spine", () => {
     });
     // Parent carries no step content — comfortably under the 10KB budget.
     expect(parentBytes).toBeLessThan(10_240);
-  });
+  }, 15_000);
 
   test("re-persisting the same trace dedups instead of duplicating", async () => {
     const t = convexTest(schema);
@@ -162,7 +162,10 @@ describe("agentTraces persistence spine", () => {
     });
 
     const opts = { paginationOpts: { numItems: 50, cursor: null } };
-    const blindPage = await asBlind.query(api.agentTraces.listSteps, { agentTraceId, ...opts });
+    const sessions = await asBlind.query(api.agentTraceReviewSessions.listMine, {});
+    const token = sessions[0]?.token;
+    if (!token) throw new Error("Missing opaque trace review session");
+    const blindPage = await asBlind.query(api.agentTraceReviewSessions.listSteps, { token, ...opts });
     // listSteps never hands out storage ids or URLs — only a hasBody flag.
     for (const item of blindPage.page) {
       expect(item).not.toHaveProperty("fullBodyStorageId");
@@ -178,7 +181,7 @@ describe("agentTraces persistence spine", () => {
       await asOwner.action(api.agentTraces.getStepBody, { agentTraceId, stepIndex: toolStep!.stepIndex }),
     );
     const blindBody = JSON.stringify(
-      await asBlind.action(api.agentTraces.getStepBody, { agentTraceId, stepIndex: toolStep!.stepIndex }),
+      await asBlind.action(api.agentTraceReviewSessions.getStepBody, { token, stepIndex: toolStep!.stepIndex }),
     );
     expect(ownerBody).toContain("123-45-6789");
     expect(blindBody).toContain("[REDACTED]");

--- a/convex/tests/agentTraceBlind.test.ts
+++ b/convex/tests/agentTraceBlind.test.ts
@@ -85,8 +85,11 @@ describe("#266 blind projection — no provenance leaks to evaluators", () => {
     });
 
     const opts = { paginationOpts: { numItems: 50, cursor: null } };
-    const blindSteps = await asBlind.query(api.agentTraces.listSteps, { agentTraceId, ...opts });
-    const blindTrace = await asBlind.query(api.agentTraces.getTrace, { agentTraceId });
+    const sessions = await asBlind.query(api.agentTraceReviewSessions.listMine, {});
+    const token = sessions[0]?.token;
+    if (!token) throw new Error("Missing opaque review session");
+    const blindSteps = await asBlind.query(api.agentTraceReviewSessions.listSteps, { token, ...opts });
+    const blindTrace = await asBlind.query(api.agentTraceReviewSessions.getTrace, { token });
 
     // Metadata + inline scalars carry no identifiers. (Bodies are opaque URLs;
     // their redacted content is asserted separately below.)
@@ -95,9 +98,10 @@ describe("#266 blind projection — no provenance leaks to evaluators", () => {
       expect(blindMeta).not.toContain(needle);
     }
     // Positive projection checks.
-    expect(blindTrace?.harnessName).toBeUndefined();
-    expect(blindTrace?.model).toBeUndefined();
-    expect(blindTrace?.traceId).toBeUndefined();
+    expect(blindTrace).not.toHaveProperty("harnessName");
+    expect(blindTrace).not.toHaveProperty("model");
+    expect(blindTrace).not.toHaveProperty("traceId");
+    expect(blindTrace).not.toHaveProperty("_id");
     const bashStep = blindSteps.page.find((s) => s.kind === "tool_call");
     expect(bashStep?.toolName).toBe("run_command"); // aliased
     expect(bashStep?.toolCallId).toBe("call-1"); // opaque positional

--- a/convex/tests/agentTraceReview.test.ts
+++ b/convex/tests/agentTraceReview.test.ts
@@ -56,14 +56,21 @@ async function persist(asUser: Ident, projectId: Id<"projects">, run: JeevesClog
   return res.agentTraceId;
 }
 
+async function reviewToken(asUser: Ident, kind: "trace" | "matchup" = "trace") {
+  const sessions = await asUser.query(api.agentTraceReviewSessions.listMine, {});
+  const session = sessions.find((candidate) => candidate.kind === kind);
+  if (!session) throw new Error(`Missing ${kind} review session`);
+  return session.token;
+}
+
 describe("#267 step-level trace review", () => {
   test("blind reviewer comments on a tool-call step; owner sees it anchored correctly", async () => {
     const t = convexTest(schema);
     const { ids, asOwner, asBlind } = await seed(t);
     const traceId = await persist(asOwner, ids.projectId, baseRun);
 
-    await asBlind.mutation(api.agentTraceReview.addComment, {
-      agentTraceId: traceId,
+    await asBlind.mutation(api.agentTraceReviewSessions.addComment, {
+      token: await reviewToken(asBlind),
       target: { kind: "tool_call", stepIndex: 3 }, // the create_escalation call
       comment: "Escalating on hardship without verifying is risky.",
       label: "issue",
@@ -80,10 +87,10 @@ describe("#267 step-level trace review", () => {
   test("out-of-range step anchor is rejected", async () => {
     const t = convexTest(schema);
     const { ids, asOwner, asBlind } = await seed(t);
-    const traceId = await persist(asOwner, ids.projectId, baseRun);
+    await persist(asOwner, ids.projectId, baseRun);
     await expect(
-      asBlind.mutation(api.agentTraceReview.addComment, {
-        agentTraceId: traceId,
+      asBlind.mutation(api.agentTraceReviewSessions.addComment, {
+        token: await reviewToken(asBlind),
         target: { kind: "step", stepIndex: 99 },
         comment: "no such step",
         label: "thought",
@@ -96,10 +103,11 @@ describe("#267 step-level trace review", () => {
     const { ids, asOwner, asBlind } = await seed(t);
     const traceId = await persist(asOwner, ids.projectId, baseRun);
 
-    await asBlind.mutation(api.agentTraceReview.setVerdict, { agentTraceId: traceId, rating: "weak" });
-    await asBlind.mutation(api.agentTraceReview.setVerdict, { agentTraceId: traceId, rating: "acceptable", note: "changed my mind" });
+    const token = await reviewToken(asBlind);
+    await asBlind.mutation(api.agentTraceReviewSessions.setVerdict, { token, rating: "weak" });
+    await asBlind.mutation(api.agentTraceReviewSessions.setVerdict, { token, rating: "acceptable", note: "changed my mind" });
 
-    const mine = await asBlind.query(api.agentTraceReview.myVerdict, { agentTraceId: traceId });
+    const mine = await asBlind.query(api.agentTraceReviewSessions.myVerdict, { token });
     expect(mine?.rating).toBe("acceptable");
     const count = await t.run(async (ctx) =>
       (await ctx.db.query("agentTraceVerdicts").withIndex("by_trace", (q) => q.eq("agentTraceId", traceId)).collect()).length,
@@ -112,14 +120,13 @@ describe("#267 step-level trace review", () => {
     const { ids, asOwner, asBlind } = await seed(t);
     await persist(asOwner, ids.projectId, baseRun);
 
-    const list = await asBlind.query(api.agentTraces.listReviewableTraces, {});
+    const list = await asBlind.query(api.agentTraceReviewSessions.listMine, {});
     expect(list).toHaveLength(1);
     expect(list[0]?.projectName).toBe("P");
     expect(list[0]?.stepCount).toBeGreaterThan(0);
-    // Blinded: no harness/model/product for the evaluator.
-    expect(list[0]?.harnessName).toBeUndefined();
-    expect(list[0]?.model).toBeUndefined();
+    expect(list[0]?.kind).toBe("trace");
     expect(JSON.stringify(list)).not.toContain("jeeves_clog");
+    expect(JSON.stringify(list)).not.toContain("agentTraceId");
   });
 
   test("step-level pairwise: owner sets up, blind reviewer picks the winner", async () => {
@@ -128,7 +135,7 @@ describe("#267 step-level trace review", () => {
     const left = await persist(asOwner, ids.projectId, baseRun);
     const right = await persist(asOwner, ids.projectId, { ...baseRun, run_id: "JEEVES-RUN-REVIEW-B", final_answer: "Did nothing." });
 
-    const matchupId = await asOwner.mutation(api.agentTraceReview.createMatchup, {
+    await asOwner.mutation(api.agentTraceReview.createMatchup, {
       leftTraceId: left,
       rightTraceId: right,
       divergenceStepIndex: 3,
@@ -136,15 +143,17 @@ describe("#267 step-level trace review", () => {
       rightBlindLabel: "Trajectory B",
     });
 
-    await asBlind.mutation(api.agentTraceReview.decideMatchup, {
-      matchupId,
+    const token = await reviewToken(asBlind, "matchup");
+    await asBlind.mutation(api.agentTraceReviewSessions.decideMatchup, {
+      token,
       winner: "left",
       reasonTags: ["accuracy"],
     });
 
-    const m = await asBlind.query(api.agentTraceReview.getMatchup, { matchupId });
+    const m = await asBlind.query(api.agentTraceReviewSessions.getMatchup, { token });
     expect(m?.winner).toBe("left");
-    expect(m?.leftBlindLabel).toBe("Trajectory A");
+    expect(new Set([m?.leftBlindLabel, m?.rightBlindLabel])).toEqual(new Set(["A", "B"]));
+    expect(["left", "right"]).toContain(m?.firstSide);
     // No provenance in the matchup payload.
     expect(JSON.stringify(m)).not.toContain("jeeves_clog");
     expect(JSON.stringify(m)).not.toContain("claude-sonnet-4-0");

--- a/convex/tests/agentTraceReviewSessions.test.ts
+++ b/convex/tests/agentTraceReviewSessions.test.ts
@@ -1,0 +1,226 @@
+/// <reference types="vite/client" />
+import { convexTest } from "convex-test";
+import { describe, expect, test } from "vitest";
+import { api } from "../_generated/api";
+import type { Id } from "../_generated/dataModel";
+import schema from "../schema";
+import {
+  normalizeJeevesClogRun,
+  type AgentRunTrace,
+  type JeevesClogRunExport,
+} from "../lib/agentTrace";
+
+const asJson = <T>(value: T): T => JSON.parse(JSON.stringify(value)) as T;
+type Identity = ReturnType<ReturnType<typeof convexTest>["withIdentity"]>;
+
+const runWith = (
+  runId: string,
+  divergenceTool: string,
+  firstMessage = "Looking it up.",
+): JeevesClogRunExport => ({
+  run_id: runId,
+  product: "support",
+  harness: { name: "pi", version: "3", sdk: "pi_session_jsonl" },
+  model: "claude-sonnet-4-7",
+  steps: [
+    { type: "message", role: "user", content: "Handle the account." },
+    { type: "message", role: "assistant", content: firstMessage },
+    { type: "tool_call", id: "t2", name: divergenceTool, args: { account: "A-1" } },
+  ],
+  final_answer: "Done.",
+  usage: { total_tokens: 100 },
+});
+
+async function seed(t: ReturnType<typeof convexTest>) {
+  const ids = await t.run(async (ctx) => {
+    const owner = await ctx.db.insert("users", { name: "Owner", email: "owner@test.com" });
+    const reviewer1 = await ctx.db.insert("users", { name: "Reviewer 1", email: "r1@test.com" });
+    const reviewer2 = await ctx.db.insert("users", { name: "Reviewer 2", email: "r2@test.com" });
+    const orgId = await ctx.db.insert("organizations", { name: "Org", slug: "org", createdById: owner });
+    await ctx.db.insert("organizationMembers", { organizationId: orgId, userId: owner, role: "owner" });
+    const projectId = await ctx.db.insert("projects", { organizationId: orgId, name: "Agent QA", createdById: owner });
+    await ctx.db.insert("projectCollaborators", { projectId, userId: owner, role: "owner", invitedById: owner, invitedAt: Date.now() });
+    await ctx.db.insert("projectCollaborators", { projectId, userId: reviewer1, role: "evaluator", blindMode: true, invitedById: owner, invitedAt: Date.now() });
+    await ctx.db.insert("projectCollaborators", { projectId, userId: reviewer2, role: "evaluator", blindMode: true, invitedById: owner, invitedAt: Date.now() });
+    return { owner, reviewer1, reviewer2, projectId };
+  });
+  const identity = (userId: Id<"users">) => t.withIdentity({
+    subject: `${userId}|session`,
+    tokenIdentifier: `test|${userId}`,
+  });
+  return {
+    ids,
+    asOwner: identity(ids.owner),
+    asReviewer1: identity(ids.reviewer1),
+    asReviewer2: identity(ids.reviewer2),
+  };
+}
+
+async function persist(identity: Identity, projectId: Id<"projects">, run: JeevesClogRunExport) {
+  const result = await identity.action(api.agentTraces.persistTrace, {
+    projectId,
+    trace: asJson(normalizeJeevesClogRun(run)) as unknown as AgentRunTrace,
+  });
+  return result.agentTraceId;
+}
+
+async function tokenFor(
+  identity: Identity,
+  kind: "trace" | "matchup",
+): Promise<string> {
+  const sessions = await identity.query(api.agentTraceReviewSessions.listMine, {});
+  const session = sessions.find((candidate) => candidate.kind === kind);
+  if (!session) throw new Error(`Missing ${kind} review session in test`);
+  return session.token;
+}
+
+describe("opaque trajectory review sessions", () => {
+  test("reviewer payloads and access use tokens only; raw ID functions are denied", async () => {
+    const t = convexTest(schema);
+    const { ids, asOwner, asReviewer1, asReviewer2 } = await seed(t);
+    const traceId = await persist(asOwner, ids.projectId, runWith("trace-a", "escalate"));
+
+    const sessions = await asReviewer1.query(api.agentTraceReviewSessions.listMine, {});
+    expect(sessions).toHaveLength(1);
+    const serialized = JSON.stringify(sessions);
+    expect(serialized).not.toContain(traceId);
+    expect(serialized).not.toContain("agentTraceId");
+    expect(serialized).not.toContain("claude-sonnet");
+    expect(serialized).not.toContain("pi_session_jsonl");
+
+    const token = sessions[0]?.token;
+    if (!token) throw new Error("Missing review token");
+    const trace = await asReviewer1.query(api.agentTraceReviewSessions.getTrace, { token });
+    expect(trace.projectName).toBe("Agent QA");
+    expect(trace).not.toHaveProperty("_id");
+    expect(trace).not.toHaveProperty("model");
+    const steps = await asReviewer1.query(api.agentTraceReviewSessions.listSteps, {
+      token,
+      paginationOpts: { numItems: 20, cursor: null },
+    });
+    expect(steps.page).toHaveLength(3);
+    expect(JSON.stringify(steps)).not.toContain(traceId);
+
+    const reviewer2Token = await tokenFor(asReviewer2, "trace");
+    await asReviewer2.mutation(api.agentTraceReviewSessions.addComment, {
+      token: reviewer2Token,
+      target: { kind: "step", stepIndex: 1 },
+      comment: "Peer comment must remain independent.",
+      label: "thought",
+    });
+    await asReviewer1.mutation(api.agentTraceReviewSessions.addComment, {
+      token,
+      target: { kind: "step", stepIndex: 1 },
+      comment: "Good evidence gathering.",
+      label: "praise",
+    });
+    const myComments = await asReviewer1.query(api.agentTraceReviewSessions.listComments, { token });
+    expect(myComments).toHaveLength(1);
+    expect(JSON.stringify(myComments)).not.toContain("Peer comment");
+    await asReviewer1.mutation(api.agentTraceReviewSessions.setVerdict, {
+      token,
+      rating: "acceptable",
+    });
+    expect((await asReviewer1.query(api.agentTraceReviewSessions.myVerdict, { token }))?.rating).toBe("acceptable");
+
+    await expect(asReviewer1.query(api.agentTraces.getTrace, { agentTraceId: traceId })).rejects.toThrow(/opaque review session/i);
+    await expect(asReviewer1.query(api.agentTraces.listSteps, {
+      agentTraceId: traceId,
+      paginationOpts: { numItems: 20, cursor: null },
+    })).rejects.toThrow(/opaque review session/i);
+
+    await t.run(async (ctx) => {
+      const collaborator = await ctx.db
+        .query("projectCollaborators")
+        .withIndex("by_project_and_user", (q) =>
+          q.eq("projectId", ids.projectId).eq("userId", ids.reviewer1),
+        )
+        .unique();
+      if (collaborator) await ctx.db.delete(collaborator._id);
+    });
+    expect(await asReviewer1.query(api.agentTraceReviewSessions.listMine, {})).toEqual([]);
+    await expect(asReviewer1.query(api.agentTraceReviewSessions.getTrace, { token }))
+      .rejects.toThrow(/not found or expired/i);
+  });
+
+  test("two reviewers keep independent matchup decisions and disagreement is explicitly excluded", async () => {
+    const t = convexTest(schema);
+    const { ids, asOwner, asReviewer1, asReviewer2 } = await seed(t);
+    const left = await persist(asOwner, ids.projectId, runWith("left", "escalate"));
+    const right = await persist(asOwner, ids.projectId, runWith("right", "close_ticket"));
+    await asOwner.mutation(api.agentTraceReview.createMatchup, {
+      leftTraceId: left,
+      rightTraceId: right,
+      divergenceStepIndex: 2,
+      leftBlindLabel: "A",
+      rightBlindLabel: "B",
+    });
+
+    const token1 = await tokenFor(asReviewer1, "matchup");
+    const token2 = await tokenFor(asReviewer2, "matchup");
+    expect(token1).not.toBe(token2);
+    await asReviewer1.mutation(api.agentTraceReviewSessions.decideMatchup, {
+      token: token1,
+      winner: "left",
+      reasonTags: ["accuracy"],
+    });
+    await asReviewer2.mutation(api.agentTraceReviewSessions.decideMatchup, {
+      token: token2,
+      winner: "right",
+      reasonTags: ["safety"],
+    });
+
+    const decisions = await t.run(async (ctx) => await ctx.db.query("agentTraceMatchupDecisions").collect());
+    expect(decisions).toHaveLength(2);
+    expect(new Set(decisions.map((decision) => decision.userId)).size).toBe(2);
+    expect((await asReviewer1.query(api.agentTraceReviewSessions.getMatchup, { token: token1 })).winner).toBe("left");
+    expect((await asReviewer2.query(api.agentTraceReviewSessions.getMatchup, { token: token2 })).winner).toBe("right");
+
+    const exported = await asOwner.action(api.exports.generateExport, {
+      projectId: ids.projectId,
+      source: "trajectory",
+      format: "dpo",
+    });
+    expect(exported.rowCount).toBe(0);
+    expect(exported.manifest.excluded_by_reason.review_disagreement).toBe(1);
+
+    await asReviewer2.mutation(api.agentTraceReviewSessions.decideMatchup, {
+      token: token2,
+      winner: "tie",
+      reasonTags: [],
+    });
+    const tieExport = await asOwner.action(api.exports.generateExport, {
+      projectId: ids.projectId,
+      source: "trajectory",
+      format: "dpo",
+    });
+    expect(tieExport.rowCount).toBe(0);
+    expect(tieExport.manifest.excluded_by_reason.no_preference).toBe(1);
+  });
+
+  test("mismatched prefixes are persisted invalid and excluded with an explicit manifest reason", async () => {
+    const t = convexTest(schema);
+    const { ids, asOwner, asReviewer1 } = await seed(t);
+    const left = await persist(asOwner, ids.projectId, runWith("left-mismatch", "escalate"));
+    const right = await persist(asOwner, ids.projectId, runWith("right-mismatch", "close_ticket", "Different prefix."));
+    const matchupId = await asOwner.mutation(api.agentTraceReview.createMatchup, {
+      leftTraceId: left,
+      rightTraceId: right,
+      divergenceStepIndex: 2,
+      leftBlindLabel: "A",
+      rightBlindLabel: "B",
+    });
+    const matchup = await t.run(async (ctx) => await ctx.db.get(matchupId));
+    expect(matchup?.comparabilityStatus).toBe("invalid");
+    expect(matchup?.invalidReason).toBe("prefix_mismatch");
+    expect((await asReviewer1.query(api.agentTraceReviewSessions.listMine, {})).filter((session) => session.kind === "matchup")).toHaveLength(0);
+
+    const exported = await asOwner.action(api.exports.generateExport, {
+      projectId: ids.projectId,
+      source: "trajectory",
+      format: "dpo",
+    });
+    expect(exported.rowCount).toBe(0);
+    expect(exported.manifest.excluded_by_reason.non_comparable_prefix).toBe(1);
+  });
+});

--- a/convex/tests/csvImport.test.ts
+++ b/convex/tests/csvImport.test.ts
@@ -1,0 +1,159 @@
+/// <reference types="vite/client" />
+import { convexTest } from "convex-test";
+import { describe, expect, test } from "vitest";
+import { api } from "../_generated/api";
+import schema from "../schema";
+import { parseCsvTraceBatch } from "../lib/csvTrace";
+
+const csv = [
+  "run_id,prompt,response,model,provider,harness,case_key,note",
+  'r-1,"Summarize this, please","First line\nSecond line",gpt-4.1,openai,custom-agent,case-1,"contains, comma"',
+  'r-2,"Draft a reply","Thanks for writing",claude-sonnet-4-7,anthropic,custom-agent,case-2,plain',
+].join("\r\n");
+
+const mapping = {
+  idColumn: "run_id",
+  inputColumn: "prompt",
+  outputColumn: "response",
+  modelColumn: "model",
+  providerColumn: "provider",
+  harnessColumn: "harness",
+  metadataColumns: ["case_key", "note"],
+} as const;
+
+async function seed(t: ReturnType<typeof convexTest>) {
+  const ids = await t.run(async (ctx) => {
+    const ownerUserId = await ctx.db.insert("users", { name: "Owner", email: "owner@test.com" });
+    const reviewerUserId = await ctx.db.insert("users", { name: "Reviewer", email: "reviewer@test.com" });
+    const orgId = await ctx.db.insert("organizations", { name: "Org", slug: "org", createdById: ownerUserId });
+    await ctx.db.insert("organizationMembers", { organizationId: orgId, userId: ownerUserId, role: "owner" });
+    const projectId = await ctx.db.insert("projects", { organizationId: orgId, name: "P", createdById: ownerUserId });
+    await ctx.db.insert("projectCollaborators", { projectId, userId: ownerUserId, role: "owner", invitedById: ownerUserId, invitedAt: Date.now() });
+    await ctx.db.insert("projectCollaborators", { projectId, userId: reviewerUserId, role: "evaluator", blindMode: true, invitedById: ownerUserId, invitedAt: Date.now() });
+    return { ownerUserId, reviewerUserId, projectId };
+  });
+  return {
+    ids,
+    asOwner: t.withIdentity({ subject: `${ids.ownerUserId}|s`, tokenIdentifier: `test|${ids.ownerUserId}` }),
+    asReviewer: t.withIdentity({ subject: `${ids.reviewerUserId}|s`, tokenIdentifier: `test|${ids.reviewerUserId}` }),
+  };
+}
+
+describe("mapped CSV trajectory parsing", () => {
+  test("parses RFC-style quoting and maps flat rows into normalized traces", () => {
+    const result = parseCsvTraceBatch(csv, mapping);
+
+    expect(result.summary).toMatchObject({ rows: 2, valid: 2, invalid: 0 });
+    expect(result.summary.headers).toEqual([
+      "run_id", "prompt", "response", "model", "provider", "harness", "case_key", "note",
+    ]);
+    expect(result.traces).toHaveLength(2);
+    expect(result.traces[0]?.sourceId).toBe("r-1");
+    expect(result.traces[0]?.trace.trace_id).toBe("csv-r-1");
+    expect(result.traces[0]?.trace.harness.name).toBe("custom-agent");
+    expect(result.traces[0]?.trace.steps.flatMap((step) =>
+      step.type === "message" ? [step.message.content] : [],
+    )).toEqual(["Summarize this, please", "First line\nSecond line"]);
+    expect(result.traces[0]?.trace.metadata).toEqual({
+      case_key: "case-1",
+      note: "contains, comma",
+    });
+    expect(JSON.stringify(result.summary)).not.toContain("Summarize this");
+    expect(JSON.stringify(result.summary)).not.toContain("Thanks for writing");
+  });
+
+  test("reports missing required cells by row without echoing their content", () => {
+    const invalidCsv = "prompt,response\nhello,\n,answer\nvalid,answer";
+    const result = parseCsvTraceBatch(invalidCsv, {
+      inputColumn: "prompt",
+      outputColumn: "response",
+      metadataColumns: [],
+    });
+    expect(result.summary).toMatchObject({
+      rows: 3,
+      valid: 1,
+      invalid: 2,
+      missingInput: 1,
+      missingOutput: 1,
+      invalidRows: [2, 3],
+    });
+    expect(result.traces).toHaveLength(1);
+  });
+
+  test("rejects unknown mapping columns and unterminated quotes", () => {
+    expect(() => parseCsvTraceBatch(csv, { ...mapping, inputColumn: "missing" })).toThrow(/unknown column.*missing/i);
+    expect(() => parseCsvTraceBatch('prompt,response\n"broken,value', {
+      inputColumn: "prompt",
+      outputColumn: "response",
+      metadataColumns: [],
+    })).toThrow(/unterminated quoted field/i);
+  });
+});
+
+describe("mapped CSV import through the trajectory spine", () => {
+  test("authenticates before parsing untrusted file content", async () => {
+    const t = convexTest(schema);
+    const { ids } = await seed(t);
+    await expect(t.action(api.csvImport.importMappedCsv, {
+      projectId: ids.projectId,
+      csv: "not,csv",
+      mapping: { inputColumn: "input", outputColumn: "output", metadataColumns: [] },
+    })).rejects.toThrow(/not authenticated/i);
+  });
+
+  test("runs the canonical CSV import → opaque review → SFT reuse loop", async () => {
+    const t = convexTest(schema);
+    const { ids, asOwner, asReviewer } = await seed(t);
+    const oneRow = "run_id,prompt,response\nr-1,hello,world";
+    expect(await asOwner.action(api.csvImport.importMappedCsv, {
+      projectId: ids.projectId,
+      csv: oneRow,
+      mapping: { idColumn: "run_id", inputColumn: "prompt", outputColumn: "response", metadataColumns: [] },
+    })).toMatchObject({ imported: 1, deduped: 0 });
+
+    const sessions = await asReviewer.query(api.agentTraceReviewSessions.listMine, {});
+    expect(sessions).toHaveLength(1);
+    const token = sessions[0]?.token;
+    if (!token) throw new Error("Missing opaque review token");
+    expect(JSON.stringify(sessions)).not.toContain("agentTraceId");
+    await asReviewer.mutation(api.agentTraceReviewSessions.addComment, {
+      token,
+      target: { kind: "trace" },
+      comment: "Approved synthetic fixture.",
+      label: "praise",
+    });
+    await asReviewer.mutation(api.agentTraceReviewSessions.setVerdict, { token, rating: "best" });
+
+    const exported = await asOwner.action(api.exports.generateExport, {
+      projectId: ids.projectId,
+      source: "trajectory",
+      format: "sft",
+    });
+    expect(exported.rowCount).toBe(1);
+    expect(exported.manifest).toMatchObject({ format: "sft", source_units: 1, reviewers: 1 });
+  });
+
+  test("persists valid rows and deduplicates a repeated upload", async () => {
+    const t = convexTest(schema);
+    const { ids, asOwner } = await seed(t);
+
+    const first = await asOwner.action(api.csvImport.importMappedCsv, {
+      projectId: ids.projectId,
+      csv,
+      mapping: { ...mapping, metadataColumns: [...mapping.metadataColumns] },
+    });
+    expect(first).toMatchObject({ imported: 2, deduped: 0, summary: { valid: 2 } });
+
+    const imports = await t.run(async (ctx) => await ctx.db.query("traceImports").collect());
+    expect(imports).toHaveLength(2);
+    expect(imports.every((row) => row.source === "csv" && row.rawPayloadStorageId !== undefined)).toBe(true);
+
+    const second = await asOwner.action(api.csvImport.importMappedCsv, {
+      projectId: ids.projectId,
+      csv,
+      mapping: { ...mapping, metadataColumns: [...mapping.metadataColumns] },
+    });
+    expect(second).toMatchObject({ imported: 0, deduped: 2 });
+    expect(await t.run(async (ctx) => (await ctx.db.query("agentTraces").collect()).length)).toBe(2);
+  });
+});

--- a/convex/tests/dogfoodFlow.test.ts
+++ b/convex/tests/dogfoodFlow.test.ts
@@ -35,7 +35,7 @@ async function seed(t: ReturnType<typeof convexTest>) {
 }
 
 describe("M31 dogfood — full flywheel on real trajectories", () => {
-  test("ingest → blind review → A/B → real DPO + SFT export", async () => {
+  test("ingest → opaque blind review → honest DPO exclusion + SFT export", async () => {
     const t = convexTest(schema);
     const { ids, asOwner, asBlind } = await seed(t);
 
@@ -49,21 +49,28 @@ describe("M31 dogfood — full flywheel on real trajectories", () => {
 
     // 2. BLIND REVIEW — a reviewer discovers them (no provenance), reads steps,
     //    comments on a step, and rates the trajectory.
-    const list = await asBlind.query(api.agentTraces.listReviewableTraces, {});
-    expect(list).toHaveLength(3);
-    const steps = await asBlind.query(api.agentTraces.listSteps, {
-      agentTraceId: traces.opus!,
+    const list = await asBlind.query(api.agentTraceReviewSessions.listMine, {});
+    const traceSessions = list.filter((session) => session.kind === "trace");
+    expect(traceSessions).toHaveLength(3);
+    expect(JSON.stringify(traceSessions)).not.toContain("agentTraceId");
+    const firstToken = traceSessions[0]?.token;
+    const secondToken = traceSessions[1]?.token;
+    if (!firstToken || !secondToken) throw new Error("Missing opaque review sessions");
+    const steps = await asBlind.query(api.agentTraceReviewSessions.listSteps, {
+      token: firstToken,
       paginationOpts: { numItems: 50, cursor: null },
     });
     expect(steps.page.length).toBeGreaterThan(0);
-    await asBlind.mutation(api.agentTraceReview.addComment, {
-      agentTraceId: traces.opus!,
-      target: { kind: "step", stepIndex: steps.page[1]!.stepIndex },
+    const commentStep = steps.page[1];
+    if (!commentStep) throw new Error("Missing comment step");
+    await asBlind.mutation(api.agentTraceReviewSessions.addComment, {
+      token: firstToken,
+      target: { kind: "step", stepIndex: commentStep.stepIndex },
       comment: "Reasonable first move.",
       label: "praise",
     });
-    await asBlind.mutation(api.agentTraceReview.setVerdict, { agentTraceId: traces.haiku!, rating: "best" });
-    await asBlind.mutation(api.agentTraceReview.setVerdict, { agentTraceId: traces.opus!, rating: "acceptable" });
+    await asBlind.mutation(api.agentTraceReviewSessions.setVerdict, { token: firstToken, rating: "best" });
+    await asBlind.mutation(api.agentTraceReviewSessions.setVerdict, { token: secondToken, rating: "acceptable" });
 
     // 3. A/B MATCHUP — the DPO-shaped signal: winner's next action vs loser's.
     // Real divergence is at step 4 (steps 0-3 are an identical prefix — user
@@ -75,39 +82,22 @@ describe("M31 dogfood — full flywheel on real trajectories", () => {
       leftBlindLabel: "A",
       rightBlindLabel: "B",
     });
-    await asBlind.mutation(api.agentTraceReview.decideMatchup, { matchupId, winner: "left", reasonTags: ["accuracy"] });
+    const persistedMatchup = await t.run(async (ctx) => await ctx.db.get(matchupId));
+    expect(persistedMatchup?.comparabilityStatus).toBe("invalid");
 
-    // 4. EXPORT — the flywheel payoff: a real DPO pair falls out of the matchup.
+    // 4. EXPORT — the real Harbor pair is honestly excluded because its
+    // normalized prefixes differ. The old flow overclaimed this as DPO-ready.
     const dpo = await asOwner.action(api.exports.generateExport, {
       projectId: ids.projectId, source: "trajectory", format: "dpo",
     });
-    expect(dpo.rowCount).toBeGreaterThanOrEqual(1);
-    // The Fireworks handoff manifest is emitted alongside the JSONL.
+    expect(dpo.rowCount).toBe(0);
     expect(dpo.manifest).toMatchObject({
       schema: "blindbench.training-export",
       version: 1,
       source: "trajectory",
       format: "dpo",
-      fireworks: { compatible: true, row_shape: "prompt/chosen/rejected" },
+      excluded_by_reason: { non_comparable_prefix: 1 },
     });
-    expect(dpo.manifest.row_count).toBe(dpo.rowCount);
-    expect(dpo.manifest.reviewers).toBeGreaterThanOrEqual(1);
-    const dpoJsonl = await t.run(async (ctx) => {
-      const row = await ctx.db.query("trainingExports").order("desc").first();
-      const blob = row ? await ctx.storage.get(row.storageId) : null;
-      return blob ? await blob.text() : "";
-    });
-    const pair = JSON.parse(dpoJsonl.split("\n")[0]!);
-    // The DPO pair carries real content: a prompt (shared prefix), and distinct
-    // chosen (winner) vs rejected (loser) next actions.
-    expect(pair).toHaveProperty("prompt");
-    expect(pair).toHaveProperty("chosen");
-    expect(pair).toHaveProperty("rejected");
-    expect(pair.chosen).not.toBe(pair.rejected);
-    expect(typeof pair.prompt).toBe("string");
-    expect(pair.prompt.length).toBeGreaterThan(0);
-    // No provider/harness provenance leaks into the training data.
-    expect(dpoJsonl).not.toContain("claude-opus");
 
     // SFT from the best-verdict trajectory.
     const sft = await asOwner.action(api.exports.generateExport, {
@@ -119,14 +109,7 @@ describe("M31 dogfood — full flywheel on real trajectories", () => {
       fireworks: { row_shape: "messages[]" },
     });
 
-    // Surface the real artifact so a dogfood run shows what shipped.
-    // eslint-disable-next-line no-console
-    console.log(
-      `\n[dogfood] DPO pair from real Harbor A/B (Opus✓ vs Sonnet✗):\n` +
-        `  prompt : ${String(pair.prompt).slice(0, 90).replace(/\n/g, " ")}…\n` +
-        `  chosen : ${String(pair.chosen).slice(0, 90).replace(/\n/g, " ")}…\n` +
-        `  reject : ${String(pair.rejected).slice(0, 90).replace(/\n/g, " ")}…\n` +
-        `  → dpo rows=${dpo.rowCount} excluded=${dpo.excludedCount}, sft rows=${sft.rowCount}`,
-    );
+    expect(dpo.excludedCount).toBe(1);
+    expect(sft.rowCount).toBeGreaterThanOrEqual(1);
   });
 });

--- a/convex/tests/harborMatrix.test.ts
+++ b/convex/tests/harborMatrix.test.ts
@@ -38,7 +38,7 @@ async function seed(t: ReturnType<typeof convexTest>) {
 }
 
 describe("#268 Harbor matrix → spine → blind review (real trajectories)", () => {
-  test("3 combos of the same task import and are blind-reviewable side-by-side", async () => {
+  test("3 combos import into opaque review sessions and invalid A/B prefixes are rejected", async () => {
     const t = convexTest(schema);
     const { ids, asOwner, asBlind } = await seed(t);
 
@@ -54,14 +54,17 @@ describe("#268 Harbor matrix → spine → blind review (real trajectories)", ()
     }
 
     // A blind reviewer discovers all 3, provenance stripped (no model/harness).
-    const list = await asBlind.query(api.agentTraces.listReviewableTraces, {});
-    expect(list).toHaveLength(3);
+    const list = await asBlind.query(api.agentTraceReviewSessions.listMine, {});
+    const traceSessions = list.filter((session) => session.kind === "trace");
+    expect(traceSessions).toHaveLength(3);
     expect(JSON.stringify(list)).not.toContain("claude-opus");
     expect(JSON.stringify(list)).not.toContain("claude_code");
+    expect(JSON.stringify(list)).not.toContain("agentTraceId");
 
-    // Blind step read on the winner (Opus solved) — steps render, no provenance.
-    const page = await asBlind.query(api.agentTraces.listSteps, {
-      agentTraceId: persisted.opus!,
+    const token = traceSessions[0]?.token;
+    if (!token) throw new Error("Missing opaque review session");
+    const page = await asBlind.query(api.agentTraceReviewSessions.listSteps, {
+      token,
       paginationOpts: { numItems: 50, cursor: null },
     });
     expect(page.page.length).toBeGreaterThan(0);
@@ -75,14 +78,9 @@ describe("#268 Harbor matrix → spine → blind review (real trajectories)", ()
       leftBlindLabel: "Trajectory A",
       rightBlindLabel: "Trajectory B",
     });
-    await asBlind.mutation(api.agentTraceReview.decideMatchup, {
-      matchupId,
-      winner: "left",
-      reasonTags: ["accuracy"],
-    });
-    const m = await asBlind.query(api.agentTraceReview.getMatchup, { matchupId });
-    expect(m?.winner).toBe("left");
-    // No provenance in the matchup payload — reviewer can't see which model won.
-    expect(JSON.stringify(m)).not.toContain("claude");
+    const matchup = await t.run(async (ctx) => await ctx.db.get(matchupId));
+    expect(matchup?.comparabilityStatus).toBe("invalid");
+    expect(matchup?.invalidReason).toBe("prefix_mismatch");
+    expect((await asBlind.query(api.agentTraceReviewSessions.listMine, {})).filter((session) => session.kind === "matchup")).toHaveLength(0);
   });
 });

--- a/convex/tests/otlpFileImport.test.ts
+++ b/convex/tests/otlpFileImport.test.ts
@@ -1,0 +1,107 @@
+/// <reference types="vite/client" />
+import { convexTest } from "convex-test";
+import { describe, expect, test } from "vitest";
+import { api } from "../_generated/api";
+import schema from "../schema";
+import { mapOtlpToTraces } from "../lib/otelGenAI";
+
+const attr = (key: string, value: string) => ({ key, value: { stringValue: value } });
+const payload = {
+  resourceSpans: [{
+    scopeSpans: [{
+      spans: [
+        {
+          traceId: "trace-import-1",
+          spanId: "span-genai",
+          startTimeUnixNano: "1000",
+          attributes: [
+            attr("gen_ai.request.model", "gpt-4.1"),
+            attr("gen_ai.system", "openai"),
+            attr("gen_ai.prompt", "Summarize this ticket"),
+            attr("gen_ai.completion", "The customer needs a refund"),
+          ],
+        },
+        {
+          traceId: "trace-http-only",
+          spanId: "span-http",
+          startTimeUnixNano: "2000",
+          attributes: [attr("http.request.method", "POST")],
+        },
+      ],
+    }],
+  }],
+};
+
+async function seed(t: ReturnType<typeof convexTest>) {
+  const ids = await t.run(async (ctx) => {
+    const ownerUserId = await ctx.db.insert("users", { name: "Owner", email: "owner@test.com" });
+    const orgId = await ctx.db.insert("organizations", { name: "Org", slug: "org", createdById: ownerUserId });
+    await ctx.db.insert("organizationMembers", { organizationId: orgId, userId: ownerUserId, role: "owner" });
+    const projectId = await ctx.db.insert("projects", { organizationId: orgId, name: "P", createdById: ownerUserId });
+    await ctx.db.insert("projectCollaborators", { projectId, userId: ownerUserId, role: "owner", invitedById: ownerUserId, invitedAt: Date.now() });
+    return { ownerUserId, projectId };
+  });
+  return {
+    ids,
+    asOwner: t.withIdentity({ subject: `${ids.ownerUserId}|s`, tokenIdentifier: `test|${ids.ownerUserId}` }),
+  };
+}
+
+describe("OTLP GenAI file mapping", () => {
+  test("ignores ordinary non-GenAI spans instead of reporting a false-ready trace", () => {
+    const result = mapOtlpToTraces(payload);
+    expect(result.summary).toMatchObject({ traces: 1, spans: 1, ignoredSpans: 1, invalid: false });
+    expect(result.traces[0]?.trace_id).toBe("otlp-trace-import-1");
+  });
+
+  test("plain HTTP telemetry maps zero traces and is not ready", () => {
+    const plain = {
+      resourceSpans: [{ scopeSpans: [{ spans: [{
+        traceId: "plain",
+        spanId: "http",
+        attributes: [attr("http.request.method", "GET")],
+      }] }] }],
+    };
+    const result = mapOtlpToTraces(plain);
+    expect(result.traces).toHaveLength(0);
+    expect(result.summary).toMatchObject({ traces: 0, spans: 0, ignoredSpans: 1, invalid: true });
+  });
+});
+
+describe("authenticated OTLP JSON file import", () => {
+  test("imports GenAI traces, retains raw provenance, and deduplicates retry", async () => {
+    const t = convexTest(schema);
+    const { ids, asOwner } = await seed(t);
+    const json = JSON.stringify(payload);
+
+    const first = await asOwner.action(api.otlpFileImport.importOtlpJson, {
+      projectId: ids.projectId,
+      json,
+    });
+    expect(first).toMatchObject({ imported: 1, deduped: 0, summary: { traces: 1, ignoredSpans: 1 } });
+
+    const persisted = await t.run(async (ctx) => {
+      const trace = await ctx.db.query("agentTraces").first();
+      const imported = trace?.traceImportId ? await ctx.db.get(trace.traceImportId) : null;
+      return { trace, imported };
+    });
+    expect(persisted.trace?.status).toBe("ready");
+    expect(persisted.imported?.source).toBe("otlp");
+    expect(persisted.imported?.rawPayloadStorageId).toBeDefined();
+
+    const second = await asOwner.action(api.otlpFileImport.importOtlpJson, {
+      projectId: ids.projectId,
+      json,
+    });
+    expect(second).toMatchObject({ imported: 0, deduped: 1 });
+  });
+
+  test("rejects a file with no GenAI spans", async () => {
+    const t = convexTest(schema);
+    const { ids, asOwner } = await seed(t);
+    await expect(asOwner.action(api.otlpFileImport.importOtlpJson, {
+      projectId: ids.projectId,
+      json: JSON.stringify({ resourceSpans: [{ scopeSpans: [{ spans: [{ traceId: "x", attributes: [] }] }] }] }),
+    })).rejects.toThrow(/no genai spans/i);
+  });
+});

--- a/convex/tests/piImport.test.ts
+++ b/convex/tests/piImport.test.ts
@@ -1,0 +1,138 @@
+/// <reference types="vite/client" />
+import { convexTest } from "convex-test";
+import { describe, expect, test } from "vitest";
+import { api } from "../_generated/api";
+import schema from "../schema";
+import { parsePiSession } from "../lib/piTrace";
+
+const SESSION_ID = "11111111-2222-3333-4444-555555555555";
+
+const entries: ReadonlyArray<unknown> = [
+  { type: "session", version: 3, id: SESSION_ID, timestamp: "2026-07-10T10:00:00.000Z", cwd: "/work/blind-bench" },
+  { type: "message", id: "u1", parentId: null, timestamp: "2026-07-10T10:00:01.000Z", message: { role: "user", content: "Review the importer." } },
+  {
+    type: "message",
+    id: "a1",
+    parentId: "u1",
+    timestamp: "2026-07-10T10:00:02.000Z",
+    message: {
+      role: "assistant",
+      provider: "anthropic",
+      model: "claude-sonnet-4-7",
+      content: [
+        { type: "thinking", thinking: "I should inspect the parser." },
+        { type: "text", text: "I will read the file." },
+        { type: "toolCall", id: "call-1", name: "read", arguments: { path: "convex/import.ts", secret_token: "DO-NOT-SHOW" } },
+      ],
+      usage: { input: 100, output: 20, cacheRead: 5, cacheWrite: 0, totalTokens: 125, cost: { total: 0.01 } },
+      stopReason: "toolUse",
+      timestamp: 1783677602000,
+    },
+  },
+  {
+    type: "message",
+    id: "r1",
+    parentId: "a1",
+    timestamp: "2026-07-10T10:00:03.000Z",
+    message: {
+      role: "toolResult",
+      toolCallId: "call-1",
+      toolName: "read",
+      content: [{ type: "text", text: "export const importer = true;" }],
+      isError: false,
+      timestamp: 1783677603000,
+    },
+  },
+  // An abandoned branch must not interleave with the active path.
+  { type: "message", id: "alt-u", parentId: "u1", timestamp: "2026-07-10T10:00:03.500Z", message: { role: "user", content: "Ignore the importer." } },
+  { type: "message", id: "alt-a", parentId: "alt-u", timestamp: "2026-07-10T10:00:04.000Z", message: { role: "assistant", provider: "openai", model: "gpt-alt", content: [{ type: "text", text: "Abandoned answer" }], usage: { totalTokens: 999, cost: { total: 9 } }, stopReason: "stop", timestamp: 1783677604000 } },
+  { type: "model_change", id: "m1", parentId: "r1", timestamp: "2026-07-10T10:00:05.000Z", provider: "anthropic", modelId: "claude-opus-4-7" },
+  { type: "compaction", id: "c1", parentId: "m1", timestamp: "2026-07-10T10:00:06.000Z", summary: "Earlier work summarized", firstKeptEntryId: "r1", tokensBefore: 50000 },
+  { type: "message", id: "a2", parentId: "c1", timestamp: "2026-07-10T10:00:07.000Z", message: { role: "assistant", provider: "anthropic", model: "claude-opus-4-7", content: [{ type: "text", text: "The importer is ready for review." }], usage: { totalTokens: 40, cost: { total: 0.02 } }, stopReason: "stop", timestamp: 1783677607000 } },
+];
+
+const jsonl = entries.map((entry) => JSON.stringify(entry)).join("\n");
+
+async function seed(t: ReturnType<typeof convexTest>) {
+  const ids = await t.run(async (ctx) => {
+    const ownerUserId = await ctx.db.insert("users", { name: "Owner", email: "owner@test.com" });
+    const orgId = await ctx.db.insert("organizations", { name: "Org", slug: "org", createdById: ownerUserId });
+    await ctx.db.insert("organizationMembers", { organizationId: orgId, userId: ownerUserId, role: "owner" });
+    const projectId = await ctx.db.insert("projects", { organizationId: orgId, name: "P", createdById: ownerUserId });
+    await ctx.db.insert("projectCollaborators", { projectId, userId: ownerUserId, role: "owner", invitedById: ownerUserId, invitedAt: Date.now() });
+    return { ownerUserId, projectId };
+  });
+  return {
+    ids,
+    asOwner: t.withIdentity({ subject: `${ids.ownerUserId}|s`, tokenIdentifier: `test|${ids.ownerUserId}` }),
+  };
+}
+
+describe("Pi session JSONL parser", () => {
+  test("normalizes only the active tree path with messages, tools, usage, and compaction", () => {
+    const result = parsePiSession(jsonl);
+
+    expect(result.sessionId).toBe(SESSION_ID);
+    expect(result.trace.trace_id).toBe(`pi-${SESSION_ID}`);
+    expect(result.trace.harness).toEqual({ name: "pi", version: "3", sdk: "pi_session_jsonl" });
+    expect(result.trace.model).toBe("claude-opus-4-7");
+    expect(result.trace.final_answer).toBe("The importer is ready for review.");
+    expect(result.trace.usage.total_tokens).toBe(165);
+    expect(result.trace.usage.cost_usd).toBeCloseTo(0.03);
+    expect(result.summary.branchesExcluded).toBe(2);
+    expect(result.summary.compactions).toBe(1);
+    expect(result.summary.activeEntries).toBe(6);
+    expect(JSON.stringify(result.trace)).not.toContain("Abandoned answer");
+    expect(JSON.stringify(result.trace)).not.toContain("gpt-alt");
+    expect(result.trace.steps.map((step) => step.type)).toEqual([
+      "message",
+      "message",
+      "message",
+      "tool_call",
+      "tool_result",
+      "state",
+      "policy_event",
+      "message",
+    ]);
+    const toolCall = result.trace.steps.find((step) => step.type === "tool_call");
+    expect(toolCall?.type === "tool_call" ? toolCall.redacted_args : {}).toEqual({
+      path: "convex/import.ts",
+      secret_token: "[REDACTED]",
+    });
+  });
+
+  test("rejects a session whose active path has a missing parent", () => {
+    const broken = `${jsonl}\n${JSON.stringify({ type: "message", id: "bad", parentId: "missing", timestamp: "2026-07-10T10:00:08.000Z", message: { role: "user", content: "broken" } })}`;
+    expect(() => parsePiSession(broken)).toThrow(/missing parent/i);
+  });
+});
+
+describe("Pi session import through the trajectory spine", () => {
+  test("persists one trace, stores provenance, and deduplicates re-upload", async () => {
+    const t = convexTest(schema);
+    const { ids, asOwner } = await seed(t);
+
+    const first = await asOwner.action(api.piImport.importPiSession, {
+      projectId: ids.projectId,
+      jsonl,
+    });
+    expect(first.deduped).toBe(false);
+    expect(first.summary.steps).toBe(8);
+
+    const persisted = await t.run(async (ctx) => {
+      const trace = await ctx.db.query("agentTraces").first();
+      const imported = trace?.traceImportId ? await ctx.db.get(trace.traceImportId) : null;
+      return { trace, imported };
+    });
+    expect(persisted.trace?.status).toBe("ready");
+    expect(persisted.imported?.source).toBe("pi");
+    expect(persisted.imported?.rawPayloadStorageId).toBeDefined();
+
+    const second = await asOwner.action(api.piImport.importPiSession, {
+      projectId: ids.projectId,
+      jsonl,
+    });
+    expect(second.deduped).toBe(true);
+    expect(await t.run(async (ctx) => (await ctx.db.query("agentTraces").collect()).length)).toBe(1);
+  });
+});

--- a/convex/tests/trainingExport.test.ts
+++ b/convex/tests/trainingExport.test.ts
@@ -51,6 +51,16 @@ describe("#53 training-export data-boundary gate", () => {
     expect(excluded[0]?.reason).toBe("degenerate");
   });
 
+  test("invalid SFT roles or a missing final assistant turn are excluded", () => {
+    const rows: ClassifiedRow[] = [
+      { row: { kind: "sft", messages: [{ role: "developer", content: "x" }, { role: "assistant", content: "ok" }] }, privacyClass: "public" },
+      { row: { kind: "sft", messages: [{ role: "user", content: "unfinished" }] }, privacyClass: "public" },
+    ];
+    const { included, excluded } = gateRows(rows);
+    expect(included).toHaveLength(0);
+    expect(excluded.map((row) => row.reason)).toEqual(["invalid_sft_shape", "invalid_sft_shape"]);
+  });
+
   test("empty rows are excluded with a reason, never silently dropped", () => {
     const rows: ClassifiedRow[] = [
       { row: dpo({ chosen: "   " }), privacyClass: "public" },

--- a/convex/traceAdapters/cloudflareGatewayPreflight.test.ts
+++ b/convex/traceAdapters/cloudflareGatewayPreflight.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "vitest";
 import {
+  DEFAULT_MAX_BYTES,
   formatGatewayPreflightJson,
   formatGatewayPreflightText,
   summarizeGatewayPreflight,
@@ -87,5 +88,28 @@ describe("Cloudflare Gateway preflight", () => {
     expect(summary.parsed).toBe(0);
     expect(summary.invalid).toBe(1);
     expect(summary.caveats.join(" ")).toContain("No valid Gateway log records");
+    expect(formatGatewayPreflightText(summary)).not.toContain("safe_to_import");
+  });
+
+  test("blocks parser truncation instead of presenting a partial import as ready", () => {
+    const jsonl = Array.from({ length: 5_001 }, (_, index) => JSON.stringify({
+      log_id: `log-${index}`,
+      timestamp: "2026-07-09T10:00:00Z",
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      request: { messages: [{ role: "user", content: "fixture" }] },
+      response: { choices: [{ message: { content: "fixture" } }] },
+    })).join("\n");
+    const summary = summarizeGatewayPreflight(jsonl);
+    expect(summary.truncated).toBe(true);
+    expect(summary.status).toBe("blocked");
+  });
+
+  test("blocks files over the live importer's byte limit", () => {
+    const summary = summarizeGatewayPreflight("x".repeat(DEFAULT_MAX_BYTES + 1));
+    expect(summary.status).toBe("blocked");
+    expect(summary.over_size).toBe(true);
+    expect(summary.caveats.join(" ")).toMatch(/8 MiB.*limit/i);
+    expect(formatGatewayPreflightText(summary)).toContain("no_data_sent");
   });
 });

--- a/convex/traceAdapters/cloudflareGatewayPreflight.ts
+++ b/convex/traceAdapters/cloudflareGatewayPreflight.ts
@@ -15,6 +15,8 @@ export interface GatewayPreflightSummary {
   invalid: number;
   invalid_lines: number[];
   truncated: boolean;
+  over_size: boolean;
+  input_bytes: number;
   redacted_request: number;
   redacted_response: number;
   models: string[];
@@ -28,6 +30,8 @@ export interface GatewayPreflightSummary {
   };
   caveats: string[];
 }
+
+export const DEFAULT_MAX_BYTES = DEFAULT_LIMITS.maxBytes;
 
 export interface GatewayPreflightOptions {
   sidecarJson?: string;
@@ -49,6 +53,23 @@ export function summarizeGatewayPreflight(
   jsonl: string,
   options: GatewayPreflightOptions = {},
 ): GatewayPreflightSummary {
+  const inputBytes = new TextEncoder().encode(jsonl).byteLength;
+  if (inputBytes > DEFAULT_MAX_BYTES) {
+    return {
+      status: "blocked",
+      parsed: 0,
+      invalid: 0,
+      invalid_lines: [],
+      truncated: false,
+      over_size: true,
+      input_bytes: inputBytes,
+      redacted_request: 0,
+      redacted_response: 0,
+      models: [],
+      providers: [],
+      caveats: ["Input exceeds the authenticated importer's 8 MiB file limit; split the export before import."],
+    };
+  }
   let sidecar: SidecarMap | undefined;
   let sidecarEntries = 0;
   const sidecarSupplied = options.sidecarJson !== undefined;
@@ -61,13 +82,15 @@ export function summarizeGatewayPreflight(
   const parsed = parseGatewayJsonl(jsonl, DEFAULT_LIMITS, sidecar);
   const aggregate = summarizeTraces(parsed.traces);
   const matched = parsed.sidecarMerged.filter(Boolean).length;
-  const status: GatewayPreflightStatus = parsed.traces.length > 0 ? "ready" : "blocked";
+  const status: GatewayPreflightStatus = parsed.traces.length > 0 && !parsed.truncated ? "ready" : "blocked";
   const withoutCaveats: Omit<GatewayPreflightSummary, "caveats"> = {
     status,
     parsed: parsed.traces.length,
     invalid: parsed.invalidLines.length,
     invalid_lines: parsed.invalidLines.slice(0, MAX_REPORTED_INVALID_LINES),
     truncated: parsed.truncated,
+    over_size: false,
+    input_bytes: inputBytes,
     redacted_request: aggregate.redactedRequest,
     redacted_response: aggregate.redactedResponse,
     models: aggregate.models,
@@ -87,6 +110,8 @@ export function formatGatewayPreflightText(summary: GatewayPreflightSummary): st
   lines.push(`parsed: ${summary.parsed}`);
   lines.push(`invalid_lines: ${summary.invalid}${summary.invalid_lines.length ? ` (${summary.invalid_lines.join(", ")})` : ""}`);
   lines.push(`truncated: ${summary.truncated}`);
+  lines.push(`over_size: ${summary.over_size}`);
+  lines.push(`input_bytes: ${summary.input_bytes}`);
   lines.push(`models: ${summary.models.length ? summary.models.join(", ") : "unknown"}`);
   lines.push(`providers: ${summary.providers.length ? summary.providers.join(", ") : "unknown"}`);
   lines.push(`time_bounds: ${summary.earliest ?? "unknown"} → ${summary.latest ?? "unknown"}`);
@@ -100,7 +125,9 @@ export function formatGatewayPreflightText(summary: GatewayPreflightSummary): st
     lines.push("caveats:");
     for (const caveat of summary.caveats) lines.push(`- ${caveat}`);
   }
-  lines.push("safe_to_import: use the authenticated Gateway Import app surface next; this preflight did not send data anywhere.");
+  lines.push(summary.status === "ready"
+    ? "safe_to_import: use the authenticated Gateway Import app surface next; this preflight did not send data anywhere."
+    : "no_data_sent: preflight is blocked; resolve the caveats before authenticated import.");
   return lines.join("\n") + "\n";
 }
 

--- a/convex/traceImports.ts
+++ b/convex/traceImports.ts
@@ -9,6 +9,10 @@ const SOURCE_VALIDATOR = v.union(
   v.literal("manual_paste"),
   v.literal("cloudflare_ai_gateway"),
   v.literal("claude_code"),
+  v.literal("pi"),
+  v.literal("csv"),
+  v.literal("otlp"),
+  v.literal("native"),
 );
 
 /**

--- a/docs/canonical-demo-loop.md
+++ b/docs/canonical-demo-loop.md
@@ -5,9 +5,7 @@ it without understanding the whole platform.
 
 ## One path we lead with
 
-1. **Bring in one agent run** — native `eval-record` v1, Claude Code JSONL,
-   Gateway/OTLP, or another thin adapter. The adapter choice is not the story;
-   every path normalizes into the same agent-trace spine.
+1. **Bring in completed runs** — mapped CSV, native `eval-record` v1, OTLP JSON or live OTLP, Pi session JSONL, Claude Code JSONL, Gateway logs, or another thin adapter. The adapter choice is not the story; every path normalizes into the same agent-trace spine.
 2. **Send one blind review link** — a domain expert opens the run or matchup
    without version/model/harness provenance. For trajectories, the promise is
    bias reduction, not perfect anonymity.
@@ -20,8 +18,7 @@ it without understanding the whole platform.
 
 - Do not lead with adapter breadth. Native JSON is the public contract; OTLP,
   Cloudflare Gateway, Claude Code, Harbor, and future emitters are adapters.
-- Do not lead with sandbox orchestration. Harbor/Daytona/etc. own execution;
-  Blind Bench owns import, blind judgment, and evidence artifacts.
+- Do not lead with or own sandbox orchestration. Pi, Claude Code, CI, Harbor/Daytona, gateways, and customer harnesses own execution; Blind Bench owns import, blind judgment, and evidence artifacts. The prompt playground remains secondary.
 - Do not lead with DPO unless the captured review data is comparable and
   non-degenerate. Exclusions must be reported.
 - Do not claim trace anonymity. Say "blind review" and explain it as provenance

--- a/docs/claude-code-session-preflight.md
+++ b/docs/claude-code-session-preflight.md
@@ -5,6 +5,10 @@ Use this local preflight before uploading an internal Claude Code session transc
 ```bash
 npm run preflight:claude-code -- /path/to/session.jsonl
 npm run preflight:claude-code -- /path/to/session.jsonl --json
+# Machine-readable stdout without npm's command banner:
+npm run --silent preflight:claude-code -- /path/to/session.jsonl --json
+# Equivalent direct invocation:
+npx tsx scripts/claude-code-session-preflight.ts /path/to/session.jsonl --json
 ```
 
 The preflight is intentionally local-only:

--- a/docs/ingestion-first.md
+++ b/docs/ingestion-first.md
@@ -1,0 +1,54 @@
+# Ingestion-first operator guide
+
+Blind Bench reviews completed AI behavior. It does not execute Pi, Claude Code, arbitrary harness code, or customer sandboxes.
+
+## Choose an input
+
+Use the authenticated project **Import runs** tab for files up to 8 MiB:
+
+| Input | Best for | Required shape |
+| --- | --- | --- |
+| CSV | Flat prompt/output or interaction batches | Header row, then map input and output; optional ID, system, timestamp, model, provider, harness, product, module, environment, privacy class, and metadata columns |
+| OpenTelemetry JSON | Captured multi-span GenAI traces | OTLP/HTTP `resourceSpans`; only recognized GenAI spans import |
+| Pi session JSONL | One coding-agent trajectory | Pi session v3 header and tree-linked entries; importer follows one deterministic active leaf path |
+| Claude Code JSONL | One Claude Code trajectory | Claude Code session transcript records |
+
+For continuous collection, use the token-authenticated native `eval-record` v1 or OTLP endpoints documented in [`native-ingest.md`](./native-ingest.md). Cloudflare Gateway exports remain available through the Gateway import flow.
+
+## Import contract
+
+Every adapter:
+
+1. authenticates and checks project editor/owner access;
+2. enforces bounded input before persistence;
+3. normalizes into the shared `agentTraces` / paginated `agentTraceSteps` spine;
+4. stores raw provenance and large full/blind step bodies in access-controlled file storage;
+5. returns counts and caveats without echoing raw prompts, outputs, tool bodies, or malformed lines;
+6. deduplicates retries by a stable source/content identity.
+
+CSV is intentionally flat. Use OTLP or harness JSONL when order, tool calls, branches, compactions, or multi-step structure matter.
+
+## Review and reuse
+
+After import:
+
+1. Open **Review** and create or use the opaque trace-review session link.
+2. Send the link to a reviewer who does not already have owner/editor provenance access.
+3. The reviewer submits an independent verdict, comment, or matchup decision.
+4. Owners may reveal provenance after review and route judgments into regression/evidence or training export.
+
+Blind trajectory review is provenance stripping and bias reduction, not a claim of perfect anonymity. Tool patterns may still fingerprint a harness.
+
+DPO export is default-deny: both options must have the same persisted trajectory-prefix hash and independent reviewer decisions must resolve to one winner. Prefix mismatch, disagreement, tie, skip, or missing decisions are explicit exclusions. SFT/evidence exports remain available under their own approval rules.
+
+## Data boundary
+
+Structured key-name redaction protects recognized sensitive tool fields. Free-text prompts, outputs, logs, and attachments are not guaranteed to be scrubbed. Import only data the workspace is approved to store and review.
+
+Before live customer/operator logs:
+
+```bash
+npm run readiness:customer-testing
+```
+
+A blocked result is intentional. A generated launch packet or sanitized customer label is not consent and does not approve live-log import. Follow [`customer-testing-readiness.md`](./customer-testing-readiness.md) and [`customer-test-launch-packet.md`](./customer-test-launch-packet.md).

--- a/docs/required-checks.md
+++ b/docs/required-checks.md
@@ -1,0 +1,26 @@
+# Required main-branch checks
+
+The pull-request workflow in `.github/workflows/required-checks.yml` runs the release checks that do not require customer credentials:
+
+- `npm run build`
+- `npm run test:evals`
+- `npm run test:convex`
+- `npm run test:ct` in Chromium
+
+Run all four locally with `npm run test:all` after Convex generated types are available. CI generates offline Convex type stubs because it does not connect to a deployment.
+
+Repository administrators should require both workflow jobs before merging to `main`:
+
+- **Required checks / build-and-tests**
+- **Required checks / browser-components**
+
+These checks cover parsing, persistence, blind projection/session boundaries, independent decisions, export exclusions, and browser component behavior. They do **not** prove a deployed authenticated two-account journey.
+
+Before claiming customer production readiness, also run a deployed browser E2E with synthetic data across two principals:
+
+1. owner imports CSV, OTLP, Pi, and Claude Code fixtures;
+2. blind reviewer opens only an opaque session URL and submits a verdict/comment and matchup decision;
+3. owner reveals provenance and generates reuse/export artifacts;
+4. browser network payloads and DOM are inspected against the 13 blind-eval rules.
+
+Until that deployed check and real external approval records are present, `readiness:customer-testing` must remain blocked and a green CI run must not be described as customer-production approval.

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test:evals": "vitest run src/lib/evals/",
     "test:convex": "vitest run --config convex/vitest.config.ts",
     "test:ct": "playwright test -c playwright-ct.config.ts",
+    "test:all": "npm run build && npm run test:evals && npm run test:convex && npm run test:ct",
     "test:landing-journey": "node scripts/landing-journey-check.mjs",
     "preflight:claude-code": "npx tsx scripts/claude-code-session-preflight.ts",
     "scorecard:demo": "npx tsx src/lib/evals/scorecard.ts",

--- a/project-docs/Blind Bench - Architecture.md
+++ b/project-docs/Blind Bench - Architecture.md
@@ -14,7 +14,7 @@ tags:
 
 > Part of [[MOC - Blind Bench]]
 
-> "Git meets Google Docs" for collaborative prompt engineering
+> Ingestion-neutral blind human review for completed AI runs
 
 ---
 
@@ -40,20 +40,19 @@ tags:
 
 ## Overview
 
-**Blind Bench** is a collaborative prompt engineering platform that enables teams to iteratively refine prompts through structured human evaluation and LLM-assisted improvements.
+**Blind Bench** is the execution-neutral blind human-review layer for completed AI runs. Customers execute prompts and agents in their existing harnesses, gateways, CI, or observability stack; Blind Bench imports the resulting evidence, removes provenance from reviewer-facing projections, captures independent judgment, and exports reusable evaluation artifacts.
 
-### Core Workflow
+### Core Workflow (M33 direction of record)
 
 ```
-1. CREATE        2. RUN            3. EVALUATE         4. OPTIMIZE
-──────────       ────────          ──────────          ──────────
-User creates     Prompt runs       Collaborators       System generates
-prompt with      3x against        review outputs      new prompt from
-variables        a test case       blind, leave        all feedback
-                                   feedback
-
-                        ◄────────── REPEAT ──────────►
+1. EXECUTE ELSEWHERE   2. IMPORT          3. REVIEW BLIND     4. REUSE
+───────────────────    ─────────          ───────────────     ────────
+Pi, Claude Code,       CSV, OTLP, native  Experts inspect     Verdicts become
+CI, gateways, and      JSON, or harness   opaque trajectory   regression cases,
+customer runtimes      session JSONL      review sessions     evidence, or exports
 ```
+
+The original prompt playground remains supported as a secondary authoring and experimentation tool. It is not the first-run path or the architectural center. Blind Bench does **not** provision sandboxes, execute arbitrary harness code, store runtime credentials, or own runtime cleanup and compute billing.
 
 ### Tech Stack
 
@@ -64,7 +63,8 @@ variables        a test case       blind, leave        all feedback
 | Database | Convex DB |
 | Auth | Convex Auth |
 | File Storage | Convex file storage |
-| LLM Provider | OpenRouter (BYOK per org) |
+| Optional playground LLM provider | OpenRouter (BYOK per org; secondary flow) |
+| Primary ingest boundary | Native `eval-record` v1 plus CSV, OTLP, Pi, and Claude Code adapters |
 | Observability | TODO — action-layer seam preserved |
 
 ---

--- a/project-docs/Blind Bench - Build Plan.md
+++ b/project-docs/Blind Bench - Build Plan.md
@@ -614,6 +614,35 @@ This milestone is **not done** if any acceptance criterion is "mostly passing": 
 
 ---
 
+## M33 — Ingestion-First Pivot (2026-07)
+
+**Goal**: make completed-run ingestion the primary product flow while retaining the prompt playground as a secondary tool. This milestone supersedes the deferred M32 hosted-runtime direction; issues #320–#332 remain closed as historical context, not deleted.
+
+### Product boundary
+
+- Blind Bench owns import, normalization receipts, opaque blind review, independent judgments, and regression/training/evidence exports.
+- Customer harnesses, Pi, Claude Code, CI systems, gateways, and observability platforms own execution.
+- No Blind Bench-owned sandbox provisioning, arbitrary harness execution, runtime credentials, compute billing, or cleanup.
+
+### Deliverables
+
+1. One authenticated **Import runs** surface for mapped CSV, OTLP/HTTP GenAI JSON, Pi v3 session JSONL, and Claude Code session JSONL.
+2. Storage-backed raw provenance, bounded parsing, counts-only summaries, and idempotent retries for every adapter.
+3. Ingestion-first welcome, new-project, project navigation, and actionable trace empty states; playground remains reachable but secondary.
+4. Opaque trace-review session URLs, token-scoped reviewer APIs, and independent per-reviewer matchup decisions.
+5. SHA-256 shared-prefix comparability checks and default-deny DPO export with explicit disagreement/tie/skip/mismatch exclusions.
+6. Honest preflight/readiness gates, browser component coverage, and a canonical import → review → reuse integration test.
+
+### Testable demo
+
+> Upload a synthetic CSV, OTLP payload, Pi session, or Claude Code session → receive a safe import receipt → open a second-principal opaque review link → submit a verdict/comment or matchup decision → reveal provenance only to an authorized owner → export the judgment, with non-comparable DPO rows explicitly excluded.
+
+### Out of scope
+
+Hosted Pi SDK execution, Daytona/Modal/E2B orchestration, runtime profile editors, arbitrary-code BYOK, and runtime compute billing. Reconsider only if repeated paid-pilot evidence shows customers need Blind Bench to generate runs rather than judge them.
+
+---
+
 ## Out of scope for v1 (restated)
 
 These carry forward from [[Blind Bench - Architecture#v1 Scope & Deferred]] so this doc is self-contained:
@@ -639,7 +668,7 @@ These carry forward from [[Blind Bench - Architecture#v1 Scope & Deferred]] so t
 - **M4 (non-negotiable)**: every authorization check on the runs/versions/feedback functions must have a test proving an Evaluator is rejected and an Editor/Owner is allowed. Plus a test that `getOutputsForEvaluator` returns only the expected fields.
 - M5: optimizer output validation — every failure mode from [[Blind Bench - Optimizer Meta-Prompt#5 Failure modes and action-level validation]] has a test that feeds in a crafted bad output and asserts the request fails with the right error message.
 
-**No E2E framework in v1.** Playwright and similar are deferred.
+**Browser verification (M33).** Playwright component tests are required for import and blind-review surfaces. The canonical deployed import → second-principal review → reuse journey remains a required release gate; until authenticated deployed E2E credentials and branch protection are configured, production customer readiness must remain explicitly blocked rather than inferred from unit tests.
 
 **Adversarial check at M4**: sit down with devtools open and try to break blind eval. Check every rule in [[Blind Bench - UX Spec#10 Blind eval security rules]] manually. If you find a leak, the milestone is not done.
 

--- a/project-docs/Blind Bench - Glossary.md
+++ b/project-docs/Blind Bench - Glossary.md
@@ -42,6 +42,10 @@ An image file stored in Convex file storage and wired into a run for vision mode
 
 Never stored as URLs — always resolved via `ctx.storage.getUrl()` at read time. At dispatch, blobs are inlined as base64 `data:` URLs in OpenRouter's `image_url` content blocks (mimic of OpenAI multimodal format). See [[Blind Bench - Architecture#File Storage & DB Size]].
 
+### Completed run
+
+AI behavior executed outside Blind Bench and supplied for judgment. A completed run may be a flat prompt/output interaction or a multi-step agent trajectory. CSV, OTLP, native `eval-record` JSON, Pi session JSONL, and Claude Code session JSONL are adapter inputs; all normalize into the common trace spine.
+
 ### Blind Mode
 
 A per-invite, per-collaborator boolean flag (`projectCollaborators.blindMode`, `invitations.blindMode`) that gates whether a [[#Reviewer]] sees the prompt or only blinded [[#Output]]s. Introduced in M26. Only meaningful when `role === "evaluator"`; ignored for [[#Owner (role)]] / [[#Editor (role)]] / org roles.
@@ -90,6 +94,10 @@ A [[#Collaborator]] who can only see blinded [[#Output]]s (labeled A/B/C with no
 ### Fan-out
 
 The pattern of executing a single [[#Run]] as three parallel OpenRouter calls, producing three [[#Output]]s with blind labels `A`/`B`/`C`. Configured via `runCount` on the `runs.execute` mutation. The primitive behind A/B/C blind evaluation. See [[Blind Bench - Architecture#How a run actually executes in Convex]].
+
+### Import receipt
+
+A counts-only, content-safe summary returned after an import. It reports imported, deduplicated, ignored, invalid, missing-body, model/harness completeness, and caveat counts as applicable; it never echoes raw prompts, outputs, tool bodies, credentials, or transcript lines.
 
 ### Image variable
 
@@ -176,6 +184,10 @@ The `evaluator` literal is retained in code (`projectCollaborators.role`, `cycle
 ### Rollback
 
 Creating a new [[#Version]] at the head of the sequence by copying the content of an earlier version. The new version has `parentVersionId` pointing to the current head and `sourceVersionId` pointing to the copied version. Preserves both sequence and rollback origin without branching. See [[Blind Bench - Architecture#Key Design Decisions]].
+
+### Runtime-neutral
+
+The product boundary in which Blind Bench does not execute arbitrary customer harnesses, provision sandboxes, hold runtime credentials, or own compute cleanup/billing. External systems produce [[#Completed run|completed runs]]; Blind Bench imports, blinds, reviews, and exports judgment. The prompt playground is a secondary exception for focused prompt experiments, not the canonical agent flow.
 
 ### Run
 

--- a/project-docs/Blind Bench - Positioning One-Pager.md
+++ b/project-docs/Blind Bench - Positioning One-Pager.md
@@ -1,14 +1,14 @@
 # Blind Bench — Positioning One-Pager
 
-*v1 · 2026-07-08 · Decision of record (Noah): agent-first framing. Working history
-and persona detail live in [[Blind Bench - Positioning]]; where they conflict,
-this one-pager wins.*
+*v2 · 2026-07-10 · Decision of record: ingestion-first, execution-neutral human review. Working history and persona detail live in [[Blind Bench - Positioning]]; where they conflict, this one-pager wins.*
 
 ---
 
 ## One-liner
 
-**Blind Bench is the blind human-review layer for AI agents.**
+**Bring your traces. Blind Bench turns them into defensible human judgment.**
+
+Blind Bench is the blind human-review layer for AI agents and model outputs; it does not run the agent for you.
 
 Your domain experts review agent trajectories — and plain model outputs — without
 knowing which version, model, or harness produced them. Their judgment becomes
@@ -48,17 +48,12 @@ randomized, blinded human tests) is the one no platform ships.
 
 ## What Blind Bench is not
 
-Not an observability platform, not an LLM-judge vendor, not a labeling
-workforce, not a crowd arena. Keep Braintrust, LangSmith, Langfuse, your
-gateway, your judges. Blind Bench sits above them as the judgment layer they
-feed into.
+Not an observability platform, not an LLM-judge vendor, not a labeling workforce, not a crowd arena, and not a hosted agent runtime or sandbox orchestrator. Keep Pi, Claude Code, Braintrust, LangSmith, Langfuse, your gateway, CI, and your judges. They execute or observe; Blind Bench sits above them as the judgment layer they feed into. The original prompt playground remains available for focused experiments, but it is secondary.
 
 ## How agent data gets in
 
 One versioned public contract — `eval-record` v1, plain JSON over HTTPS — with
-adapters meeting data where it lives: agent harnesses (Claude Code today, more
-to follow), OpenTelemetry / AI-gateway push, log import, and thin customer-side
-exporters from existing trace platforms. Per-project tokens, counts-only
+adapters meeting data where it lives: mapped CSV for flat interactions, Pi and Claude Code session JSONL for coding trajectories, OpenTelemetry / AI-gateway push and file upload, and thin customer-side exporters from existing trace platforms. Per-project tokens, counts-only
 responses, BYOK throughout: Blind Bench never holds your model, gateway, or
 platform credentials.
 

--- a/project-docs/Blind Bench - UX Spec.md
+++ b/project-docs/Blind Bench - UX Spec.md
@@ -67,7 +67,9 @@ Six opinionated constraints that everything below has to respect.
 /orgs/:orgSlug/settings                         → org general settings
 /orgs/:orgSlug/settings/members                 → org member + role management
 /orgs/:orgSlug/settings/openrouter-key          → BYOK: set / rotate / check status
-/orgs/:orgSlug/projects/:projectId              → project home: current version, recent runs, pending optimizations
+/orgs/:orgSlug/projects/:projectId              → project home: imported runs and review activity
+/orgs/:orgSlug/projects/:projectId/import       → primary import surface: CSV, OTLP JSON, Pi JSONL, Claude Code JSONL
+/orgs/:orgSlug/projects/:projectId/traces       → completed trajectory list and owner reveal/detail
 /orgs/:orgSlug/projects/:projectId/versions     → version history / timeline
 /orgs/:orgSlug/projects/:projectId/versions/:versionId → version editor (system + user template + variables chips + attachments + config + Run)
 /orgs/:orgSlug/projects/:projectId/variables    → project variable manager
@@ -118,7 +120,7 @@ The application shell (top bar + side nav + main content) differs by role.
 Within a project, a secondary nav appears as tabs at the top of the main content area:
 
 ```
-Editor  Versions  Runs  Test Cases  Variables  Meta Context  Compare  Settings
+Import runs  Traces  Review  Playground  Versions  Runs  Test Cases  Export  Settings
 ```
 
 ### Evaluator shell
@@ -168,14 +170,15 @@ Each screen entry has: **route**, **roles**, **purpose**, **layout**, **primary 
 - **States**: Loading, Error (token expired / invalid).
 - **Transitions out**: Same as sign-in success.
 
-### 4.4 First-run welcome (M29.4)
+### 4.4 First-run welcome (M33)
 - **Route**: `/welcome`.
 - **Roles**: Authenticated, zero owned projects.
-- **Purpose**: One question, two paths into a real, mutable project.
-- **Layout**: Centered card on the same Grainient backdrop as `/auth/sign-in` for a continuous post-auth handoff. Headline ("What are you working on?"), two-tab control: "I have a prompt" (textarea + system/user role toggle + "Create project") and "Show me an example" (one paragraph + "Load example project").
-- **Primary actions**: `projects.createFromPaste` (paste path) or `projects.cloneStarter` (example path). Both lazily create a personal workspace if the user doesn't already own one.
+- **Purpose**: Start from completed AI behavior without requiring Blind Bench to execute it.
+- **Layout**: Centered card headed "Bring in completed AI runs". The default tab is **Import runs**, naming CSV, OpenTelemetry, Pi, and Claude Code. **Prompt playground** and **Example** remain adjacent secondary tabs.
+- **Primary action**: create the personal workspace/project and transition directly to `/orgs/:orgSlug/projects/:projectId/import`.
+- **Secondary actions**: create a project from pasted prompt content or clone the starter example.
 - **States**: Idle, Submitting (per path), Error.
-- **Transitions out**: `/orgs/:orgSlug/projects/:projectId/versions/:versionId` — directly into the editor with the user's content already saved.
+- **Product boundary copy**: the import path states that Blind Bench normalizes evidence and never runs the customer's harness.
 
 ### 4.4b Org bootstrap (legacy)
 - **Route**: `/onboarding`. Reachable only as a fallback when the welcome screen errors and there's no membership to land on.
@@ -222,13 +225,19 @@ Each screen entry has: **route**, **roles**, **purpose**, **layout**, **primary 
 ### 4.9 Project home
 - **Route**: `/orgs/:orgSlug/projects/:projectId`.
 - **Roles**: Owner, Editor.
-- **Purpose**: The project dashboard. Summarize state, point at next actions.
-- **Layout**: Project title + secondary nav at the top. Main content is a 2/3 + 1/3 split:
-  - **Left (2/3)**: "Current version" card (version number, status pill, diff-stat vs parent, "Edit" button); below it, "Recent runs" list (5 most recent runs with timestamp, test case name, model, status pill, 3 blind-label mini-previews).
-  - **Right (1/3)**: Collaborators list (avatars with role badges), pending optimization requests count with link, meta-context completeness ("3 of 3 questions answered"), BYOK status ("Key set" / "No key — set one").
-- **Primary actions**: Edit current version, view recent run, request optimization (if feedback exists).
-- **Secondary actions**: View all versions, view all runs, invite collaborator.
-- **States**: Populated, Empty (new project with no versions — shows a "Draft your first prompt" CTA that jumps to the version editor).
+- **Purpose**: Summarize imported trajectories and review activity, then point at the next import/review/reuse action.
+- **Primary actions**: Import completed runs, open review queue, reuse judgments.
+- **Secondary actions**: Open the prompt playground, manage collaborators, inspect historical prompt versions/runs.
+- **States**: Populated; Empty with actionable "Import completed runs" copy linking to the import surface.
+
+### 4.9b Import completed runs (M33)
+- **Route**: `/orgs/:orgSlug/projects/:projectId/import`.
+- **Roles**: Owner, Editor.
+- **Purpose**: Normalize completed behavior from customer-owned runtimes into the common trajectory spine.
+- **Layout**: Source chooser for mapped CSV, OpenTelemetry GenAI JSON, Pi session JSONL, and Claude Code session JSONL; bounded file picker; CSV field mapping; counts-only completeness receipt; governance warning.
+- **Primary action**: Import runs.
+- **States**: Empty, file selected, mapping required, importing, completed receipt, blocked validation/error.
+- **Safety**: never echo raw row/transcript content in receipts or logs; retain raw provenance access-controlled and storage-backed; idempotent retries; non-GenAI OTLP spans are ignored and counted.
 
 ### 4.10 Version list / history
 - **Route**: `/orgs/:orgSlug/projects/:projectId/versions`.

--- a/scripts/canonical-demo-readiness.ts
+++ b/scripts/canonical-demo-readiness.ts
@@ -5,7 +5,7 @@ const invokedDirectly =
   process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href;
 
 if (invokedDirectly) {
-  runCanonicalDemoReadiness()
+  runCanonicalDemoReadiness({ generated_at: new Date().toISOString() })
     .then((report) => {
       process.stdout.write(
         `Wrote artifacts/canonical-demo-readiness.{md,json} — status: ${report.status}.\n`,

--- a/scripts/customer-test-launch-packet.ts
+++ b/scripts/customer-test-launch-packet.ts
@@ -53,6 +53,7 @@ export async function main(argv: string[]): Promise<number> {
   const packet = buildCustomerTestLaunchPacket({
     outDir: args.outDir,
     customerLabel: args.customerLabel,
+    generatedAt: new Date().toISOString(),
   });
   writeCustomerTestLaunchPacket(packet);
   process.stdout.write(args.json ? formatCustomerTestLaunchPacketJson(packet) : formatCustomerTestLaunchPacketMarkdown(packet));

--- a/scripts/customer-testing-readiness.ts
+++ b/scripts/customer-testing-readiness.ts
@@ -68,7 +68,11 @@ export async function main(argv: string[]): Promise<number> {
     }
   }
 
-  const report = buildCustomerTestingReadinessReport({ approvals, outDir: args.outDir });
+  const report = buildCustomerTestingReadinessReport({
+    approvals,
+    outDir: args.outDir,
+    generatedAt: new Date().toISOString(),
+  });
   writeCustomerTestingReadinessReport(report);
   process.stdout.write(args.json ? formatCustomerTestingReadinessJson(report) : formatCustomerTestingReadinessMarkdown(report));
   return report.status === "ready_for_customer_testing" ? 0 : 1;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -52,6 +52,7 @@ const VersionDashboard = lazy(() => import("./routes/orgs/projects/cycles/Versio
 const EvaluatePage = lazy(() => import("./routes/orgs/projects/EvaluatePage").then(m => ({ default: m.EvaluatePage })));
 const ExportTraining = lazy(() => import("./routes/orgs/projects/ExportTraining").then(m => ({ default: m.ExportTraining })));
 const IngestEndpoint = lazy(() => import("./routes/orgs/projects/IngestEndpoint").then(m => ({ default: m.IngestEndpoint })));
+const ImportRuns = lazy(() => import("./routes/orgs/projects/ImportRuns").then(m => ({ default: m.ImportRuns })));
 const TraceList = lazy(() => import("./routes/traces/TraceList").then(m => ({ default: m.TraceList })));
 const TraceViewer = lazy(() => import("./routes/traces/TraceViewer").then(m => ({ default: m.TraceViewer })));
 const TraceMatchup = lazy(() => import("./routes/traces/TraceMatchup").then(m => ({ default: m.TraceMatchup })));
@@ -94,7 +95,8 @@ export function App() {
             <Route path="settings/openrouter-key" element={<OpenRouterKey />} />
             <Route path="settings/billing" element={<Billing />} />
             <Route path="projects/:projectId" element={<ProjectLayout />}>
-              <Route index element={<Navigate to="versions" replace />} />
+              <Route index element={<Navigate to="import" replace />} />
+              <Route path="import" element={<ImportRuns />} />
               <Route path="variables" element={<Variables />} />
               <Route path="test-cases" element={<TestCases />} />
               <Route
@@ -146,8 +148,8 @@ export function App() {
           <Route path="/eval" element={<EvalLayout />}>
             <Route index element={<InvitesInbox />} />
             <Route path="traces" element={<TraceReviewList />} />
-            <Route path="traces/:agentTraceId" element={<TraceReview />} />
-            <Route path="matchups/:matchupId" element={<TraceMatchupReview />} />
+            <Route path="traces/:reviewToken" element={<TraceReview />} />
+            <Route path="matchups/:reviewToken" element={<TraceMatchupReview />} />
           </Route>
           <Route path="/denied" element={<Denied />} />
           <Route path="*" element={<NotFound />} />

--- a/src/components/NewProjectDialog.tsx
+++ b/src/components/NewProjectDialog.tsx
@@ -32,9 +32,10 @@ export function NewProjectDialog({
   const createWithPrompt = useMutation(api.projects.createWithPrompt);
 
   const [step, setStep] = useState<"info" | "prompt">("info");
+  const [projectMode, setProjectMode] = useState<"import" | "playground">("import");
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
-  const [seedSample, setSeedSample] = useState(true);
+  const [seedSample, setSeedSample] = useState(false);
   const [promptText, setPromptText] = useState("");
   const [varDefaults, setVarDefaults] = useState<Record<string, string>>({});
   const [saving, setSaving] = useState(false);
@@ -47,9 +48,10 @@ export function NewProjectDialog({
 
   function resetState() {
     setStep("info");
+    setProjectMode("import");
     setName("");
     setDescription("");
-    setSeedSample(true);
+    setSeedSample(false);
     setPromptText("");
     setVarDefaults({});
     setError("");
@@ -64,13 +66,15 @@ export function NewProjectDialog({
         orgId,
         name: name.trim(),
         description: description.trim() || undefined,
-        seedSample: seedSample || undefined,
+        seedSample: projectMode === "playground" && seedSample ? true : undefined,
       });
       onOpenChange(false);
       resetState();
-      navigate(`/orgs/${org.slug}/projects/${projectId}`);
+      navigate(
+        `/orgs/${org.slug}/projects/${projectId}/${projectMode === "import" ? "import" : "versions"}`,
+      );
     } catch (err) {
-      setError(friendlyError(err, "Failed to create prompt."));
+      setError(friendlyError(err, "Failed to create the project."));
     } finally {
       setSaving(false);
     }
@@ -108,7 +112,7 @@ export function NewProjectDialog({
       <DialogContent className="sm:max-w-lg">
         <DialogHeader>
           <DialogTitle>
-            {step === "info" ? "New prompt" : "Paste your prompt"}
+            {step === "info" ? "New project" : "Paste your prompt"}
           </DialogTitle>
         </DialogHeader>
 
@@ -133,19 +137,38 @@ export function NewProjectDialog({
                 placeholder="What this prompt is about"
               />
             </div>
-            <div>
-              <label className="flex items-center gap-2 cursor-pointer">
-                <Checkbox
-                  checked={seedSample}
-                  onCheckedChange={(checked) => setSeedSample(!!checked)}
-                />
-                <span className="text-sm">Start with a sample prompt</span>
-              </label>
-              <p className="mt-1 ml-6 text-xs text-muted-foreground">
-                Includes a sample prompt, variable, and test case so you can try
-                the full workflow immediately.
-              </p>
+            <div className="grid gap-2 sm:grid-cols-2">
+              <button
+                type="button"
+                onClick={() => { setProjectMode("import"); setSeedSample(false); }}
+                className={`rounded-lg border p-3 text-left text-sm ${projectMode === "import" ? "border-primary bg-primary/5" : "hover:bg-muted/40"}`}
+              >
+                <span className="font-medium">Import completed runs</span>
+                <span className="mt-1 block text-xs text-muted-foreground">CSV, OpenTelemetry, Pi, or Claude Code.</span>
+              </button>
+              <button
+                type="button"
+                onClick={() => { setProjectMode("playground"); setSeedSample(true); }}
+                className={`rounded-lg border p-3 text-left text-sm ${projectMode === "playground" ? "border-primary bg-primary/5" : "hover:bg-muted/40"}`}
+              >
+                <span className="font-medium">Prompt playground</span>
+                <span className="mt-1 block text-xs text-muted-foreground">Draft and run prompts inside Blind Bench.</span>
+              </button>
             </div>
+            {projectMode === "playground" && (
+              <div>
+                <label className="flex items-center gap-2 cursor-pointer">
+                  <Checkbox
+                    checked={seedSample}
+                    onCheckedChange={(checked) => setSeedSample(!!checked)}
+                  />
+                  <span className="text-sm">Start with a sample prompt</span>
+                </label>
+                <p className="mt-1 ml-6 text-xs text-muted-foreground">
+                  Includes a sample prompt, variable, and test case.
+                </p>
+              </div>
+            )}
             {error && <p className="text-sm text-destructive">{error}</p>}
             <div className="flex justify-between">
               <Button
@@ -156,19 +179,22 @@ export function NewProjectDialog({
                 Cancel
               </Button>
               <div className="flex gap-2">
-                <Button
-                  type="button"
-                  variant="outline"
-                  disabled={saving || !name.trim()}
-                  onClick={() => { setSeedSample(false); setStep("prompt"); }}
-                >
-                  Paste a prompt instead
-                </Button>
-                <Button
-                  disabled={saving || !name.trim()}
-                  onClick={handleCreateBlank}
-                >
-                  {saving ? "Creating..." : "Create"}
+                {projectMode === "playground" && (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    disabled={saving || !name.trim()}
+                    onClick={() => { setSeedSample(false); setStep("prompt"); }}
+                  >
+                    Paste a prompt instead
+                  </Button>
+                )}
+                <Button disabled={saving || !name.trim()} onClick={handleCreateBlank}>
+                  {saving
+                    ? "Creating..."
+                    : projectMode === "import"
+                      ? "Create and import"
+                      : "Create playground"}
                 </Button>
               </div>
             </div>

--- a/src/components/ProjectTabs.tsx
+++ b/src/components/ProjectTabs.tsx
@@ -4,12 +4,16 @@ import { cn } from "@/lib/utils";
 import { Settings } from "lucide-react";
 
 const tabs = [
-  { label: "Editor", path: "versions" },
-  { label: "Run", path: "run" },
-  { label: "Test Cases", path: "test-cases" },
-  { label: "Evaluate", path: "evaluate" },
+  { label: "Import", path: "import" },
+  { label: "Trajectories", path: "traces" },
+  { label: "Review", path: "evaluate" },
   { label: "Export", path: "export" },
-  { label: "Ingest", path: "ingest" },
+  { label: "Live ingest", path: "ingest" },
+  // The original prompt playground remains available, but imported behavior is
+  // the primary product flow.
+  { label: "Playground", path: "versions" },
+  { label: "Run prompt", path: "run" },
+  { label: "Test Cases", path: "test-cases" },
   { label: "History", path: "history" },
 ];
 
@@ -29,12 +33,13 @@ export function ProjectTabs() {
           // Evaluators: hide authoring/setup tabs
           if (
             role === "evaluator" &&
-            (tab.label === "Run" ||
-              tab.label === "Editor" ||
+            (tab.label === "Import" ||
+              tab.label === "Playground" ||
+              tab.label === "Run prompt" ||
               tab.label === "Test Cases" ||
-              tab.label === "Evaluate" ||
+              tab.label === "Review" ||
               tab.label === "Export" ||
-              tab.label === "Ingest")
+              tab.label === "Live ingest")
           )
             return null;
 

--- a/src/lib/evals/canonicalReadiness.ts
+++ b/src/lib/evals/canonicalReadiness.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import { main as scorecardMain } from "./scorecard";
 import { main as comparisonMain } from "./modelComparison";
 import { main as trainingDatasetMain } from "./trainingDataset";
+import { verifyTrainingExportArtifacts } from "./trainingExportVerifier";
 
 export type ReadinessStatus = "pass" | "fail";
 
@@ -124,15 +125,17 @@ function requiredArtifactCheck(
   label: string,
   artifacts: string[],
   summary: Record<string, string | number | boolean | null>,
+  blockingErrors: string[] = [],
 ): ReadinessCheck {
   const missing = artifacts.filter((p) => !existsSync(p));
+  const errors = [...missing.map((p) => `Missing artifact: ${p}`), ...blockingErrors];
   return {
     id,
     label,
-    status: missing.length ? "fail" : "pass",
+    status: errors.length ? "fail" : "pass",
     artifacts,
     summary,
-    ...(missing.length ? { errors: missing.map((p) => `Missing artifact: ${p}`) } : {}),
+    ...(errors.length ? { errors } : {}),
   };
 }
 
@@ -144,12 +147,12 @@ export async function runCanonicalDemoReadiness(
   opts: { outDir?: string; generated_at?: string } = {},
 ): Promise<CanonicalDemoReadinessReport> {
   const outDir = opts.outDir ?? "artifacts";
-  const generated_at = opts.generated_at ?? new Date(0).toISOString();
+  const generated_at = opts.generated_at ?? new Date().toISOString();
   mkdirSync(outDir, { recursive: true });
 
-  await scorecardMain([]);
-  await comparisonMain([]);
-  await trainingDatasetMain([generated_at]);
+  const scorecardExit = await scorecardMain([]);
+  const comparisonExit = await comparisonMain([]);
+  const trainingDatasetExit = await trainingDatasetMain([generated_at]);
 
   const scorecardPath = join(outDir, "ai-quality-scorecard.json");
   const comparisonPath = join(outDir, "model-comparison.json");
@@ -171,6 +174,7 @@ export async function runCanonicalDemoReadiness(
     dataset_hash: string;
   }>(manifestPath);
 
+  const trainingVerification = verifyTrainingExportArtifacts({ artifactDir: outDir });
   const checks: ReadinessCheck[] = [
     requiredArtifactCheck(
       "scorecard_demo",
@@ -183,6 +187,11 @@ export async function runCanonicalDemoReadiness(
         hard_failed_cases: scorecard.safety_privacy.hard_failed_cases,
         fine_tuning_status: scorecard.fine_tuning_readiness.status,
       },
+      [
+        ...(scorecardExit !== 0 ? [`Scorecard gate exited ${scorecardExit}.`] : []),
+        ...(scorecard.safety_privacy.hard_failed_cases > 0 ? ["Scorecard contains blocking safety/privacy hard failures."] : []),
+        ...(scorecard.fine_tuning_readiness.status !== "ready" ? [`Fine-tuning gate: ${scorecard.fine_tuning_readiness.status}`] : []),
+      ],
     ),
     requiredArtifactCheck(
       "model_comparison_demo",
@@ -194,6 +203,11 @@ export async function runCanonicalDemoReadiness(
         blocking: comparison.recommendation.blocking,
         hard_fail_regressions: comparison.safety_privacy.hard_fail_regressions.length,
       },
+      [
+        ...(comparisonExit !== 0 ? [`Model comparison gate exited ${comparisonExit}.`] : []),
+        ...(comparison.recommendation.blocking ? ["Model comparison recommendation is blocking."] : []),
+        ...(comparison.safety_privacy.hard_fail_regressions.length > 0 ? ["Model comparison contains safety/privacy hard-fail regressions."] : []),
+      ],
     ),
     requiredArtifactCheck(
       "training_dataset_demo",
@@ -210,7 +224,12 @@ export async function runCanonicalDemoReadiness(
         test_rows: manifest.split_counts.test,
         excluded_rows: manifest.excluded.length,
         dataset_hash_prefix: manifest.dataset_hash.slice(0, 16),
+        verifier_status: trainingVerification.readiness,
       },
+      [
+        ...(trainingDatasetExit !== 0 ? [`Training dataset compiler exited ${trainingDatasetExit}.`] : []),
+        ...trainingVerification.errors.map((error) => `Training export verifier: ${error}`),
+      ],
     ),
   ];
 

--- a/src/lib/evals/csvTrace.core.ts
+++ b/src/lib/evals/csvTrace.core.ts
@@ -1,0 +1,265 @@
+/**
+ * Isomorphic mapped-CSV adapter. CSV is intentionally limited to one flat
+ * model interaction per row; hierarchical agent sessions use OTLP or harness
+ * JSONL importers instead.
+ */
+import {
+  normalizeEvalRecordV1,
+  type AgentRunTrace,
+  type PrivacyClass,
+} from "./agentTrace.core";
+
+/** User-selected CSV column mapping. */
+export interface CsvTraceMapping {
+  readonly inputColumn: string;
+  readonly outputColumn: string;
+  readonly idColumn?: string;
+  readonly systemColumn?: string;
+  readonly timestampColumn?: string;
+  readonly modelColumn?: string;
+  readonly providerColumn?: string;
+  readonly harnessColumn?: string;
+  readonly productColumn?: string;
+  readonly moduleColumn?: string;
+  readonly environmentColumn?: string;
+  readonly privacyClassColumn?: string;
+  readonly metadataColumns: ReadonlyArray<string>;
+}
+
+/** One normalized CSV row and its stable source-scoped deduplication key. */
+export interface CsvNormalizedTrace {
+  readonly sourceId: string;
+  readonly trace: AgentRunTrace;
+}
+
+/** Content-free parse/import preview safe for UI and operator logs. */
+export interface CsvTraceSummary {
+  readonly headers: ReadonlyArray<string>;
+  readonly rows: number;
+  readonly valid: number;
+  readonly invalid: number;
+  readonly missingInput: number;
+  readonly missingOutput: number;
+  readonly invalidRows: ReadonlyArray<number>;
+  readonly models: ReadonlyArray<string>;
+  readonly harnesses: ReadonlyArray<string>;
+}
+
+/** Parsed traces plus their management-safe summary. */
+export interface CsvTraceBatch {
+  readonly traces: ReadonlyArray<CsvNormalizedTrace>;
+  readonly summary: CsvTraceSummary;
+}
+
+export const CSV_IMPORT_MAX_ROWS = 1_000;
+const MAX_COLUMNS = 200;
+const PRIVACY_CLASSES = new Set<PrivacyClass>([
+  "public",
+  "internal",
+  "confidential",
+  "pii",
+  "phi",
+]);
+
+/** Parse RFC 4180-style CSV, including escaped quotes and quoted newlines. */
+export function parseCsvRows(csv: string): ReadonlyArray<ReadonlyArray<string>> {
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let field = "";
+  let quoted = false;
+
+  const pushField = (): void => {
+    row.push(field);
+    field = "";
+  };
+  const pushRow = (): void => {
+    pushField();
+    if (row.length > MAX_COLUMNS) {
+      throw new Error(`CSV has more than ${MAX_COLUMNS} columns.`);
+    }
+    if (row.some((value) => value.length > 0)) rows.push(row);
+    row = [];
+    if (rows.length > CSV_IMPORT_MAX_ROWS + 1) {
+      throw new Error(`CSV has more than ${CSV_IMPORT_MAX_ROWS} data rows.`);
+    }
+  };
+
+  for (let index = 0; index < csv.length; index++) {
+    const char = csv[index];
+    if (quoted) {
+      if (char === '"') {
+        if (csv[index + 1] === '"') {
+          field += '"';
+          index++;
+        } else {
+          quoted = false;
+        }
+      } else {
+        field += char;
+      }
+      continue;
+    }
+    if (char === '"' && field.length === 0) {
+      quoted = true;
+    } else if (char === ",") {
+      pushField();
+    } else if (char === "\n") {
+      pushRow();
+    } else if (char === "\r") {
+      if (csv[index + 1] === "\n") continue;
+      pushRow();
+    } else {
+      field += char;
+    }
+  }
+  if (quoted) throw new Error("CSV has an unterminated quoted field.");
+  if (field.length > 0 || row.length > 0) pushRow();
+  return rows;
+}
+
+const optionalMappings = (mapping: CsvTraceMapping): ReadonlyArray<string> => [
+  mapping.idColumn,
+  mapping.systemColumn,
+  mapping.timestampColumn,
+  mapping.modelColumn,
+  mapping.providerColumn,
+  mapping.harnessColumn,
+  mapping.productColumn,
+  mapping.moduleColumn,
+  mapping.environmentColumn,
+  mapping.privacyClassColumn,
+].flatMap((column) => (column === undefined ? [] : [column]));
+
+/** Parse, validate, and normalize mapped CSV rows into trajectory records. */
+export function parseCsvTraceBatch(
+  csv: string,
+  mapping: CsvTraceMapping,
+): CsvTraceBatch {
+  const rows = parseCsvRows(csv);
+  const headerRow = rows[0];
+  if (!headerRow) throw new Error("CSV must contain a header row.");
+  const headers = headerRow.map((header) => header.trim());
+  if (headers.some((header) => header.length === 0)) {
+    throw new Error("CSV header names cannot be empty.");
+  }
+  if (new Set(headers).size !== headers.length) {
+    throw new Error("CSV header names must be unique.");
+  }
+  const indexByHeader = new Map(headers.map((header, index) => [header, index]));
+  const mappedColumns = [
+    mapping.inputColumn,
+    mapping.outputColumn,
+    ...optionalMappings(mapping),
+    ...mapping.metadataColumns,
+  ];
+  for (const column of mappedColumns) {
+    if (!indexByHeader.has(column)) {
+      throw new Error(`CSV mapping references unknown column "${column}".`);
+    }
+  }
+
+  const valueAt = (row: ReadonlyArray<string>, column: string | undefined): string | undefined => {
+    if (column === undefined) return undefined;
+    const index = indexByHeader.get(column);
+    if (index === undefined) return undefined;
+    const value = row[index];
+    return value === undefined || value.length === 0 ? undefined : value;
+  };
+
+  const traces: CsvNormalizedTrace[] = [];
+  const invalidRows: number[] = [];
+  const models = new Set<string>();
+  const harnesses = new Set<string>();
+  let missingInput = 0;
+  let missingOutput = 0;
+  const dataRows = rows.slice(1);
+
+  for (let index = 0; index < dataRows.length; index++) {
+    const row = dataRows[index] ?? [];
+    const input = valueAt(row, mapping.inputColumn);
+    const output = valueAt(row, mapping.outputColumn);
+    if (input === undefined || input.trim().length === 0) missingInput++;
+    if (output === undefined || output.trim().length === 0) missingOutput++;
+    if (
+      input === undefined ||
+      input.trim().length === 0 ||
+      output === undefined ||
+      output.trim().length === 0
+    ) {
+      invalidRows.push(index + 2);
+      continue;
+    }
+
+    const sourceId = valueAt(row, mapping.idColumn);
+    const model = valueAt(row, mapping.modelColumn);
+    const provider = valueAt(row, mapping.providerColumn);
+    const harness = valueAt(row, mapping.harnessColumn);
+    const privacyRaw = valueAt(row, mapping.privacyClassColumn);
+    const privacyClass =
+      privacyRaw !== undefined && PRIVACY_CLASSES.has(privacyRaw as PrivacyClass)
+        ? (privacyRaw as PrivacyClass)
+        : undefined;
+    if (privacyRaw !== undefined && privacyClass === undefined) {
+      invalidRows.push(index + 2);
+      continue;
+    }
+
+    const metadata: Record<string, unknown> = {};
+    for (const column of mapping.metadataColumns) {
+      const value = valueAt(row, column);
+      if (value !== undefined) metadata[column] = value;
+    }
+    const messages = [
+      ...(valueAt(row, mapping.systemColumn) === undefined
+        ? []
+        : [{ role: "system", content: valueAt(row, mapping.systemColumn) ?? "" }]),
+      { role: "user", content: input },
+    ];
+    const nativeTrace = normalizeEvalRecordV1({
+      version: "1",
+      id: sourceId,
+      timestamp: valueAt(row, mapping.timestampColumn),
+      model,
+      provider,
+      input: { messages },
+      output: { content: output },
+      product: valueAt(row, mapping.productColumn),
+      module: valueAt(row, mapping.moduleColumn),
+      environment: valueAt(row, mapping.environmentColumn),
+      harness: harness === undefined ? undefined : { name: harness, sdk: "csv" },
+      metadata,
+      privacy_class: privacyClass,
+    });
+    const derivedId = nativeTrace.trace_id.startsWith("native-")
+      ? nativeTrace.trace_id.slice("native-".length)
+      : nativeTrace.trace_id;
+    const csvSourceId = sourceId ?? derivedId;
+    const trace: AgentRunTrace = {
+      ...nativeTrace,
+      trace_id: `csv-${csvSourceId}`,
+      run_id: csvSourceId,
+      source_ids: { csv_row_id: csvSourceId },
+      harness: harness === undefined
+        ? { name: "csv_import", sdk: "csv" }
+        : { name: harness, sdk: "csv" },
+    };
+    traces.push({ sourceId: csvSourceId, trace });
+    if (model !== undefined) models.add(model);
+    if (harness !== undefined) harnesses.add(harness);
+  }
+
+  return {
+    traces,
+    summary: {
+      headers,
+      rows: dataRows.length,
+      valid: traces.length,
+      invalid: invalidRows.length,
+      missingInput,
+      missingOutput,
+      invalidRows: invalidRows.slice(0, 100),
+      models: [...models],
+      harnesses: [...harnesses],
+    },
+  };
+}

--- a/src/lib/evals/customerTestLaunchPacket.test.ts
+++ b/src/lib/evals/customerTestLaunchPacket.test.ts
@@ -17,6 +17,9 @@ describe("customer test launch packet", () => {
     expect(packet.status).toBe("ready_to_review");
     expect(packet.customer_label).toBe("customer-test-01");
     expect(packet.customer_label_is_approval_evidence).toBe(false);
+    expect(packet.live_logs_approved).toBe(false);
+    expect(packet.generated_at).not.toBe("2026-01-01T00:00:00Z");
+    expect(formatCustomerTestLaunchPacketMarkdown(packet)).toContain("does not approve live-log import");
     expect(packet.counts.source_docs_present).toBe(CUSTOMER_TEST_LAUNCH_SOURCE_DOCS.length);
     expect(packet.go_no_go_checklist.some((item) => item.requiredBeforeLiveLogs)).toBe(true);
   });

--- a/src/lib/evals/customerTestLaunchPacket.ts
+++ b/src/lib/evals/customerTestLaunchPacket.ts
@@ -20,6 +20,7 @@ export interface CustomerTestLaunchPacket {
   status: CustomerTestLaunchPacketStatus;
   customer_label: string;
   customer_label_is_approval_evidence: false;
+  live_logs_approved: false;
   source_docs: LaunchPacketSourceDoc[];
   counts: {
     source_docs: number;
@@ -41,7 +42,6 @@ export interface CustomerTestLaunchPacket {
   };
 }
 
-const GENERATED_AT = "2026-01-01T00:00:00Z";
 const DEFAULT_OUT_DIR = join("artifacts", "customer-test-launch-packet");
 
 export const CUSTOMER_TEST_LAUNCH_SOURCE_DOCS: Array<{ path: string; purpose: string }> = [
@@ -99,10 +99,11 @@ export function buildCustomerTestLaunchPacket(options: {
   ];
 
   return {
-    generated_at: options.generatedAt ?? GENERATED_AT,
+    generated_at: options.generatedAt ?? new Date().toISOString(),
     status,
     customer_label: customerLabel,
     customer_label_is_approval_evidence: false,
+    live_logs_approved: false,
     source_docs: sourceDocs,
     counts: {
       source_docs: sourceDocs.length,
@@ -160,6 +161,8 @@ export function formatCustomerTestLaunchPacketMarkdown(packet: CustomerTestLaunc
     "",
     `Generated at: ${packet.generated_at}`,
     `Status: \`${packet.status}\``,
+    "",
+    "**This packet status only means the source documents are present for review. It does not approve live-log import or prove customer consent.**",
     "",
     "## Objective",
     "",

--- a/src/lib/evals/customerTestingReadiness.test.ts
+++ b/src/lib/evals/customerTestingReadiness.test.ts
@@ -23,6 +23,8 @@ describe("customer testing readiness", () => {
     expect(report.counts.docs_present).toBe(report.counts.required_docs);
     expect(report.counts.gates_approved).toBe(0);
     expect(report.caveats).toContain("no_local_approvals_file_supplied");
+    expect(Date.parse(report.generated_at)).not.toBeNaN();
+    expect(report.generated_at).not.toBe("2026-01-01T00:00:00Z");
   });
 
   test("passes when required docs exist and every gate is approved", () => {

--- a/src/lib/evals/customerTestingReadiness.ts
+++ b/src/lib/evals/customerTestingReadiness.ts
@@ -45,8 +45,6 @@ export interface CustomerTestingReadinessReport {
   };
 }
 
-const GENERATED_AT = "2026-01-01T00:00:00Z";
-
 export const REQUIRED_CUSTOMER_TESTING_DOCS = [
   "docs/tenancy-consent-data-isolation.md",
   "docs/cloudflare-gateway-live-import.md",
@@ -102,6 +100,7 @@ export function buildCustomerTestingReadinessReport(options: {
   if (gatesApproved !== gates.length) caveats.push("explicit_approvals_missing_or_incomplete");
   if (options.approvals === undefined) caveats.push("no_local_approvals_file_supplied");
   caveats.push("do_not_import_customer_or_operator_logs_until_status_is_ready");
+  caveats.push("ready_status_is_not_evidence_of_customer_consent");
 
   const status: CustomerTestingReadinessStatus =
     docsPresent === requiredDocs.length && gatesApproved === gates.length
@@ -109,7 +108,7 @@ export function buildCustomerTestingReadinessReport(options: {
       : "blocked_until_approved";
 
   return {
-    generated_at: options.generatedAt ?? GENERATED_AT,
+    generated_at: options.generatedAt ?? new Date().toISOString(),
     status,
     required_docs: requiredDocs,
     gates,
@@ -160,6 +159,7 @@ export function formatCustomerTestingReadinessMarkdown(report: CustomerTestingRe
     ...report.caveats.map((caveat) => `- \`${caveat}\``),
     "",
     "This report intentionally omits customer trace content, approval notes, credential values, and raw logs.",
+    "A ready status records only the supplied repo-side checklist; it is not evidence that a customer granted consent.",
     "",
   ];
   return lines.join("\n");

--- a/src/lib/evals/trainingExportVerifier.test.ts
+++ b/src/lib/evals/trainingExportVerifier.test.ts
@@ -66,6 +66,32 @@ describe("training export verifier", () => {
     expect(summary.errors).toContain("test:line_2:invalid_json");
   });
 
+  test("requires manifest count and row-hash bindings", () => {
+    const dir = writeExportDir();
+    const manifestPath = join(dir, "training-dataset.manifest.json");
+    const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+    delete manifest.split_counts;
+    delete manifest.row_entries;
+    writeFileSync(manifestPath, JSON.stringify(manifest));
+
+    const summary = verifyTrainingExportArtifacts({ artifactDir: dir });
+    expect(summary.readiness).toBe("not_ready");
+    expect(summary.errors).toContain("manifest_split_counts_missing");
+    expect(summary.errors).toContain("manifest_row_entries_missing");
+  });
+
+  test("requires supported roles and a final assistant completion", () => {
+    const dir = writeExportDir();
+    writeFileSync(
+      join(dir, "training-dataset.test.jsonl"),
+      `${JSON.stringify({ messages: [{ role: "developer", content: "unsupported" }, { role: "user", content: "unfinished" }] })}\n`,
+    );
+    const summary = verifyTrainingExportArtifacts({ artifactDir: dir });
+    expect(summary.readiness).toBe("not_ready");
+    expect(summary.errors).toContain("test:line_1:message_role_unsupported");
+    expect(summary.errors).toContain("test:line_1:final_message_not_assistant");
+  });
+
   test("blocks forbidden substrings without echoing the substring in text or JSON", () => {
     const dir = writeExportDir();
     const forbidden = "TOKEN_DO_NOT_PRINT_123456";

--- a/src/lib/evals/trainingExportVerifier.ts
+++ b/src/lib/evals/trainingExportVerifier.ts
@@ -53,18 +53,28 @@ function hasBlockedSubstring(value: string, blocked: string[]): boolean {
   return blocked.some((s) => s.length > 0 && value.includes(s));
 }
 
-function validateMessagesRow(value: unknown): string | null {
-  if (!value || typeof value !== "object" || Array.isArray(value)) return "row_not_object";
+function validateMessagesRow(value: unknown): string[] {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return ["row_not_object"];
   const row = value as Record<string, unknown>;
-  if (!Array.isArray(row.messages)) return "messages_missing";
-  if (row.messages.length === 0) return "messages_empty";
+  if (!Array.isArray(row.messages)) return ["messages_missing"];
+  if (row.messages.length === 0) return ["messages_empty"];
+  const errors: string[] = [];
   for (const message of row.messages) {
-    if (!message || typeof message !== "object" || Array.isArray(message)) return "message_not_object";
+    if (!message || typeof message !== "object" || Array.isArray(message)) {
+      errors.push("message_not_object");
+      continue;
+    }
     const m = message as Record<string, unknown>;
-    if (typeof m.role !== "string" || m.role.length === 0) return "message_role_invalid";
-    if (typeof m.content !== "string" || m.content.length === 0) return "message_content_empty";
+    if (typeof m.role !== "string" || m.role.length === 0) errors.push("message_role_invalid");
+    else if (!["system", "user", "assistant"].includes(m.role)) errors.push("message_role_unsupported");
+    if (typeof m.content !== "string" || m.content.length === 0) errors.push("message_content_empty");
   }
-  return null;
+  const finalMessage = row.messages[row.messages.length - 1];
+  if (!finalMessage || typeof finalMessage !== "object" || Array.isArray(finalMessage)
+      || (finalMessage as Record<string, unknown>).role !== "assistant") {
+    errors.push("final_message_not_assistant");
+  }
+  return [...new Set(errors)];
 }
 
 function readText(path: string, readFile?: ReadFile): string {
@@ -123,8 +133,8 @@ export function verifyTrainingExportArtifacts(
         errors.push(`${split}:line_${i + 1}:invalid_json`);
         return;
       }
-      const shapeError = validateMessagesRow(parsed);
-      if (shapeError) errors.push(`${split}:line_${i + 1}:${shapeError}`);
+      const shapeErrors = validateMessagesRow(parsed);
+      for (const shapeError of shapeErrors) errors.push(`${split}:line_${i + 1}:${shapeError}`);
       if (hasBlockedSubstring(line, blocked)) errors.push(`${split}:line_${i + 1}:blocked_substring_present`);
       rowHashes[split].push(sha256hex(stableStringify(parsed)));
     });
@@ -138,7 +148,7 @@ export function verifyTrainingExportArtifacts(
       }
     }
   } else if (manifest) {
-    caveats.push("Manifest has no split_counts object.");
+    errors.push("manifest_split_counts_missing");
   }
 
   if (manifest?.row_entries) {
@@ -161,7 +171,10 @@ export function verifyTrainingExportArtifacts(
       errors.push("manifest_dataset_hash_mismatch");
     }
   } else if (manifest) {
-    caveats.push("Manifest has no row_entries object; row-level hashes were not checked.");
+    errors.push("manifest_row_entries_missing");
+  }
+  if (manifest && typeof manifest.dataset_hash !== "string") {
+    errors.push("manifest_dataset_hash_missing");
   }
 
   const excludedCount = Array.isArray(manifest?.excluded) ? manifest!.excluded!.length : 0;

--- a/src/routes/orgs/projects/ImportRuns.ct.spec.tsx
+++ b/src/routes/orgs/projects/ImportRuns.ct.spec.tsx
@@ -1,0 +1,53 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+import { MemoryRouter } from "react-router-dom";
+import type { Doc, Id } from "../../../../convex/_generated/dataModel";
+import { ProjectProvider } from "@/contexts/ProjectContext";
+import { ImportRuns } from "./ImportRuns";
+
+const projectId = "project_import_test" as Id<"projects">;
+const project = {
+  _id: projectId,
+  _creationTime: 1,
+  organizationId: "org_import_test",
+  name: "Imported runs",
+  createdById: "user_import_test",
+} as Doc<"projects">;
+
+test("ingestion-first surface exposes CSV, OTLP, Pi, and Claude Code", async ({ mount }) => {
+  const component = await mount(
+    <MemoryRouter>
+      <ProjectProvider value={{ project, projectId, role: "owner" }}>
+        <ImportRuns />
+      </ProjectProvider>
+    </MemoryRouter>,
+  );
+
+  await expect(component.getByRole("heading", { name: "Import completed runs" })).toBeVisible();
+  for (const source of ["CSV", "OpenTelemetry", "Pi session", "Claude Code"]) {
+    await expect(component.getByRole("listitem").filter({ hasText: source })).toBeVisible();
+  }
+  await expect(component).toContainText("does not execute your harness");
+});
+
+test("CSV upload discovers headers and requires input/output mapping", async ({ mount }) => {
+  const component = await mount(
+    <MemoryRouter>
+      <ProjectProvider value={{ project, projectId, role: "owner" }}>
+        <ImportRuns />
+      </ProjectProvider>
+    </MemoryRouter>,
+  );
+
+  await component.locator("#run-import-file").setInputFiles({
+    name: "runs.csv",
+    mimeType: "text/csv",
+    buffer: Buffer.from("trace_id,prompt,response,model\nr-1,hello,world,gpt-4.1"),
+  });
+
+  await expect(component).toContainText("1 data rows · 4 columns");
+  await expect(component.locator("#csv-inputColumn")).toHaveValue("prompt");
+  await expect(component.locator("#csv-outputColumn")).toHaveValue("response");
+  await expect(component.locator("#csv-idColumn")).toHaveValue("trace_id");
+  await expect(component).not.toContainText("hello");
+  await expect(component).not.toContainText("world");
+});

--- a/src/routes/orgs/projects/ImportRuns.tsx
+++ b/src/routes/orgs/projects/ImportRuns.tsx
@@ -1,0 +1,453 @@
+import { useMemo, useState } from "react";
+import { useAction } from "convex/react";
+import { Link } from "react-router-dom";
+import type { FunctionReturnType } from "convex/server";
+import { api } from "../../../../convex/_generated/api";
+import { useProject } from "@/contexts/ProjectContext";
+import { Button, buttonVariants } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import { friendlyError } from "@/lib/errors";
+import { cn } from "@/lib/utils";
+import {
+  parseCsvRows,
+  type CsvTraceMapping,
+} from "@/lib/evals/csvTrace.core";
+import {
+  Braces,
+  CheckCircle2,
+  FileSpreadsheet,
+  Route,
+  ShieldAlert,
+  Upload,
+} from "lucide-react";
+
+type ImportSource = "csv" | "otlp" | "pi" | "claude_code";
+type CsvResult = FunctionReturnType<typeof api.csvImport.importMappedCsv>;
+type OtlpResult = FunctionReturnType<typeof api.otlpFileImport.importOtlpJson>;
+type PiResult = FunctionReturnType<typeof api.piImport.importPiSession>;
+type ClaudeResult = FunctionReturnType<typeof api.claudeCodeImport.importClaudeCodeSession>;
+type ImportResult = CsvResult | OtlpResult | PiResult | ClaudeResult;
+
+type MappingField = Exclude<keyof CsvTraceMapping, "metadataColumns">;
+
+const MAX_BYTES = 8 * 1024 * 1024;
+
+const SOURCES = [
+  {
+    id: "csv",
+    title: "CSV",
+    description: "Map flat prompt/output or interaction rows from any platform.",
+    accept: ".csv,text/csv",
+    icon: FileSpreadsheet,
+  },
+  {
+    id: "otlp",
+    title: "OpenTelemetry",
+    description: "Upload captured OTLP/HTTP GenAI JSON from a tracing platform.",
+    accept: ".json,application/json",
+    icon: Route,
+  },
+  {
+    id: "pi",
+    title: "Pi session",
+    description: "Import one saved Pi coding-agent session JSONL trajectory.",
+    accept: ".jsonl,application/x-ndjson",
+    icon: Braces,
+  },
+  {
+    id: "claude_code",
+    title: "Claude Code",
+    description: "Import one Claude Code session transcript JSONL trajectory.",
+    accept: ".jsonl,application/x-ndjson",
+    icon: Braces,
+  },
+] as const satisfies ReadonlyArray<{
+  readonly id: ImportSource;
+  readonly title: string;
+  readonly description: string;
+  readonly accept: string;
+  readonly icon: typeof FileSpreadsheet;
+}>;
+
+const MAPPING_FIELDS: ReadonlyArray<{
+  readonly key: MappingField;
+  readonly label: string;
+  readonly required?: boolean;
+}> = [
+  { key: "inputColumn", label: "Input / prompt", required: true },
+  { key: "outputColumn", label: "Output / response", required: true },
+  { key: "idColumn", label: "Stable row / trace ID" },
+  { key: "systemColumn", label: "System message" },
+  { key: "timestampColumn", label: "Timestamp" },
+  { key: "modelColumn", label: "Model" },
+  { key: "providerColumn", label: "Provider" },
+  { key: "harnessColumn", label: "Harness / agent" },
+  { key: "productColumn", label: "Product" },
+  { key: "moduleColumn", label: "Module" },
+  { key: "environmentColumn", label: "Environment" },
+  { key: "privacyClassColumn", label: "Privacy class" },
+];
+
+const FIELD_GUESSES: Record<MappingField, ReadonlyArray<string>> = {
+  inputColumn: ["input", "prompt", "request", "question", "user_message"],
+  outputColumn: ["output", "response", "completion", "answer", "assistant_message"],
+  idColumn: ["id", "trace_id", "run_id", "request_id"],
+  systemColumn: ["system", "system_message", "instructions"],
+  timestampColumn: ["timestamp", "created_at", "time"],
+  modelColumn: ["model", "model_id"],
+  providerColumn: ["provider", "model_provider"],
+  harnessColumn: ["harness", "agent", "sdk"],
+  productColumn: ["product", "application", "service"],
+  moduleColumn: ["module", "feature"],
+  environmentColumn: ["environment", "env"],
+  privacyClassColumn: ["privacy_class", "sensitivity"],
+};
+
+function guessMapping(headers: ReadonlyArray<string>): Partial<Record<MappingField, string>> {
+  const lower = new Map(headers.map((header) => [header.toLowerCase(), header]));
+  const mapping: Partial<Record<MappingField, string>> = {};
+  for (const field of MAPPING_FIELDS) {
+    const match = FIELD_GUESSES[field.key]
+      .map((guess) => lower.get(guess))
+      .find((value) => value !== undefined);
+    if (match !== undefined) mapping[field.key] = match;
+  }
+  return mapping;
+}
+
+export function ImportRuns() {
+  const { projectId } = useProject();
+  const importCsv = useAction(api.csvImport.importMappedCsv);
+  const importOtlp = useAction(api.otlpFileImport.importOtlpJson);
+  const importPi = useAction(api.piImport.importPiSession);
+  const importClaude = useAction(api.claudeCodeImport.importClaudeCodeSession);
+
+  const [source, setSource] = useState<ImportSource>("csv");
+  const [fileName, setFileName] = useState("");
+  const [payload, setPayload] = useState("");
+  const [csvHeaders, setCsvHeaders] = useState<ReadonlyArray<string>>([]);
+  const [csvRows, setCsvRows] = useState(0);
+  const [mapping, setMapping] = useState<Partial<Record<MappingField, string>>>({});
+  const [metadataColumns, setMetadataColumns] = useState<ReadonlyArray<string>>([]);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState("");
+  const [result, setResult] = useState<ImportResult | null>(null);
+
+  const selectedSource = SOURCES.find((item) => item.id === source) ?? SOURCES[0];
+  const mappedColumns = useMemo(
+    () => new Set(Object.values(mapping).filter((value) => value !== undefined)),
+    [mapping],
+  );
+  const csvReady =
+    source !== "csv" ||
+    (mapping.inputColumn !== undefined && mapping.outputColumn !== undefined);
+
+  function resetFile(nextSource: ImportSource) {
+    setSource(nextSource);
+    setFileName("");
+    setPayload("");
+    setCsvHeaders([]);
+    setCsvRows(0);
+    setMapping({});
+    setMetadataColumns([]);
+    setError("");
+    setResult(null);
+  }
+
+  async function onFile(event: React.ChangeEvent<HTMLInputElement>) {
+    const file = event.target.files?.[0];
+    if (!file) return;
+    setResult(null);
+    setError("");
+    if (file.size > MAX_BYTES) {
+      setError(`${file.name} is over the 8 MB upload limit. Split the file and retry.`);
+      return;
+    }
+    const text = await file.text();
+    setFileName(file.name);
+    setPayload(text);
+    if (source === "csv") {
+      try {
+        const rows = parseCsvRows(text);
+        const headers = rows[0]?.map((header) => header.trim()) ?? [];
+        if (headers.length === 0) throw new Error("CSV must contain a header row.");
+        setCsvHeaders(headers);
+        setCsvRows(Math.max(0, rows.length - 1));
+        setMapping(guessMapping(headers));
+      } catch (cause: unknown) {
+        setError(friendlyError(cause, "Could not read this CSV file."));
+      }
+    }
+  }
+
+  async function handleImport() {
+    if (!payload || !csvReady || busy) return;
+    setBusy(true);
+    setError("");
+    setResult(null);
+    try {
+      if (source === "csv") {
+        const inputColumn = mapping.inputColumn;
+        const outputColumn = mapping.outputColumn;
+        if (!inputColumn || !outputColumn) {
+          setError("Map both the input and output columns before importing.");
+          return;
+        }
+        const csvMapping: CsvTraceMapping = {
+          inputColumn,
+          outputColumn,
+          idColumn: mapping.idColumn,
+          systemColumn: mapping.systemColumn,
+          timestampColumn: mapping.timestampColumn,
+          modelColumn: mapping.modelColumn,
+          providerColumn: mapping.providerColumn,
+          harnessColumn: mapping.harnessColumn,
+          productColumn: mapping.productColumn,
+          moduleColumn: mapping.moduleColumn,
+          environmentColumn: mapping.environmentColumn,
+          privacyClassColumn: mapping.privacyClassColumn,
+          metadataColumns,
+        };
+        setResult(await importCsv({
+          projectId,
+          csv: payload,
+          mapping: { ...csvMapping, metadataColumns: [...csvMapping.metadataColumns] },
+        }));
+      } else if (source === "otlp") {
+        setResult(await importOtlp({ projectId, json: payload }));
+      } else if (source === "pi") {
+        setResult(await importPi({ projectId, jsonl: payload }));
+      } else {
+        setResult(await importClaude({ projectId, jsonl: payload }));
+      }
+    } catch (cause: unknown) {
+      setError(friendlyError(cause, "Import failed. Check the selected format and retry."));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="mx-auto max-w-4xl p-6">
+      <header>
+        <div className="flex items-center gap-2">
+          <Upload aria-hidden="true" className="h-5 w-5 text-primary" />
+          <h1 className="text-2xl font-bold">Import completed runs</h1>
+        </div>
+        <p className="mt-1 max-w-2xl text-sm text-muted-foreground">
+          Bring traces from the systems you already run. Blind Bench stores and
+          reviews the resulting evidence; it does not execute your harness.
+        </p>
+      </header>
+
+      <div className="mt-6 grid gap-3 sm:grid-cols-2 lg:grid-cols-4" role="list" aria-label="Import source">
+        {SOURCES.map((item) => {
+          const Icon = item.icon;
+          const selected = source === item.id;
+          return (
+            <button
+              key={item.id}
+              type="button"
+              role="listitem"
+              onClick={() => resetFile(item.id)}
+              className={cn(
+                "rounded-lg border p-4 text-left transition-colors",
+                selected ? "border-primary bg-primary/5" : "hover:border-primary/40 hover:bg-muted/40",
+              )}
+              aria-pressed={selected}
+            >
+              <Icon aria-hidden="true" className="h-4 w-4 text-primary" />
+              <p className="mt-2 text-sm font-medium">{item.title}</p>
+              <p className="mt-1 text-xs text-muted-foreground">{item.description}</p>
+            </button>
+          );
+        })}
+      </div>
+
+      <Card className="mt-6">
+        <CardHeader>
+          <CardTitle className="text-base">{selectedSource.title} file</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <label
+            htmlFor="run-import-file"
+            className="flex cursor-pointer items-center gap-2 rounded-md border border-dashed px-4 py-6 text-sm text-muted-foreground hover:border-primary/50 hover:text-foreground"
+          >
+            <Upload aria-hidden="true" className="h-4 w-4" />
+            {fileName || `Choose a ${selectedSource.title} file…`}
+          </label>
+          <input
+            id="run-import-file"
+            type="file"
+            accept={selectedSource.accept}
+            onChange={onFile}
+            className="sr-only"
+          />
+          <p className="text-xs text-muted-foreground">
+            Up to 8 MB. The raw file is retained access-controlled for re-parsing;
+            import results and logs contain counts only.
+          </p>
+
+          {source === "csv" && csvHeaders.length > 0 && (
+            <CsvMappingEditor
+              headers={csvHeaders}
+              rows={csvRows}
+              mapping={mapping}
+              metadataColumns={metadataColumns}
+              mappedColumns={mappedColumns}
+              onMappingChange={(field, column) =>
+                setMapping((current) => ({ ...current, [field]: column || undefined }))
+              }
+              onMetadataChange={setMetadataColumns}
+            />
+          )}
+
+          {error && <p className="text-sm text-destructive" role="alert">{error}</p>}
+
+          <Button onClick={handleImport} disabled={busy || !payload || !csvReady}>
+            {busy ? "Importing…" : "Import runs"}
+          </Button>
+        </CardContent>
+      </Card>
+
+      {result && <ImportSummary result={result} tracesHref="../traces" />}
+
+      <Card className="mt-6 border-amber-500/40 bg-amber-500/5">
+        <CardContent className="flex gap-3 pt-6 text-sm text-muted-foreground">
+          <ShieldAlert aria-hidden="true" className="mt-0.5 h-4 w-4 shrink-0 text-amber-600" />
+          <p>
+            Key-name redaction protects structured tool fields. Free-text prompts,
+            outputs, and logs are not automatically scrubbed; upload only data your
+            workspace is approved to store and review.
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function CsvMappingEditor({
+  headers,
+  rows,
+  mapping,
+  metadataColumns,
+  mappedColumns,
+  onMappingChange,
+  onMetadataChange,
+}: {
+  readonly headers: ReadonlyArray<string>;
+  readonly rows: number;
+  readonly mapping: Partial<Record<MappingField, string>>;
+  readonly metadataColumns: ReadonlyArray<string>;
+  readonly mappedColumns: ReadonlySet<string>;
+  readonly onMappingChange: (field: MappingField, column: string) => void;
+  readonly onMetadataChange: (columns: ReadonlyArray<string>) => void;
+}) {
+  return (
+    <div className="space-y-4 rounded-lg border bg-muted/20 p-4">
+      <div>
+        <p className="text-sm font-medium">Map CSV columns</p>
+        <p className="text-xs text-muted-foreground">
+          {rows.toLocaleString()} data rows · {headers.length} columns. Row content is not previewed.
+        </p>
+      </div>
+      <div className="grid gap-3 sm:grid-cols-2">
+        {MAPPING_FIELDS.map((field) => (
+          <div key={field.key} className="space-y-1">
+            <Label htmlFor={`csv-${field.key}`} className="text-xs">
+              {field.label}{field.required ? " *" : ""}
+            </Label>
+            <select
+              id={`csv-${field.key}`}
+              value={mapping[field.key] ?? ""}
+              onChange={(event) => onMappingChange(field.key, event.target.value)}
+              className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm"
+            >
+              <option value="">Not mapped</option>
+              {headers.map((header) => <option key={header} value={header}>{header}</option>)}
+            </select>
+          </div>
+        ))}
+      </div>
+      <div className="space-y-2">
+        <Label className="text-xs">Additional metadata columns</Label>
+        <div className="flex flex-wrap gap-2">
+          {headers.filter((header) => !mappedColumns.has(header)).map((header) => {
+            const selected = metadataColumns.includes(header);
+            return (
+              <label key={header} className="flex items-center gap-1.5 rounded border px-2 py-1 text-xs">
+                <input
+                  type="checkbox"
+                  checked={selected}
+                  onChange={() => onMetadataChange(
+                    selected
+                      ? metadataColumns.filter((column) => column !== header)
+                      : [...metadataColumns, header],
+                  )}
+                />
+                {header}
+              </label>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ImportSummary({ result, tracesHref }: { readonly result: ImportResult; readonly tracesHref: string }) {
+  const imported = "imported" in result ? result.imported : result.deduped ? 0 : 1;
+  const deduped = typeof result.deduped === "number" ? result.deduped : result.deduped ? 1 : 0;
+  const summary = result.summary as unknown as Record<string, unknown>;
+  const numberAt = (key: string): number | undefined =>
+    typeof summary[key] === "number" ? summary[key] : undefined;
+  const stringsAt = (key: string): ReadonlyArray<string> =>
+    Array.isArray(summary[key])
+      ? (summary[key] as ReadonlyArray<unknown>).filter((value): value is string => typeof value === "string")
+      : [];
+  const metrics = [
+    ["traces", numberAt("traces")],
+    ["spans", numberAt("spans")],
+    ["ignored spans", numberAt("ignoredSpans")],
+    ["steps", numberAt("steps")],
+    ["valid rows", numberAt("valid")],
+    ["invalid rows/lines", numberAt("invalid")],
+    ["missing inputs", numberAt("missingInput") ?? numberAt("requestMissing")],
+    ["missing outputs", numberAt("missingOutput") ?? numberAt("responseMissing")],
+    ["active entries", numberAt("activeEntries")],
+    ["branches excluded", numberAt("branchesExcluded")],
+    ["compactions", numberAt("compactions")],
+  ] as const;
+  const metricText = metrics.flatMap(([label, value]) =>
+    value === undefined ? [] : [`${value} ${label}`],
+  );
+  const models = stringsAt("models");
+  const harnesses = stringsAt("harnesses");
+  return (
+    <Card className="mt-6 border-primary/30">
+      <CardContent className="flex flex-col gap-4 pt-6 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <p className="flex items-center gap-2 text-sm font-medium">
+            <CheckCircle2 aria-hidden="true" className="h-4 w-4 text-primary" />
+            Import complete
+          </p>
+          <p className="mt-1 text-sm text-muted-foreground">
+            {imported} imported · {deduped} already present
+            {metricText.length > 0 ? ` · ${metricText.join(" · ")}` : ""}
+          </p>
+          {(models.length > 0 || harnesses.length > 0) && (
+            <p className="mt-1 text-xs text-muted-foreground">
+              {models.length > 0 ? `Models: ${models.join(", ")}` : ""}
+              {models.length > 0 && harnesses.length > 0 ? " · " : ""}
+              {harnesses.length > 0 ? `Harnesses: ${harnesses.join(", ")}` : ""}
+            </p>
+          )}
+        </div>
+        <Link to={tracesHref} className={buttonVariants({ size: "sm" })}>
+          Review trajectories
+        </Link>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/routes/traces/TraceList.tsx
+++ b/src/routes/traces/TraceList.tsx
@@ -46,7 +46,7 @@ export function TraceList() {
           </p>
         </div>
         <Link
-          to={`${base}/trace-import`}
+          to={`${projectBase}/import`}
           className={buttonVariants({ size: "sm", variant: "outline" })}
         >
           <Upload aria-hidden="true" className="mr-1.5 h-3.5 w-3.5" />
@@ -68,11 +68,11 @@ export function TraceList() {
               agent’s steps, tool calls, and decisions.
             </p>
             <Link
-              to={`${base}/trace-import`}
+              to={`${projectBase}/import`}
               className={buttonVariants({ size: "sm" })}
             >
               <Upload aria-hidden="true" className="mr-1.5 h-3.5 w-3.5" />
-              Import an agent session
+              Import completed runs
             </Link>
           </div>
         ) : (

--- a/src/routes/traces/TraceMatchupReview.tsx
+++ b/src/routes/traces/TraceMatchupReview.tsx
@@ -1,39 +1,24 @@
-/**
- * #271 (M31): blind reviewer's step-level pairwise-preference page. Rendered
- * under EvalLayout at /eval/matchups/:matchupId — no org/project context. The
- * matchup surface is the shared TraceMatchupBody; this wrapper only reads the
- * :matchupId param and sets the blind-eval document title (Rule 3).
- */
+/** Blind matchup route. The URL carries only a stored opaque review token. */
 import { useEffect } from "react";
 import { useQuery } from "convex/react";
 import { useParams } from "react-router-dom";
 import { api } from "../../../convex/_generated/api";
-import type { Id } from "../../../convex/_generated/dataModel";
-import { TraceMatchupBody } from "./TraceMatchupBody";
+import { TraceTokenMatchupBody } from "./TraceTokenMatchupBody";
 
 export function TraceMatchupReview() {
-  const { matchupId } = useParams<{ matchupId: string }>();
-  const id = matchupId as Id<"agentTraceMatchups">;
-
-  const matchup = useQuery(api.agentTraceReview.getMatchup, { matchupId: id });
-
-  // Rule 3: evaluators see "Evaluation — {project name}" and nothing else.
-  useEffect(() => {
-    if (!matchup) return;
-    const previous = document.title;
-    document.title = matchup.projectName
-      ? `Evaluation — ${matchup.projectName}`
-      : "Evaluation";
-    return () => {
-      document.title = previous;
-    };
-  }, [matchup]);
-
-  return (
-    <TraceMatchupBody
-      matchupId={id}
-      backTo="/eval/traces"
-      backLabel="Trajectories to review"
-    />
+  const { reviewToken = "" } = useParams<{ reviewToken: string }>();
+  const matchup = useQuery(
+    api.agentTraceReviewSessions.getMatchup,
+    reviewToken ? { token: reviewToken } : "skip",
   );
+
+  useEffect(() => {
+    document.title = matchup?.projectName
+      ? `Evaluation — ${matchup.projectName}`
+      : "Evaluation — Blind Bench";
+    return () => { document.title = "Blind Bench"; };
+  }, [matchup?.projectName]);
+
+  if (!reviewToken) return null;
+  return <TraceTokenMatchupBody token={reviewToken} />;
 }

--- a/src/routes/traces/TraceReview.tsx
+++ b/src/routes/traces/TraceReview.tsx
@@ -1,39 +1,24 @@
-/**
- * #271 (M31): blind reviewer's single-trajectory review page. Rendered under
- * EvalLayout at /eval/traces/:agentTraceId — no org/project context. The review
- * surface itself is the shared TraceReviewBody; this wrapper only reads the
- * :agentTraceId param and sets the blind-eval document title (Rule 3).
- */
+/** Blind trajectory review route. The URL carries only a stored opaque token. */
 import { useEffect } from "react";
 import { useQuery } from "convex/react";
 import { useParams } from "react-router-dom";
 import { api } from "../../../convex/_generated/api";
-import type { Id } from "../../../convex/_generated/dataModel";
-import { TraceReviewBody } from "./TraceReviewBody";
+import { TraceTokenReviewBody } from "./TraceTokenReviewBody";
 
 export function TraceReview() {
-  const { agentTraceId } = useParams<{ agentTraceId: string }>();
-  const traceId = agentTraceId as Id<"agentTraces">;
-
-  const trace = useQuery(api.agentTraces.getTrace, { agentTraceId: traceId });
-
-  // Rule 3: evaluators see "Evaluation — {project name}" and nothing else.
-  useEffect(() => {
-    if (!trace) return;
-    const previous = document.title;
-    document.title = trace.projectName
-      ? `Evaluation — ${trace.projectName}`
-      : "Evaluation";
-    return () => {
-      document.title = previous;
-    };
-  }, [trace]);
-
-  return (
-    <TraceReviewBody
-      agentTraceId={traceId}
-      backTo="/eval/traces"
-      backLabel="Trajectories to review"
-    />
+  const { reviewToken = "" } = useParams<{ reviewToken: string }>();
+  const trace = useQuery(
+    api.agentTraceReviewSessions.getTrace,
+    reviewToken ? { token: reviewToken } : "skip",
   );
+
+  useEffect(() => {
+    document.title = trace?.projectName
+      ? `Evaluation — ${trace.projectName}`
+      : "Evaluation — Blind Bench";
+    return () => { document.title = "Blind Bench"; };
+  }, [trace?.projectName]);
+
+  if (!reviewToken) return null;
+  return <TraceTokenReviewBody token={reviewToken} />;
 }

--- a/src/routes/traces/TraceReviewList.tsx
+++ b/src/routes/traces/TraceReviewList.tsx
@@ -1,9 +1,8 @@
 /**
  * #271 (M31): blind reviewer's cross-project discovery list of trajectories to
  * review. Rendered under EvalLayout at /eval/traces — no org/project context.
- * Reads everything from `listReviewableTraces`; for blind reviewers the backend
- * strips product/harness/model, so those rows show only the project name and
- * step count. No real ids or provenance attributes reach the DOM.
+ * Reads opaque review sessions only. Raw trace/matchup IDs never reach the
+ * reviewer payload, route, or DOM.
  */
 import { useQuery } from "convex/react";
 import { Link } from "react-router-dom";
@@ -26,7 +25,7 @@ function StatusBadge({ status }: { status: string }) {
 }
 
 export function TraceReviewList() {
-  const traces = useQuery(api.agentTraces.listReviewableTraces, {});
+  const sessions = useQuery(api.agentTraceReviewSessions.listMine, {});
 
   return (
     <div className="mx-auto max-w-3xl p-6">
@@ -42,13 +41,13 @@ export function TraceReviewList() {
       </header>
 
       <div className="mt-6">
-        {traces === undefined ? (
+        {sessions === undefined ? (
           <div className="space-y-2">
             {[0, 1, 2, 3].map((i) => (
               <Skeleton key={i} className="h-16 w-full" />
             ))}
           </div>
-        ) : traces.length === 0 ? (
+        ) : sessions.length === 0 ? (
           <div className="max-w-lg space-y-3 rounded-lg border border-dashed p-6">
             <p className="text-sm">
               No trajectories assigned to review yet. When a teammate shares an
@@ -57,38 +56,29 @@ export function TraceReviewList() {
           </div>
         ) : (
           <ul className="space-y-2">
-            {traces.map((t) => {
-              const provenance = [t.product, t.harnessName, t.model].filter(
-                Boolean,
-              );
-              return (
-                <li key={t._id}>
-                  <Link
-                    to={`/eval/traces/${t._id}`}
-                    className="flex items-center justify-between gap-4 rounded-lg border bg-card px-4 py-3 transition-colors hover:bg-muted/50"
-                  >
-                    <div className="min-w-0">
-                      <p className="truncate text-sm font-medium">
-                        {t.projectName}
-                      </p>
-                      <p className="mt-0.5 text-xs text-muted-foreground">
-                        {provenance.length > 0 && (
-                          <>{provenance.join(" · ")} · </>
-                        )}
-                        {t.stepCount} {t.stepCount === 1 ? "step" : "steps"}
-                      </p>
-                    </div>
-                    <div className="flex shrink-0 items-center gap-3">
-                      <StatusBadge status={t.status} />
-                      <ArrowRight
-                        aria-hidden="true"
-                        className="h-4 w-4 text-muted-foreground"
-                      />
-                    </div>
-                  </Link>
-                </li>
-              );
-            })}
+            {sessions.map((session) => (
+              <li key={session.token}>
+                <Link
+                  to={session.kind === "trace"
+                    ? `/eval/traces/${session.token}`
+                    : `/eval/matchups/${session.token}`}
+                  className="flex items-center justify-between gap-4 rounded-lg border bg-card px-4 py-3 transition-colors hover:bg-muted/50"
+                >
+                  <div className="min-w-0">
+                    <p className="truncate text-sm font-medium">{session.projectName}</p>
+                    <p className="mt-0.5 text-xs text-muted-foreground">
+                      {session.kind === "trace"
+                        ? `${session.stepCount ?? 0} ${(session.stepCount ?? 0) === 1 ? "step" : "steps"}`
+                        : "A/B trajectory matchup"}
+                    </p>
+                  </div>
+                  <div className="flex shrink-0 items-center gap-3">
+                    <StatusBadge status={session.status} />
+                    <ArrowRight aria-hidden="true" className="h-4 w-4 text-muted-foreground" />
+                  </div>
+                </Link>
+              </li>
+            ))}
           </ul>
         )}
       </div>

--- a/src/routes/traces/TraceTokenMatchupBody.tsx
+++ b/src/routes/traces/TraceTokenMatchupBody.tsx
@@ -1,0 +1,150 @@
+import { useEffect, useState } from "react";
+import { useMutation, useQuery } from "convex/react";
+import { Link } from "react-router-dom";
+import { api } from "../../../convex/_generated/api";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
+import { friendlyError } from "@/lib/errors";
+import { COMMENT_TAGS, StepList, type CommentTag } from "./traceSteps";
+import { ArrowLeft, EyeOff } from "lucide-react";
+
+type Winner = "left" | "right" | "tie" | "skip";
+
+/** Blind matchup body that uses one opaque token for both hidden trajectories. */
+export function TraceTokenMatchupBody({ token }: { readonly token: string }) {
+  const matchup = useQuery(api.agentTraceReviewSessions.getMatchup, { token });
+  const decide = useMutation(api.agentTraceReviewSessions.decideMatchup);
+  const [tags, setTags] = useState<CommentTag[]>([]);
+  const [tagsInit, setTagsInit] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    if (!tagsInit && matchup !== undefined) {
+      setTags(matchup.reasonTags as CommentTag[]);
+      setTagsInit(true);
+    }
+  }, [matchup, tagsInit]);
+
+  if (matchup === undefined) {
+    return (
+      <div className="mx-auto max-w-5xl space-y-4 p-6">
+        <Skeleton className="h-8 w-64" />
+        <div className="grid gap-4 md:grid-cols-2">
+          <Skeleton className="h-96 w-full" />
+          <Skeleton className="h-96 w-full" />
+        </div>
+      </div>
+    );
+  }
+
+  const orderedSides: ReadonlyArray<{ side: "left" | "right"; label: string }> =
+    matchup.firstSide === "left"
+      ? [{ side: "left", label: matchup.leftBlindLabel }, { side: "right", label: matchup.rightBlindLabel }]
+      : [{ side: "right", label: matchup.rightBlindLabel }, { side: "left", label: matchup.leftBlindLabel }];
+  const winnerOptions: ReadonlyArray<{ value: Winner; label: string }> = [
+    ...orderedSides.map((side) => ({ value: side.side, label: `${side.label} better` })),
+    { value: "tie", label: "Tie" },
+    { value: "skip", label: "Skip" },
+  ];
+
+  async function submit(winner: Winner) {
+    setBusy(true);
+    setError("");
+    try {
+      await decide({ token, winner, reasonTags: tags });
+    } catch (cause: unknown) {
+      setError(friendlyError(cause, "Couldn’t record your pick. Try again."));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="mx-auto max-w-5xl p-6">
+      <Link to="/eval/traces" className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground">
+        <ArrowLeft aria-hidden="true" className="h-3 w-3" />
+        Reviews
+      </Link>
+      <header className="mt-3">
+        <h1 className="text-2xl font-bold">Which next move is better?</h1>
+        <p className="mt-1 text-sm text-muted-foreground">Given the same verified prefix, which agent’s next move is better?</p>
+      </header>
+      <Card className="mt-4 border-primary/30 bg-primary/5">
+        <CardContent className="flex items-start gap-2 pt-0 text-sm text-muted-foreground">
+          <EyeOff aria-hidden="true" className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
+          <p><span className="font-medium text-foreground">Blind review</span> — model and harness provenance remain hidden until the owner’s reveal.</p>
+        </CardContent>
+      </Card>
+
+      {!matchup.comparable ? (
+        <p className="mt-6 rounded-lg border border-dashed p-4 text-sm text-muted-foreground">
+          This pair cannot be reviewed because its trajectory prefixes differ.
+        </p>
+      ) : (
+        <>
+          <div className="mt-6 grid gap-4 md:grid-cols-2">
+            {orderedSides.map((side) => (
+              <div className="min-w-0" key={side.side}>
+                <h2 className="mb-3 text-sm font-semibold">{side.label}</h2>
+                <StepList reviewToken={token} matchupSide={side.side} divergenceStepIndex={matchup.divergenceStepIndex} />
+              </div>
+            ))}
+          </div>
+
+          <Card className="mt-6">
+            <CardHeader><CardTitle className="text-base">Your pick</CardTitle></CardHeader>
+            <CardContent className="space-y-3">
+              <div className="flex flex-wrap gap-2">
+                {winnerOptions.map((winner) => {
+                  const selected = matchup.winner === winner.value;
+                  return (
+                    <Button
+                      key={winner.value}
+                      type="button"
+                      variant={selected ? "default" : "outline"}
+                      size="sm"
+                      onClick={() => void submit(winner.value)}
+                      disabled={busy}
+                      className={cn(selected && "ring-2 ring-primary/40")}
+                    >
+                      {winner.label}
+                    </Button>
+                  );
+                })}
+              </div>
+              <div>
+                <p className="mb-1.5 text-xs text-muted-foreground">Reasons (optional)</p>
+                <div className="flex flex-wrap gap-1.5">
+                  {COMMENT_TAGS.map((tag) => {
+                    const selected = tags.includes(tag);
+                    return (
+                      <button
+                        key={tag}
+                        type="button"
+                        onClick={() => setTags((current) => selected
+                          ? current.filter((item) => item !== tag)
+                          : [...current, tag])}
+                        className={cn(
+                          "rounded-full border px-2 py-0.5 text-xs transition-colors",
+                          selected
+                            ? "border-primary bg-primary/10 text-primary"
+                            : "border-border text-muted-foreground hover:text-foreground",
+                        )}
+                      >
+                        {tag}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+              {error && <p className="text-sm text-destructive" role="alert">{error}</p>}
+            </CardContent>
+          </Card>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/routes/traces/TraceTokenReviewBody.tsx
+++ b/src/routes/traces/TraceTokenReviewBody.tsx
@@ -1,0 +1,156 @@
+import { useEffect, useState } from "react";
+import { useMutation, useQuery } from "convex/react";
+import { Link } from "react-router-dom";
+import { api } from "../../../convex/_generated/api";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
+import { friendlyError } from "@/lib/errors";
+import { StepBody, StepList } from "./traceSteps";
+import { ArrowLeft, EyeOff, Route } from "lucide-react";
+
+const RATINGS = [
+  { value: "best", label: "Best" },
+  { value: "acceptable", label: "Acceptable" },
+  { value: "weak", label: "Weak" },
+] as const;
+type Rating = (typeof RATINGS)[number]["value"];
+
+/** Blind trajectory review body that speaks only in opaque session tokens. */
+export function TraceTokenReviewBody({ token }: { readonly token: string }) {
+  const trace = useQuery(api.agentTraceReviewSessions.getTrace, { token });
+  const comments = useQuery(api.agentTraceReviewSessions.listComments, { token });
+
+  if (trace === undefined) {
+    return (
+      <div className="mx-auto max-w-3xl space-y-4 p-6">
+        <Skeleton className="h-8 w-56" />
+        <Skeleton className="h-24 w-full" />
+        <Skeleton className="h-64 w-full" />
+      </div>
+    );
+  }
+
+  const usageBits: string[] = [];
+  if (trace.usage.totalTokens !== undefined) usageBits.push(`${trace.usage.totalTokens.toLocaleString()} tokens`);
+  if (trace.usage.costUsd !== undefined) usageBits.push(`$${trace.usage.costUsd.toFixed(4)}`);
+  if (trace.usage.durationMs !== undefined) {
+    usageBits.push(trace.usage.durationMs >= 1000
+      ? `${(trace.usage.durationMs / 1000).toFixed(1)}s`
+      : `${trace.usage.durationMs}ms`);
+  }
+
+  return (
+    <div className="mx-auto max-w-3xl p-6">
+      <Link to="/eval/traces" className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground">
+        <ArrowLeft aria-hidden="true" className="h-3 w-3" />
+        Trajectories to review
+      </Link>
+      <header className="mt-3">
+        <div className="flex items-center gap-2">
+          <Route aria-hidden="true" className="h-5 w-5 text-primary" />
+          <h1 className="text-2xl font-bold">Trajectory</h1>
+        </div>
+        <p className="mt-1 text-sm text-muted-foreground">
+          {trace.stepCount} {trace.stepCount === 1 ? "step" : "steps"}
+          {usageBits.length > 0 && <> · {usageBits.join(" · ")}</>}
+        </p>
+      </header>
+
+      <Card className="mt-4 border-primary/30 bg-primary/5">
+        <CardContent className="flex items-start gap-2 pt-0 text-sm text-muted-foreground">
+          <EyeOff aria-hidden="true" className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
+          <p><span className="font-medium text-foreground">Blind review</span> — provenance hidden. Blinding reduces bias; it is not anonymity.</p>
+        </CardContent>
+      </Card>
+
+      <TokenVerdict token={token} />
+
+      {trace.hasFinalAnswer && (
+        <Card className="mt-6">
+          <CardHeader><CardTitle className="text-base">Final answer</CardTitle></CardHeader>
+          <CardContent><StepBody reviewToken={token} field="text" /></CardContent>
+        </Card>
+      )}
+
+      <section className="mt-6">
+        <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-muted-foreground">Steps</h2>
+        <StepList reviewToken={token} comments={comments} />
+      </section>
+    </div>
+  );
+}
+
+function TokenVerdict({ token }: { readonly token: string }) {
+  const verdict = useQuery(api.agentTraceReviewSessions.myVerdict, { token });
+  const setVerdict = useMutation(api.agentTraceReviewSessions.setVerdict);
+  const [note, setNote] = useState("");
+  const [noteInit, setNoteInit] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState("");
+  const [saved, setSaved] = useState(false);
+
+  useEffect(() => {
+    if (!noteInit && verdict !== undefined) {
+      setNote(verdict?.note ?? "");
+      setNoteInit(true);
+    }
+  }, [verdict, noteInit]);
+
+  async function submit(rating: Rating) {
+    setBusy(true);
+    setError("");
+    setSaved(false);
+    try {
+      await setVerdict({ token, rating, note: note.trim() || undefined });
+      setSaved(true);
+    } catch (cause: unknown) {
+      setError(friendlyError(cause, "Couldn’t save your verdict. Try again."));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <Card className="mt-4">
+      <CardHeader><CardTitle className="text-base">Your verdict</CardTitle></CardHeader>
+      <CardContent className="space-y-3">
+        <p className="text-sm text-muted-foreground">How did this agent handle the task overall?</p>
+        <div className="flex flex-wrap gap-2">
+          {RATINGS.map((rating) => {
+            const selected = verdict?.rating === rating.value;
+            return (
+              <Button
+                key={rating.value}
+                type="button"
+                variant={selected ? "default" : "outline"}
+                size="sm"
+                onClick={() => void submit(rating.value)}
+                disabled={busy}
+                className={cn(selected && "ring-2 ring-primary/40")}
+              >
+                {rating.label}
+              </Button>
+            );
+          })}
+        </div>
+        <Textarea
+          value={note}
+          onChange={(event) => { setNote(event.target.value); setSaved(false); }}
+          placeholder="Optional: why? (saved with your verdict)"
+          rows={2}
+          className="text-sm"
+        />
+        {verdict?.rating && (
+          <Button type="button" variant="ghost" size="sm" onClick={() => void submit(verdict.rating)} disabled={busy}>
+            {busy ? "Saving…" : "Save note"}
+          </Button>
+        )}
+        {error && <p className="text-sm text-destructive" role="alert">{error}</p>}
+        {saved && !error && <p className="text-xs text-muted-foreground">Saved.</p>}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/routes/traces/__smoke__/convexReactMock.tsx
+++ b/src/routes/traces/__smoke__/convexReactMock.tsx
@@ -34,6 +34,7 @@ const FIXTURE_BODY = {
 const noop = () => {};
 const getBodyFn = async () => FIXTURE_BODY;
 const noopMutation = async () => undefined;
+const createImportProject = async () => ({ orgSlug: "test-org", projectId: "test-project" });
 const PAGINATED = {
   results: FIXTURE_STEPS,
   status: "Exhausted" as const,
@@ -49,21 +50,30 @@ export function useAction() {
   return getBodyFn;
 }
 
-export function useMutation() {
+export function useMutation(mutation?: unknown) {
+  try {
+    if (getFunctionName(mutation as never) === "projects:createForImport") {
+      return createImportProject;
+    }
+  } catch {
+    // Keep unrelated component-test mutations as stable no-ops.
+  }
   return noopMutation;
 }
 
 // Fixture rows for the blind reviewer's discovery list (listReviewableTraces).
 export const FIXTURE_REVIEWABLE = [
   {
-    _id: "trace_review_1",
+    token: "opaque-review-token-1",
+    kind: "trace",
     projectName: "Support Router",
     status: "ready",
     stepCount: 12,
     createdAt: 2,
   },
   {
-    _id: "trace_review_2",
+    token: "opaque-review-token-2",
+    kind: "trace",
     projectName: "Refund Agent",
     status: "ready",
     stepCount: 3,
@@ -73,6 +83,17 @@ export const FIXTURE_REVIEWABLE = [
 
 // A blind reviewer's getTrace payload — provenance stripped by the backend
 // (harness/model/product undefined), projectName + usage retained.
+export const FIXTURE_BLIND_MATCHUP = {
+  projectName: "Support Router",
+  divergenceStepIndex: 1,
+  firstSide: "right",
+  leftBlindLabel: "B",
+  rightBlindLabel: "A",
+  comparable: true,
+  winner: null,
+  reasonTags: [],
+};
+
 export const FIXTURE_BLIND_TRACE = {
   _id: "trace_review_1",
   projectName: "Support Router",
@@ -95,13 +116,18 @@ export const FIXTURE_BLIND_TRACE = {
 export function useQuery(query: unknown) {
   try {
     switch (getFunctionName(query as never)) {
-      case "agentTraces:listReviewableTraces":
+      case "agentTraceReviewSessions:listMine":
         return FIXTURE_REVIEWABLE;
       case "agentTraces:getTrace":
+      case "agentTraceReviewSessions:getTrace":
         return FIXTURE_BLIND_TRACE;
+      case "agentTraceReviewSessions:getMatchup":
+        return FIXTURE_BLIND_MATCHUP;
       case "agentTraceReview:myVerdict":
+      case "agentTraceReviewSessions:myVerdict":
         return null;
       case "agentTraceReview:listComments":
+      case "agentTraceReviewSessions:listComments":
         return [];
     }
   } catch {

--- a/src/routes/traces/traceReviewBody.ct.spec.tsx
+++ b/src/routes/traces/traceReviewBody.ct.spec.tsx
@@ -1,26 +1,36 @@
 import { test, expect } from "@playwright/experimental-ct-react";
 import { MemoryRouter } from "react-router-dom";
-import type { Id } from "../../../convex/_generated/dataModel";
-import { TraceReviewBody } from "./TraceReviewBody";
+import { TraceTokenMatchupBody } from "./TraceTokenMatchupBody";
+import { TraceTokenReviewBody } from "./TraceTokenReviewBody";
 
-// #271 render smoke for the BLIND reviewer's review page: the getTrace payload
-// has provenance stripped, so the surface must show "Trajectory" (no harness/
-// model), the bias-reduction framing, the verdict control, and the steps.
-test("blind review page: no provenance, bias framing, verdict, and steps render", async ({
+// Reviewer smoke uses the opaque-token API surface, not a raw agentTraceId.
+test("blind token review: no provenance, bias framing, verdict, and steps render", async ({
   mount,
 }) => {
-  const cmp = await mount(
+  const component = await mount(
     <MemoryRouter>
-      <TraceReviewBody
-        agentTraceId={"t" as Id<"agentTraces">}
-        backTo="/eval/traces"
-        backLabel="Trajectories to review"
-      />
+      <TraceTokenReviewBody token="opaque-review-token" />
     </MemoryRouter>,
   );
-  await expect(cmp).toContainText("Trajectory"); // header, no provenance
-  await expect(cmp).toContainText("Blinding reduces bias; it is not anonymity");
-  await expect(cmp).toContainText("Your verdict");
-  await expect(cmp).toContainText("Acceptable");
-  await expect(cmp).toContainText("run_command"); // steps render via StepList
+  await expect(component).toContainText("Trajectory");
+  await expect(component).toContainText("Blinding reduces bias; it is not anonymity");
+  await expect(component).toContainText("Your verdict");
+  await expect(component).toContainText("Acceptable");
+  await expect(component).toContainText("run_command");
+  await expect(component.locator("[data-trace-id], [data-step-id]")).toHaveCount(0);
+});
+
+test("blind matchup uses session-scoped A/B order without provenance IDs", async ({ mount }) => {
+  const component = await mount(
+    <MemoryRouter>
+      <TraceTokenMatchupBody token="opaque-matchup-token" />
+    </MemoryRouter>,
+  );
+  await expect(component.getByRole("heading", { name: "Which next move is better?" })).toBeVisible();
+  await expect(component.getByRole("heading", { name: "A", exact: true })).toBeVisible();
+  await expect(component.getByRole("heading", { name: "B", exact: true })).toBeVisible();
+  await expect(component.getByRole("button", { name: "A better" })).toBeVisible();
+  await expect(component.getByRole("button", { name: "B better" })).toBeVisible();
+  await expect(component.locator("[data-trace-id], [data-step-id], [data-matchup-id]")).toHaveCount(0);
+  await expect(component).not.toContainText(/Claude|OpenAI|Pi session/i);
 });

--- a/src/routes/traces/traceSteps.tsx
+++ b/src/routes/traces/traceSteps.tsx
@@ -74,14 +74,19 @@ const BODY_FIELD: Partial<Record<TraceStep["kind"], string>> = {
  */
 export function StepBody({
   agentTraceId,
+  reviewToken,
+  matchupSide,
   stepIndex,
   field,
 }: {
-  agentTraceId: Id<"agentTraces">;
+  agentTraceId?: Id<"agentTraces">;
+  reviewToken?: string;
+  matchupSide?: "left" | "right";
   stepIndex?: number;
   field?: string;
 }) {
-  const getBody = useAction(api.agentTraces.getStepBody);
+  const getOwnerBody = useAction(api.agentTraces.getStepBody);
+  const getReviewBody = useAction(api.agentTraceReviewSessions.getStepBody);
   const [state, setState] = useState<{
     status: "loading" | "done" | "error";
     data?: unknown;
@@ -90,8 +95,12 @@ export function StepBody({
   useEffect(() => {
     let cancelled = false;
     setState({ status: "loading" });
-    getBody({ agentTraceId, stepIndex })
-      .then((data) => {
+    const request = reviewToken !== undefined
+      ? getReviewBody({ token: reviewToken, stepIndex, matchupSide })
+      : agentTraceId !== undefined
+        ? getOwnerBody({ agentTraceId, stepIndex })
+        : Promise.reject(new Error("Missing trace access scope"));
+    request.then((data) => {
         if (!cancelled) setState({ status: "done", data });
       })
       .catch(() => {
@@ -100,7 +109,7 @@ export function StepBody({
     return () => {
       cancelled = true;
     };
-  }, [agentTraceId, stepIndex, getBody]);
+  }, [agentTraceId, reviewToken, matchupSide, stepIndex, getOwnerBody, getReviewBody]);
 
   if (state.status === "loading") {
     return <Skeleton className="h-16 w-full" />;
@@ -169,10 +178,14 @@ function metaBits(step: TraceStep): string[] {
 function StepCard({
   step,
   agentTraceId,
+  reviewToken,
+  matchupSide,
   comments,
 }: {
   step: TraceStep;
-  agentTraceId: Id<"agentTraces">;
+  agentTraceId?: Id<"agentTraces">;
+  reviewToken?: string;
+  matchupSide?: "left" | "right";
   /** When provided, comment affordances render. Undefined = read-only. */
   comments?: TraceComment[];
 }) {
@@ -248,6 +261,8 @@ function StepCard({
         <div className={cn("px-3 pb-3", !expanded && "hidden")}>
           <StepBody
             agentTraceId={agentTraceId}
+            reviewToken={reviewToken}
+            matchupSide={matchupSide}
             stepIndex={step.stepIndex}
             field={BODY_FIELD[step.kind]}
           />
@@ -257,6 +272,7 @@ function StepCard({
       {comments !== undefined && (
         <StepComments
           agentTraceId={agentTraceId}
+          reviewToken={reviewToken}
           step={step}
           comments={comments}
         />
@@ -278,14 +294,17 @@ const LABEL_TONE: Record<string, string> = {
 
 function StepComments({
   agentTraceId,
+  reviewToken,
   step,
   comments,
 }: {
-  agentTraceId: Id<"agentTraces">;
+  agentTraceId?: Id<"agentTraces">;
+  reviewToken?: string;
   step: TraceStep;
   comments: TraceComment[];
 }) {
-  const addComment = useMutation(api.agentTraceReview.addComment);
+  const addOwnerComment = useMutation(api.agentTraceReview.addComment);
+  const addReviewComment = useMutation(api.agentTraceReviewSessions.addComment);
   const deleteComment = useMutation(api.agentTraceReview.deleteComment);
 
   const [composing, setComposing] = useState(false);
@@ -306,16 +325,28 @@ function StepComments({
     setBusy(true);
     setError("");
     try {
-      await addComment({
-        agentTraceId,
-        target:
-          step.kind === "tool_call"
-            ? { kind: "tool_call", stepIndex: step.stepIndex }
-            : { kind: "step", stepIndex: step.stepIndex },
-        comment: body,
-        label,
-        tags: tags.length ? tags : undefined,
-      });
+      const target = step.kind === "tool_call"
+        ? { kind: "tool_call" as const, stepIndex: step.stepIndex }
+        : { kind: "step" as const, stepIndex: step.stepIndex };
+      if (reviewToken !== undefined) {
+        await addReviewComment({
+          token: reviewToken,
+          target,
+          comment: body,
+          label,
+          tags: tags.length ? tags : undefined,
+        });
+      } else if (agentTraceId !== undefined) {
+        await addOwnerComment({
+          agentTraceId,
+          target,
+          comment: body,
+          label,
+          tags: tags.length ? tags : undefined,
+        });
+      } else {
+        throw new Error("Missing trace access scope");
+      }
       setBody("");
       setTags([]);
       setComposing(false);
@@ -474,40 +505,115 @@ function StepComments({
 
 export function StepList({
   agentTraceId,
+  reviewToken,
+  matchupSide,
   comments,
   divergenceStepIndex,
 }: {
-  agentTraceId: Id<"agentTraces">;
+  agentTraceId?: Id<"agentTraces">;
+  reviewToken?: string;
+  matchupSide?: "left" | "right";
   /** When provided, per-step comment affordances render. */
   comments?: TraceComment[];
   /** Draws a "paths diverge here" marker before this step (matchup view). */
   divergenceStepIndex?: number;
 }) {
-  const { results, status, loadMore } = usePaginatedQuery(
+  if (reviewToken !== undefined && matchupSide !== undefined) {
+    return <MatchupTokenSteps token={reviewToken} side={matchupSide} divergenceStepIndex={divergenceStepIndex} />;
+  }
+  if (reviewToken !== undefined) {
+    return <TraceTokenSteps token={reviewToken} comments={comments} divergenceStepIndex={divergenceStepIndex} />;
+  }
+  if (agentTraceId !== undefined) {
+    return <OwnerSteps agentTraceId={agentTraceId} comments={comments} divergenceStepIndex={divergenceStepIndex} />;
+  }
+  return <p className="text-sm text-destructive">This trajectory is unavailable.</p>;
+}
+
+function OwnerSteps({
+  agentTraceId,
+  comments,
+  divergenceStepIndex,
+}: {
+  readonly agentTraceId: Id<"agentTraces">;
+  readonly comments?: TraceComment[];
+  readonly divergenceStepIndex?: number;
+}) {
+  const page = usePaginatedQuery(
     api.agentTraces.listSteps,
     { agentTraceId },
     { initialNumItems: 50 },
   );
+  return <StepListResults {...page} agentTraceId={agentTraceId} comments={comments} divergenceStepIndex={divergenceStepIndex} />;
+}
 
+function TraceTokenSteps({
+  token,
+  comments,
+  divergenceStepIndex,
+}: {
+  readonly token: string;
+  readonly comments?: TraceComment[];
+  readonly divergenceStepIndex?: number;
+}) {
+  const page = usePaginatedQuery(
+    api.agentTraceReviewSessions.listSteps,
+    { token },
+    { initialNumItems: 50 },
+  );
+  return <StepListResults {...page} reviewToken={token} comments={comments} divergenceStepIndex={divergenceStepIndex} />;
+}
+
+function MatchupTokenSteps({
+  token,
+  side,
+  divergenceStepIndex,
+}: {
+  readonly token: string;
+  readonly side: "left" | "right";
+  readonly divergenceStepIndex?: number;
+}) {
+  const page = usePaginatedQuery(
+    api.agentTraceReviewSessions.listMatchupSteps,
+    { token, side },
+    { initialNumItems: 50 },
+  );
+  return <StepListResults {...page} reviewToken={token} matchupSide={side} divergenceStepIndex={divergenceStepIndex} />;
+}
+
+function StepListResults({
+  results,
+  status,
+  loadMore,
+  agentTraceId,
+  reviewToken,
+  matchupSide,
+  comments,
+  divergenceStepIndex,
+}: {
+  readonly results: ReadonlyArray<TraceStep>;
+  readonly status: "LoadingFirstPage" | "CanLoadMore" | "LoadingMore" | "Exhausted";
+  readonly loadMore: (numItems: number) => void;
+  readonly agentTraceId?: Id<"agentTraces">;
+  readonly reviewToken?: string;
+  readonly matchupSide?: "left" | "right";
+  readonly comments?: TraceComment[];
+  readonly divergenceStepIndex?: number;
+}) {
   if (status === "LoadingFirstPage") {
     return (
       <div className="space-y-2">
-        {[0, 1, 2, 3, 4].map((i) => (
-          <Skeleton key={i} className="h-11 w-full" />
-        ))}
+        {[0, 1, 2, 3, 4].map((index) => <Skeleton key={index} className="h-11 w-full" />)}
       </div>
     );
   }
-
   if (results.length === 0) {
     return (
       <p className="rounded-lg border border-dashed p-4 text-sm text-muted-foreground">
-        No steps to show yet. If this trajectory was just imported, it may still
-        be processing — refresh in a moment.
+        No steps to show yet. If this trajectory was just imported, it may still be processing — refresh in a moment.
       </p>
     );
   }
-
   return (
     <div className="space-y-3">
       <ol className="space-y-2">
@@ -517,27 +623,18 @@ export function StepList({
             <StepCard
               step={step}
               agentTraceId={agentTraceId}
-              comments={
-                comments === undefined
-                  ? undefined
-                  : comments.filter(
-                      (c) =>
-                        c.target.kind !== "trace" &&
-                        c.target.stepIndex === step.stepIndex,
-                    )
-              }
+              reviewToken={reviewToken}
+              matchupSide={matchupSide}
+              comments={comments === undefined
+                ? undefined
+                : comments.filter((comment) =>
+                    comment.target.kind !== "trace" && comment.target.stepIndex === step.stepIndex)}
             />
           </Fragment>
         ))}
       </ol>
-
       {status === "CanLoadMore" && (
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          onClick={() => loadMore(50)}
-        >
+        <Button type="button" variant="outline" size="sm" onClick={() => loadMore(50)}>
           Load more steps
         </Button>
       )}

--- a/src/routes/welcome/WelcomeFirstRun.ct.spec.tsx
+++ b/src/routes/welcome/WelcomeFirstRun.ct.spec.tsx
@@ -1,0 +1,24 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { WelcomeFirstRun } from "./WelcomeFirstRun";
+
+test("first run leads with import and keeps the playground secondary", async ({ mount }) => {
+  const component = await mount(
+    <MemoryRouter initialEntries={["/welcome"]}>
+      <Routes>
+        <Route path="/welcome" element={<WelcomeFirstRun />} />
+        <Route path="/orgs/:orgSlug/projects/:projectId/import" element={<p>Import route reached</p>} />
+      </Routes>
+    </MemoryRouter>,
+  );
+
+  await expect(component.getByRole("heading", { name: "Bring in completed AI runs" })).toBeVisible();
+  await expect(component).toContainText("CSV");
+  await expect(component).toContainText("OpenTelemetry");
+  await expect(component).toContainText("Pi");
+  await expect(component).toContainText("Claude Code");
+  await expect(component.getByRole("tab", { name: "Prompt playground" })).toBeVisible();
+
+  await component.getByRole("button", { name: "Import completed runs" }).click();
+  await expect(component).toContainText("Import route reached");
+});

--- a/src/routes/welcome/WelcomeFirstRun.tsx
+++ b/src/routes/welcome/WelcomeFirstRun.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { useMutation } from "convex/react";
 import { useNavigate } from "react-router-dom";
 import { useReducedMotion, motion } from "motion/react";
-import { ArrowRight, FileText, Sparkles } from "lucide-react";
+import { ArrowRight, FileText, Sparkles, Upload } from "lucide-react";
 
 import { api } from "../../../convex/_generated/api";
 import { Button } from "@/components/ui/button";
@@ -25,15 +25,14 @@ type PasteRole = "system" | "user";
 export function WelcomeFirstRun() {
   const navigate = useNavigate();
   const reduceMotion = useReducedMotion();
+  const createForImport = useMutation(api.projects.createForImport);
   const createFromPaste = useMutation(api.projects.createFromPaste);
   const cloneStarter = useMutation(api.projects.cloneStarter);
 
   const [content, setContent] = useState("");
   const [pasteRole, setPasteRole] = useState<PasteRole>("system");
   const [submitting, setSubmitting] = useState(false);
-  const [pendingPath, setPendingPath] = useState<"paste" | "clone" | null>(
-    null,
-  );
+  const [pendingPath, setPendingPath] = useState<"import" | "paste" | "clone" | null>(null);
   const [error, setError] = useState("");
 
   function landIn(orgSlug: string, projectId: string, versionId: string | null) {
@@ -44,6 +43,23 @@ export function WelcomeFirstRun() {
       );
     } else {
       navigate(`/orgs/${orgSlug}/projects/${projectId}`, { replace: true });
+    }
+  }
+
+  async function handleImport() {
+    if (submitting) return;
+    setSubmitting(true);
+    setPendingPath("import");
+    setError("");
+    try {
+      const res = await createForImport({});
+      navigate(`/orgs/${res.orgSlug}/projects/${res.projectId}/import`, {
+        replace: true,
+      });
+    } catch (err) {
+      setError(friendlyError(err, "Couldn't create your import workspace."));
+      setSubmitting(false);
+      setPendingPath(null);
     }
   }
 
@@ -123,24 +139,47 @@ export function WelcomeFirstRun() {
         <div className="rounded-xl border border-white/10 bg-background/90 p-8 shadow-2xl backdrop-blur-xl">
           <div className="space-y-1.5 text-center">
             <h1 className="text-2xl font-semibold tracking-tight">
-              What are you working on?
+              Bring in completed AI runs
             </h1>
             <p className="text-sm text-muted-foreground">
-              Bring in an agent prompt now, or load the example blind-review loop.
+              Upload traces from the systems you already run, then send them for blind expert review.
             </p>
           </div>
 
-          <Tabs defaultValue="paste" className="mt-6">
-            <TabsList className="grid w-full grid-cols-2">
+          <Tabs defaultValue="import" className="mt-6">
+            <TabsList className="grid w-full grid-cols-3">
+              <TabsTrigger value="import" className="gap-2">
+                <Upload className="h-3.5 w-3.5" />
+                Import runs
+              </TabsTrigger>
               <TabsTrigger value="paste" className="gap-2">
                 <FileText className="h-3.5 w-3.5" />
-                I have an agent prompt
+                Prompt playground
               </TabsTrigger>
               <TabsTrigger value="example" className="gap-2">
                 <Sparkles className="h-3.5 w-3.5" />
-                Show me an example
+                Example
               </TabsTrigger>
             </TabsList>
+
+            <TabsPanel value="import" className="space-y-4 pt-4">
+              <div className="space-y-3 rounded-md border bg-muted/30 p-4 text-xs">
+                <p className="font-medium">Start with real behavior, not another runtime</p>
+                <p className="text-muted-foreground">
+                  Upload mapped CSV, OpenTelemetry GenAI JSON, or a saved Pi or Claude Code session. Blind Bench normalizes the evidence and never runs your harness.
+                </p>
+                <div className="flex flex-wrap gap-1.5 text-[11px] text-muted-foreground">
+                  <span className="rounded border bg-background px-2 py-1">CSV</span>
+                  <span className="rounded border bg-background px-2 py-1">OpenTelemetry</span>
+                  <span className="rounded border bg-background px-2 py-1">Pi</span>
+                  <span className="rounded border bg-background px-2 py-1">Claude Code</span>
+                </div>
+              </div>
+              <Button onClick={handleImport} className="w-full" disabled={submitting}>
+                {pendingPath === "import" ? "Creating workspace…" : "Import completed runs"}
+                {pendingPath !== "import" && <ArrowRight className="ml-1.5 h-3.5 w-3.5" />}
+              </Button>
+            </TabsPanel>
 
             <TabsPanel value="paste" className="space-y-4 pt-4">
               <form onSubmit={handlePaste} className="space-y-3">
@@ -205,8 +244,7 @@ export function WelcomeFirstRun() {
               <div className="space-y-2 rounded-md border bg-muted/30 p-4 text-xs">
                 <p className="font-medium">Blind-review walkthrough</p>
                 <p className="text-muted-foreground">
-                  A complete example: run a candidate, review outputs blind,
-                  capture feedback, and route the verdict into the next version.
+                  A mutable sample of the original prompt playground. Use it to explore prompt/model output review without making it your core workflow.
                 </p>
               </div>
               <Button


### PR DESCRIPTION
## Summary

Pivots Blind Bench from an agent runtime direction to an ingestion-first, execution-neutral blind human-review product.

- makes **Import completed runs** the default first-run/project flow while retaining the prompt playground as a secondary tool
- adds one authenticated surface for mapped CSV, OTLP/HTTP GenAI JSON, Pi v3 session JSONL, and the existing Claude Code JSONL path
- stores raw provenance and large bodies in access-controlled Convex storage, returns counts-only receipts, and deduplicates retries
- replaces raw-ID blind trajectory URLs/APIs with reviewer-bound opaque sessions and session-scoped A/B ordering
- records independent per-reviewer matchup decisions and default-denies DPO/SFT rows on prefix mismatch, disagreement, tie/skip, or invalid chat shape
- fixes known false-green preflight/readiness cases and real artifact timestamps/consent copy
- documents the runtime-neutral boundary and adds required PR checks

Blind Bench does **not** provision sandboxes, execute arbitrary harness code, hold runtime credentials, or own runtime compute/cleanup. Historical M32 issues remain preserved and closed as deferred.

## Verification

Fresh local CI-equivalent run:

- `npm run build` — pass
- `npm run test:evals` — **177 passed**
- `npm run test:convex` — **280 passed**
- `npm run test:ct` — **8 Chromium component tests passed**

Additional gate evidence:

- canonical readiness now exits **1 / fail** because the synthetic scorecard contains one blocking safety/privacy hard-fail and is not fine-tuning ready (the previous existence-only false green is gone)
- customer-testing readiness exits **1 / blocked_until_approved** without external approvals and embeds the consent caveat
- customer launch packet emits a real timestamp and `live_logs_approved: false`
- no customer logs, credentials, or private traces were added

## Review focus

1. Pi active-branch parsing and session-v3 assumptions
2. reviewer-bound opaque session authorization/revocation and session-scoped A/B order
3. DPO shared-prefix and multi-reviewer resolution semantics
4. mapped CSV field UX and the 1,000-row / 8 MiB boundary
5. positioning and documentation language for the runtime-neutral product boundary

## Known follow-up / honest release boundary

#339 and parent #333 intentionally remain open. This PR adds CI browser component checks and a synthetic backend import → opaque review → SFT reuse integration test, but the **deployed authenticated two-account browser journey and repository branch-protection configuration still need to be completed before external customer-production readiness is claimed**. #313 (trial-credit farming) is also unchanged.

Closes #310
Closes #311
Closes #312
Closes #314
Closes #315
Closes #334
Closes #335
Closes #336
Closes #337
Closes #338
