### PR TITLE
M33.7: Add self-serve blind comparison campaigns

### DIFF
--- a/convex/agentTraceReview.ts
+++ b/convex/agentTraceReview.ts
@@ -38,7 +38,13 @@ const TARGET = v.union(
   v.object({ kind: v.literal("tool_call"), stepIndex: v.number() }),
 );
 const RATING = v.union(v.literal("best"), v.literal("acceptable"), v.literal("weak"));
-const WINNER = v.union(v.literal("left"), v.literal("right"), v.literal("tie"), v.literal("skip"));
+const WINNER = v.union(
+  v.literal("left"),
+  v.literal("right"),
+  v.literal("tie"),
+  v.literal("neither"),
+  v.literal("skip"),
+);
 
 const REVIEW_ROLES = ["owner", "editor", "evaluator"] as const;
 
@@ -178,6 +184,10 @@ export const createMatchup = mutation({
     divergenceStepIndex: v.number(),
     leftBlindLabel: v.string(),
     rightBlindLabel: v.string(),
+    campaignId: v.optional(v.id("comparisonCampaigns")),
+    caseKey: v.optional(v.string()),
+    segment: v.optional(v.string()),
+    sortOrder: v.optional(v.number()),
   },
   handler: async (ctx, args): Promise<Id<"agentTraceMatchups">> => {
     const left = await ctx.db.get(args.leftTraceId);
@@ -187,6 +197,15 @@ export const createMatchup = mutation({
       throw new Error("Both traces must be in the same project.");
     }
     await requireProjectRole(ctx, left.projectId, ["owner", "editor"]);
+    if (args.campaignId !== undefined) {
+      const campaign = await ctx.db.get(args.campaignId);
+      if (!campaign || campaign.projectId !== left.projectId) {
+        throw new Error("Comparison campaign not found in this project.");
+      }
+      if (!args.caseKey?.trim()) {
+        throw new Error("Campaign matchups require a case key.");
+      }
+    }
     if (!Number.isInteger(args.divergenceStepIndex) || args.divergenceStepIndex < 0) {
       throw new Error("Divergence step must be a non-negative integer.");
     }
@@ -208,10 +227,23 @@ export const createMatchup = mutation({
       throw new Error("Both traces must contain the divergence step.");
     }
     const comparable = leftStep.prefixHash === rightStep.prefixHash;
+    if (args.campaignId !== undefined && args.caseKey !== undefined) {
+      const existing = await ctx.db
+        .query("agentTraceMatchups")
+        .withIndex("by_campaign_case", (q) =>
+          q.eq("campaignId", args.campaignId).eq("caseKey", args.caseKey),
+        )
+        .unique();
+      if (existing) return existing._id;
+    }
     const matchupId = await ctx.db.insert("agentTraceMatchups", {
       projectId: left.projectId,
       leftTraceId: args.leftTraceId,
       rightTraceId: args.rightTraceId,
+      campaignId: args.campaignId,
+      caseKey: args.caseKey,
+      segment: args.segment,
+      sortOrder: args.sortOrder,
       divergenceStepIndex: args.divergenceStepIndex,
       leftBlindLabel: args.leftBlindLabel,
       rightBlindLabel: args.rightBlindLabel,
@@ -219,7 +251,7 @@ export const createMatchup = mutation({
       comparabilityStatus: comparable ? "valid" : "invalid",
       invalidReason: comparable ? undefined : "prefix_mismatch",
     });
-    if (comparable) {
+    if (comparable && args.campaignId === undefined) {
       await ensureMatchupSessionsForProjectReviewers(ctx, matchupId, left.projectId);
     }
     return matchupId;
@@ -232,6 +264,7 @@ export const decideMatchup = mutation({
     matchupId: v.id("agentTraceMatchups"),
     winner: WINNER,
     reasonTags: v.array(TAG),
+    note: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const matchup = await ctx.db.get(args.matchupId);
@@ -253,6 +286,7 @@ export const decideMatchup = mutation({
       await ctx.db.patch(existing._id, {
         winner: args.winner,
         reasonTags: args.reasonTags,
+        note: args.note,
         decidedAt: Date.now(),
       });
       return existing._id;
@@ -263,6 +297,7 @@ export const decideMatchup = mutation({
       userId,
       winner: args.winner,
       reasonTags: args.reasonTags,
+      note: args.note,
       decidedAt: Date.now(),
     });
   },

--- a/convex/agentTraceReviewSessions.ts
+++ b/convex/agentTraceReviewSessions.ts
@@ -41,7 +41,13 @@ const TARGET = v.union(
   v.object({ kind: v.literal("tool_call"), stepIndex: v.number() }),
 );
 const RATING = v.union(v.literal("best"), v.literal("acceptable"), v.literal("weak"));
-const WINNER = v.union(v.literal("left"), v.literal("right"), v.literal("tie"), v.literal("skip"));
+const WINNER = v.union(
+  v.literal("left"),
+  v.literal("right"),
+  v.literal("tie"),
+  v.literal("neither"),
+  v.literal("skip"),
+);
 const SIDE = v.union(v.literal("left"), v.literal("right"));
 
 type ReadCtx = QueryCtx | MutationCtx;
@@ -57,6 +63,19 @@ async function sessionForUser(
     .unique();
   if (!session || session.reviewerUserId !== userId) {
     throw new Error("Review session not found or expired.");
+  }
+  if (session.kind === "campaign") {
+    const campaign = session.campaignId
+      ? await ctx.db.get(session.campaignId)
+      : null;
+    if (
+      !campaign ||
+      campaign.projectId !== session.projectId ||
+      campaign.status !== "open"
+    ) {
+      throw new Error("Review session not found or expired.");
+    }
+    return session;
   }
   const collaborator = await ctx.db
     .query("projectCollaborators")
@@ -96,16 +115,26 @@ async function matchupSession(
   readonly session: Doc<"agentTraceReviewSessions">;
   readonly matchup: Doc<"agentTraceMatchups">;
   readonly userId: Id<"users">;
+  readonly leftFirst: boolean;
 }> {
   const session = await sessionForUser(ctx, token);
-  if (session.kind !== "matchup" || session.matchupId === undefined) {
-    throw new Error("This review link is not a matchup session.");
+  let matchupId: Id<"agentTraceMatchups"> | undefined;
+  let leftFirst = session.leftFirst ?? true;
+  if (session.kind === "matchup") {
+    matchupId = session.matchupId;
+  } else if (session.kind === "campaign") {
+    const entry = session.campaignOrder?.[session.currentIndex ?? 0];
+    matchupId = entry?.matchupId;
+    leftFirst = entry?.leftFirst ?? true;
   }
-  const matchup = await ctx.db.get(session.matchupId);
+  if (matchupId === undefined) {
+    throw new Error("This review link has no active matchup.");
+  }
+  const matchup = await ctx.db.get(matchupId);
   if (!matchup || matchup.projectId !== session.projectId) {
     throw new Error("Review matchup is no longer available.");
   }
-  return { session, matchup, userId: session.reviewerUserId };
+  return { session, matchup, userId: session.reviewerUserId, leftFirst };
 }
 
 /** List the caller's opaque trajectory and matchup review sessions. */
@@ -386,7 +415,10 @@ export const setVerdict = mutation({
 export const getMatchup = query({
   args: { token: v.string() },
   handler: async (ctx, args) => {
-    const { session, matchup, userId } = await matchupSession(ctx, args.token);
+    const { session, matchup, userId, leftFirst } = await matchupSession(ctx, args.token);
+    if (session.kind === "campaign") {
+      throw new Error("Campaign matchups use the campaign review flow.");
+    }
     const project = await ctx.db.get(matchup.projectId);
     const decision = await ctx.db
       .query("agentTraceMatchupDecisions")
@@ -394,7 +426,6 @@ export const getMatchup = query({
         q.eq("matchupId", matchup._id).eq("userId", userId),
       )
       .unique();
-    const leftFirst = session.leftFirst ?? true;
     return {
       projectName: project?.name ?? "Project",
       divergenceStepIndex: matchup.divergenceStepIndex,
@@ -441,11 +472,85 @@ export const listMatchupSteps = query({
   },
 });
 
+/** List the caller's comments for one side of the active opaque matchup. */
+export const listMatchupComments = query({
+  args: { token: v.string(), side: SIDE },
+  handler: async (ctx, args) => {
+    const { matchup, userId } = await matchupSession(ctx, args.token);
+    const traceId = args.side === "left" ? matchup.leftTraceId : matchup.rightTraceId;
+    const rows = await ctx.db
+      .query("agentTraceComments")
+      .withIndex("by_trace", (q) => q.eq("agentTraceId", traceId))
+      .collect();
+    return rows.filter((row) => row.userId === userId).map((row) => ({
+      _id: row._id,
+      target: row.target,
+      comment: row.comment,
+      label: row.label,
+      tags: row.tags ?? [],
+      mine: true,
+      createdAt: row._creationTime,
+    }));
+  },
+});
+
+/** Add a step/tool comment to one side of the active opaque matchup. */
+export const addMatchupComment = mutation({
+  args: {
+    token: v.string(),
+    side: SIDE,
+    target: TARGET,
+    comment: v.string(),
+    label: LABEL,
+    tags: v.optional(v.array(TAG)),
+  },
+  handler: async (ctx, args): Promise<Id<"agentTraceComments">> => {
+    const { matchup, userId } = await matchupSession(ctx, args.token);
+    const traceId = args.side === "left" ? matchup.leftTraceId : matchup.rightTraceId;
+    const trace = await ctx.db.get(traceId);
+    if (!trace) throw new Error("Review trajectory is no longer available.");
+    const body = args.comment.trim();
+    if (!body) throw new Error("Add a comment before saving.");
+    if (
+      args.target.kind !== "trace" &&
+      (args.target.stepIndex < 0 || args.target.stepIndex >= trace.stepCount)
+    ) {
+      throw new Error("That step is not part of this trace.");
+    }
+    return await ctx.db.insert("agentTraceComments", {
+      agentTraceId: trace._id,
+      projectId: trace.projectId,
+      userId,
+      target: args.target,
+      comment: body,
+      label: args.label,
+      tags: args.tags,
+    });
+  },
+});
+
+/** Delete the caller's own comment through the same opaque matchup token. */
+export const deleteMatchupComment = mutation({
+  args: { token: v.string(), side: SIDE, commentId: v.id("agentTraceComments") },
+  handler: async (ctx, args) => {
+    const { matchup, userId } = await matchupSession(ctx, args.token);
+    const traceId = args.side === "left" ? matchup.leftTraceId : matchup.rightTraceId;
+    const comment = await ctx.db.get(args.commentId);
+    if (!comment || comment.userId !== userId || comment.agentTraceId !== traceId) {
+      throw new Error("Comment not found.");
+    }
+    await ctx.db.delete(comment._id);
+  },
+});
+
 /** Record one independent matchup decision through an opaque session. */
 export const decideMatchup = mutation({
   args: { token: v.string(), winner: WINNER, reasonTags: v.array(TAG) },
   handler: async (ctx, args) => {
-    const { matchup, userId } = await matchupSession(ctx, args.token);
+    const { session, matchup, userId } = await matchupSession(ctx, args.token);
+    if (session.kind === "campaign") {
+      throw new Error("Campaign choices must use the campaign review flow.");
+    }
     if (matchup.comparabilityStatus !== "valid") {
       throw new Error("This matchup is not comparable because its prefixes differ.");
     }

--- a/convex/anonCleanup.ts
+++ b/convex/anonCleanup.ts
@@ -10,8 +10,9 @@ const BATCH_SIZE = 200;
  * public invite page, so a bot — or a user who bails before accepting — can
  * mint empty anonymous users. An anon user that never accepted a reviewer
  * invite has no projectCollaborators row: it is inert (can see and do nothing)
- * and safe to delete. We keep any anon user that became an evaluator so their
- * in-flight review session and ratings survive.
+ * and safe to delete. We keep any anon user that became an evaluator or
+ * redeemed an opaque review session so their in-flight campaign, comments,
+ * identity label, and judgments survive.
  *
  * Deleting a Convex Auth user means cascading its auth rows by hand
  * (authSessions → authRefreshTokens, authAccounts → authVerificationCodes);
@@ -36,7 +37,12 @@ export const cleanupAnonUsers = internalMutation({
         .query("projectCollaborators")
         .withIndex("by_user", (q) => q.eq("userId", user._id))
         .first();
-      if (collaborator) continue; // active reviewer — keep
+      if (collaborator) continue; // active project reviewer — keep
+      const reviewSession = await ctx.db
+        .query("agentTraceReviewSessions")
+        .withIndex("by_reviewer", (q) => q.eq("reviewerUserId", user._id))
+        .first();
+      if (reviewSession) continue; // opaque/campaign reviewer — keep
 
       await deleteAuthUser(ctx, user._id);
       deleted++;

--- a/convex/comparisonCampaigns.ts
+++ b/convex/comparisonCampaigns.ts
@@ -1,0 +1,757 @@
+/**
+ * Self-serve paired comparison campaigns over the existing agent-trace spine.
+ *
+ * The owner imports two candidates per shared context. Reviewers later redeem a
+ * campaign share token for their own opaque, user-bound review session; the
+ * share token itself never authorizes trace content or decisions.
+ */
+import { v } from "convex/values";
+import {
+  action,
+  internalMutation,
+  internalQuery,
+  mutation,
+  query,
+  type MutationCtx,
+  type QueryCtx,
+} from "./_generated/server";
+import { api, internal } from "./_generated/api";
+import type { Doc, Id } from "./_generated/dataModel";
+import { requireAuth, requireProjectRole } from "./lib/auth";
+import { generateToken } from "./lib/crypto";
+import { fisherYatesShuffle } from "./lib/shuffle";
+import {
+  parsePairedComparisonCsv,
+  type PairedComparisonCsvSummary,
+} from "./lib/pairedComparisonCsv";
+import { renderStep, type StepMeta } from "./lib/trainingExport";
+
+const MAX_BYTES = 8 * 1024 * 1024;
+const INITIAL_BATCH_SIZE = 5;
+type ReadCtx = QueryCtx | MutationCtx;
+
+interface CampaignReservation {
+  readonly campaignId: Id<"comparisonCampaigns">;
+  readonly status: "importing" | "draft" | "open" | "closed";
+  readonly rawPayloadStorageId?: Id<"_storage">;
+  readonly existing: boolean;
+}
+
+interface ImportResult {
+  readonly campaignId: Id<"comparisonCampaigns">;
+  readonly importedCases: number;
+  readonly deduped: boolean;
+  readonly summary: PairedComparisonCsvSummary;
+}
+
+async function sha256(value: string): Promise<string> {
+  const bytes = new TextEncoder().encode(value);
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
+  return [...new Uint8Array(digest)]
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+/** Reserve an idempotent campaign import before the action writes storage. */
+export const reserveImport = internalMutation({
+  args: {
+    projectId: v.id("projects"),
+    name: v.string(),
+    importKey: v.string(),
+  },
+  handler: async (ctx, args): Promise<CampaignReservation> => {
+    const { userId } = await requireProjectRole(ctx, args.projectId, [
+      "owner",
+      "editor",
+    ]);
+    const existing = await ctx.db
+      .query("comparisonCampaigns")
+      .withIndex("by_project_import", (q) =>
+        q.eq("projectId", args.projectId).eq("importKey", args.importKey),
+      )
+      .unique();
+    if (existing) {
+      return {
+        campaignId: existing._id,
+        status: existing.status,
+        rawPayloadStorageId: existing.rawPayloadStorageId,
+        existing: true,
+      };
+    }
+    const campaignId = await ctx.db.insert("comparisonCampaigns", {
+      projectId: args.projectId,
+      name: args.name.trim(),
+      status: "importing",
+      shareToken: generateToken(),
+      importKey: args.importKey,
+      caseCount: 0,
+      judgmentCount: 0,
+      createdById: userId,
+      createdAt: Date.now(),
+    });
+    return { campaignId, status: "importing", existing: false };
+  },
+});
+
+/** Attach the retained raw CSV once; retries never allocate another blob. */
+export const attachRawPayload = internalMutation({
+  args: {
+    campaignId: v.id("comparisonCampaigns"),
+    storageId: v.id("_storage"),
+  },
+  handler: async (ctx, args) => {
+    const campaign = await ctx.db.get(args.campaignId);
+    if (!campaign) throw new Error("Comparison campaign not found.");
+    await requireProjectRole(ctx, campaign.projectId, ["owner", "editor"]);
+    if (campaign.rawPayloadStorageId === undefined) {
+      await ctx.db.patch(campaign._id, { rawPayloadStorageId: args.storageId });
+    }
+  },
+});
+
+/** Mark a fully materialized import ready for owner review. */
+export const finalizeImport = internalMutation({
+  args: { campaignId: v.id("comparisonCampaigns") },
+  handler: async (ctx, args) => {
+    const campaign = await ctx.db.get(args.campaignId);
+    if (!campaign) throw new Error("Comparison campaign not found.");
+    await requireProjectRole(ctx, campaign.projectId, ["owner", "editor"]);
+    const matchups = await ctx.db
+      .query("agentTraceMatchups")
+      .withIndex("by_campaign", (q) => q.eq("campaignId", campaign._id))
+      .collect();
+    await ctx.db.patch(campaign._id, { status: "draft", caseCount: matchups.length });
+  },
+});
+
+/**
+ * Import a strict paired CSV as two candidate traces and one comparable matchup
+ * per valid row. The result is content-free and safe to render as a receipt.
+ */
+export const importPairedCsv = action({
+  args: {
+    projectId: v.id("projects"),
+    name: v.string(),
+    csv: v.string(),
+  },
+  handler: async (ctx, args): Promise<ImportResult> => {
+    await ctx.runQuery(internal.agentTraces.authorizePersist, {
+      projectId: args.projectId,
+    });
+    if (!args.name.trim()) throw new Error("Add a comparison name.");
+    const inputBytes = new TextEncoder().encode(args.csv).byteLength;
+    if (inputBytes > MAX_BYTES) {
+      throw new Error("Paired CSV is over the 8 MB upload limit.");
+    }
+    const batch = parsePairedComparisonCsv(args.csv);
+    if (batch.summary.invalid > 0) {
+      throw new Error(
+        `Paired CSV has ${batch.summary.invalid} invalid row${batch.summary.invalid === 1 ? "" : "s"} (${batch.summary.invalidRows.join(", ")}). Fix every row and import again.`,
+      );
+    }
+    if (batch.cases.length === 0) {
+      throw new Error("Paired CSV has no complete candidate pairs to import.");
+    }
+    const importKey = await sha256(args.csv);
+    const reservation: CampaignReservation = await ctx.runMutation(
+      internal.comparisonCampaigns.reserveImport,
+      {
+        projectId: args.projectId,
+        name: args.name,
+        importKey,
+      },
+    );
+    if (reservation.existing && reservation.status !== "importing") {
+      return {
+        campaignId: reservation.campaignId,
+        importedCases: 0,
+        deduped: true,
+        summary: batch.summary,
+      };
+    }
+
+    if (reservation.rawPayloadStorageId === undefined) {
+      const storageId = await ctx.storage.store(
+        new Blob([args.csv], { type: "text/csv" }),
+      );
+      await ctx.runMutation(internal.comparisonCampaigns.attachRawPayload, {
+        campaignId: reservation.campaignId,
+        storageId,
+      });
+    }
+
+    for (let index = 0; index < batch.cases.length; index++) {
+      const item = batch.cases[index];
+      if (!item) continue;
+      // Keep the pair ordered: Convex actions share bounded storage/write
+      // resources, and each trace already stores its steps in bounded chunks.
+      const candidateA = await ctx.runAction(api.agentTraces.persistTrace, {
+        projectId: args.projectId,
+        trace: item.candidateA,
+      });
+      const candidateB = await ctx.runAction(api.agentTraces.persistTrace, {
+        projectId: args.projectId,
+        trace: item.candidateB,
+      });
+      await ctx.runMutation(api.agentTraceReview.createMatchup, {
+        leftTraceId: candidateA.agentTraceId,
+        rightTraceId: candidateB.agentTraceId,
+        divergenceStepIndex: 1,
+        leftBlindLabel: "A",
+        rightBlindLabel: "B",
+        campaignId: reservation.campaignId,
+        caseKey: item.caseKey,
+        segment: item.segment,
+        sortOrder: index,
+      });
+    }
+
+    await ctx.runMutation(internal.comparisonCampaigns.finalizeImport, {
+      campaignId: reservation.campaignId,
+    });
+    return {
+      campaignId: reservation.campaignId,
+      importedCases: batch.cases.length,
+      deduped: false,
+      summary: batch.summary,
+    };
+  },
+});
+
+/** Owner/editor campaign summary, including provenance hidden from reviewers. */
+export const getOwnerCampaign = query({
+  args: { campaignId: v.id("comparisonCampaigns") },
+  handler: async (ctx, args) => {
+    const campaign = await ctx.db.get(args.campaignId);
+    if (!campaign) throw new Error("Comparison campaign not found.");
+    await requireProjectRole(ctx, campaign.projectId, ["owner", "editor"]);
+    const matchups = await ctx.db
+      .query("agentTraceMatchups")
+      .withIndex("by_campaign", (q) => q.eq("campaignId", campaign._id))
+      .collect();
+    const reviewSessions = await ctx.db
+      .query("agentTraceReviewSessions")
+      .withIndex("by_campaign_and_reviewer", (q) => q.eq("campaignId", campaign._id))
+      .collect();
+    const displayNameByReviewer = new Map(
+      reviewSessions.map((session) => [
+        String(session.reviewerUserId),
+        session.reviewerDisplayName,
+      ]),
+    );
+    const candidates = new Map<string, { model: string; harness: string }>();
+    const candidateA = new Set<string>();
+    const candidateB = new Set<string>();
+    const reviewers = new Map<string, Id<"users">>();
+    const feedbackRows: Array<{
+      caseKey: string;
+      reviewerId: string;
+      outcome: "Candidate A" | "Candidate B" | "Same" | "Neither acceptable" | "Cannot judge";
+      note: string;
+    }> = [];
+    const results = {
+      judgments: 0,
+      leftWins: 0,
+      rightWins: 0,
+      same: 0,
+      neither: 0,
+      cannotJudge: 0,
+      reviewedCases: 0,
+      agreementCases: 0,
+      agreementJudgments: 0,
+      majorityJudgments: 0,
+    };
+    for (const matchup of matchups) {
+      const traces = await Promise.all([
+        ctx.db.get(matchup.leftTraceId),
+        ctx.db.get(matchup.rightTraceId),
+      ]);
+      for (const trace of traces) {
+        if (!trace) continue;
+        const model = trace.model ?? "Unknown model";
+        const key = `${model}\u0000${trace.harnessName}`;
+        candidates.set(key, { model, harness: trace.harnessName });
+      }
+      if (traces[0]) candidateA.add(traces[0].model ?? traces[0].harnessName);
+      if (traces[1]) candidateB.add(traces[1].model ?? traces[1].harnessName);
+      const decisions = await ctx.db
+        .query("agentTraceMatchupDecisions")
+        .withIndex("by_matchup", (q) => q.eq("matchupId", matchup._id))
+        .collect();
+      const caseCounts = new Map<string, number>();
+      if (decisions.length > 0) results.reviewedCases++;
+      for (const decision of decisions) {
+        reviewers.set(String(decision.userId), decision.userId);
+        results.judgments++;
+        caseCounts.set(decision.winner, (caseCounts.get(decision.winner) ?? 0) + 1);
+        if (decision.note) {
+          const outcome = decision.winner === "left" ? "Candidate A"
+            : decision.winner === "right" ? "Candidate B"
+              : decision.winner === "tie" ? "Same"
+                : decision.winner === "neither" ? "Neither acceptable"
+                  : "Cannot judge";
+          feedbackRows.push({
+            caseKey: matchup.caseKey ?? "Comparison case",
+            reviewerId: String(decision.userId),
+            outcome,
+            note: decision.note,
+          });
+        }
+        if (decision.winner === "left") results.leftWins++;
+        else if (decision.winner === "right") results.rightWins++;
+        else if (decision.winner === "tie") results.same++;
+        else if (decision.winner === "neither") results.neither++;
+        else results.cannotJudge++;
+      }
+      if (decisions.length >= 2) {
+        results.agreementCases++;
+        results.agreementJudgments += decisions.length;
+        results.majorityJudgments += Math.max(...caseCounts.values());
+      }
+    }
+    const reviewerNames: string[] = [];
+    const reviewerNameById = new Map<string, string>();
+    for (const reviewerId of reviewers.values()) {
+      const reviewer = await ctx.db.get(reviewerId);
+      const name = displayNameByReviewer.get(String(reviewerId))?.trim()
+        || reviewer?.name?.trim()
+        || "Guest reviewer";
+      reviewerNames.push(name);
+      reviewerNameById.set(String(reviewerId), name);
+    }
+
+    return {
+      id: campaign._id,
+      projectId: campaign.projectId,
+      name: campaign.name,
+      status: campaign.status,
+      shareToken: campaign.shareToken,
+      caseCount: matchups.length,
+      comparableCount: matchups.filter(
+        (matchup) => matchup.comparabilityStatus === "valid",
+      ).length,
+      invalidCount: matchups.filter(
+        (matchup) => matchup.comparabilityStatus !== "valid",
+      ).length,
+      candidates: [...candidates.values()].sort((left, right) =>
+        left.model.localeCompare(right.model),
+      ),
+      candidateA: [...candidateA].sort(),
+      candidateB: [...candidateB].sort(),
+      reviewerNames: reviewerNames.sort((left, right) => left.localeCompare(right)),
+      feedback: feedbackRows.map(({ reviewerId, ...row }) => ({
+        ...row,
+        reviewerName: reviewerNameById.get(reviewerId) ?? "Guest reviewer",
+      })),
+      results: {
+        ...results,
+        reviewers: reviewers.size,
+        possibleJudgments: matchups.length * reviewers.size,
+        agreementRate: results.agreementJudgments > 0
+          ? results.majorityJudgments / results.agreementJudgments
+          : null,
+      },
+    };
+  },
+});
+
+/** List owner/editor comparison campaigns with progress counts. */
+export const listCampaigns = query({
+  args: { projectId: v.id("projects") },
+  handler: async (ctx, args) => {
+    await requireProjectRole(ctx, args.projectId, ["owner", "editor"]);
+    const campaigns = await ctx.db
+      .query("comparisonCampaigns")
+      .withIndex("by_project", (q) => q.eq("projectId", args.projectId))
+      .order("desc")
+      .take(100);
+    return campaigns.map((campaign) => ({
+      id: campaign._id,
+      name: campaign.name,
+      status: campaign.status,
+      caseCount: campaign.caseCount ?? 0,
+      judgments: campaign.judgmentCount ?? 0,
+      createdAt: campaign.createdAt,
+    }));
+  },
+});
+
+/** Open a fully imported campaign for guest review. */
+export const openCampaign = mutation({
+  args: { campaignId: v.id("comparisonCampaigns") },
+  handler: async (ctx, args) => {
+    const campaign = await ctx.db.get(args.campaignId);
+    if (!campaign) throw new Error("Comparison campaign not found.");
+    await requireProjectRole(ctx, campaign.projectId, ["owner", "editor"]);
+    if (campaign.status !== "draft" && campaign.status !== "open") {
+      throw new Error("Only a ready comparison campaign can be opened.");
+    }
+    if (campaign.status === "draft") {
+      await ctx.db.patch(campaign._id, { status: "open", openedAt: Date.now() });
+    }
+    return { shareToken: campaign.shareToken };
+  },
+});
+
+/** Stop new and in-progress judgments while preserving results and exports. */
+export const closeCampaign = mutation({
+  args: { campaignId: v.id("comparisonCampaigns") },
+  handler: async (ctx, args) => {
+    const campaign = await ctx.db.get(args.campaignId);
+    if (!campaign) throw new Error("Comparison campaign not found.");
+    await requireProjectRole(ctx, campaign.projectId, ["owner", "editor"]);
+    if (campaign.status !== "open" && campaign.status !== "closed") {
+      throw new Error("Only an open comparison campaign can be closed.");
+    }
+    if (campaign.status === "open") {
+      await ctx.db.patch(campaign._id, { status: "closed", closedAt: Date.now() });
+    }
+    return { closed: true };
+  },
+});
+
+async function campaignSession(ctx: ReadCtx, token: string) {
+  const userId = await requireAuth(ctx);
+  const session = await ctx.db
+    .query("agentTraceReviewSessions")
+    .withIndex("by_token", (q) => q.eq("token", token))
+    .unique();
+  if (
+    !session ||
+    session.reviewerUserId !== userId ||
+    session.kind !== "campaign" ||
+    session.campaignId === undefined
+  ) {
+    throw new Error("Review session not found or expired.");
+  }
+  const campaign = await ctx.db.get(session.campaignId);
+  if (!campaign || campaign.projectId !== session.projectId) {
+    throw new Error("Review campaign is no longer available.");
+  }
+  return { userId, session, campaign };
+}
+
+/** Redeem a campaign share token for one user-bound opaque review session. */
+export const joinCampaign = mutation({
+  args: { shareToken: v.string(), displayName: v.string() },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx);
+    const campaign = await ctx.db
+      .query("comparisonCampaigns")
+      .withIndex("by_share_token", (q) => q.eq("shareToken", args.shareToken))
+      .unique();
+    if (!campaign || campaign.status !== "open") {
+      throw new Error("This comparison is not open for review.");
+    }
+    const collaborator = await ctx.db
+      .query("projectCollaborators")
+      .withIndex("by_project_and_user", (q) =>
+        q.eq("projectId", campaign.projectId).eq("userId", userId),
+      )
+      .unique();
+    if (collaborator?.role === "owner" || collaborator?.role === "editor") {
+      throw new Error("Open this review link in a guest window to preserve blinding.");
+    }
+    const existing = await ctx.db
+      .query("agentTraceReviewSessions")
+      .withIndex("by_campaign_and_reviewer", (q) =>
+        q.eq("campaignId", campaign._id).eq("reviewerUserId", userId),
+      )
+      .unique();
+    const displayName = args.displayName.trim().slice(0, 80);
+    if (!displayName) throw new Error("Add your display name before starting.");
+    if (existing) {
+      if (displayName && existing.reviewerDisplayName !== displayName) {
+        await ctx.db.patch(existing._id, { reviewerDisplayName: displayName });
+      }
+      return { sessionToken: existing.token };
+    }
+
+    const matchups = await ctx.db
+      .query("agentTraceMatchups")
+      .withIndex("by_campaign", (q) => q.eq("campaignId", campaign._id))
+      .collect();
+    const ordered = fisherYatesShuffle(
+      matchups.filter((matchup) => matchup.comparabilityStatus === "valid"),
+    );
+    if (ordered.length === 0) throw new Error("This comparison has no reviewable pairs.");
+    const token = generateToken();
+    await ctx.db.insert("agentTraceReviewSessions", {
+      projectId: campaign.projectId,
+      reviewerUserId: userId,
+      token,
+      kind: "campaign",
+      campaignId: campaign._id,
+      reviewerDisplayName: displayName,
+      campaignOrder: ordered.map((matchup, index) => ({
+        matchupId: matchup._id,
+        leftFirst: (token.charCodeAt(index % token.length) + index) % 2 === 0,
+      })),
+      currentIndex: 0,
+      visibleCount: Math.min(INITIAL_BATCH_SIZE, ordered.length),
+    });
+    return { sessionToken: token };
+  },
+});
+
+async function decisionsForSession(
+  ctx: ReadCtx,
+  session: Doc<"agentTraceReviewSessions">,
+): Promise<Map<string, Doc<"agentTraceMatchupDecisions">>> {
+  const decisions = new Map<string, Doc<"agentTraceMatchupDecisions">>();
+  for (const entry of session.campaignOrder ?? []) {
+    const row = await ctx.db
+      .query("agentTraceMatchupDecisions")
+      .withIndex("by_matchup_and_user", (q) =>
+        q.eq("matchupId", entry.matchupId).eq("userId", session.reviewerUserId),
+      )
+      .unique();
+    if (row) decisions.set(String(entry.matchupId), row);
+  }
+  return decisions;
+}
+
+const REVIEW_CHOICE = v.union(
+  v.literal("first"),
+  v.literal("second"),
+  v.literal("same"),
+  v.literal("neither"),
+  v.literal("cannot_judge"),
+);
+
+/** Save or revise one displayed campaign choice without trusting client ids. */
+export const submitChoice = mutation({
+  args: {
+    sessionToken: v.string(),
+    position: v.number(),
+    choice: REVIEW_CHOICE,
+    note: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const { userId, session, campaign } = await campaignSession(ctx, args.sessionToken);
+    if (campaign.status !== "open") throw new Error("This comparison is closed.");
+    const order = session.campaignOrder ?? [];
+    const visibleCount = Math.min(session.visibleCount ?? INITIAL_BATCH_SIZE, order.length);
+    if (!Number.isInteger(args.position) || args.position < 0 || args.position >= visibleCount) {
+      throw new Error("That comparison item is not available.");
+    }
+    const entry = order[args.position];
+    if (!entry) throw new Error("That comparison item is not available.");
+    const matchup = await ctx.db.get(entry.matchupId);
+    if (!matchup || matchup.campaignId !== campaign._id || matchup.comparabilityStatus !== "valid") {
+      throw new Error("That comparison item is no longer reviewable.");
+    }
+    const winner = args.choice === "first"
+      ? (entry.leftFirst ? "left" : "right")
+      : args.choice === "second"
+        ? (entry.leftFirst ? "right" : "left")
+        : args.choice === "same"
+          ? "tie"
+          : args.choice === "neither"
+            ? "neither"
+            : "skip";
+    const note = args.note?.trim().slice(0, 2_000) || undefined;
+    const existing = await ctx.db
+      .query("agentTraceMatchupDecisions")
+      .withIndex("by_matchup_and_user", (q) =>
+        q.eq("matchupId", matchup._id).eq("userId", userId),
+      )
+      .unique();
+    if (existing) {
+      await ctx.db.patch(existing._id, { winner, note, decidedAt: Date.now() });
+    } else {
+      await ctx.db.insert("agentTraceMatchupDecisions", {
+        matchupId: matchup._id,
+        projectId: campaign.projectId,
+        userId,
+        winner,
+        note,
+        reasonTags: [],
+        decidedAt: Date.now(),
+      });
+      await ctx.db.patch(campaign._id, {
+        judgmentCount: (campaign.judgmentCount ?? 0) + 1,
+      });
+    }
+    const nextIndex = Math.max(session.currentIndex ?? 0, args.position + 1);
+    await ctx.db.patch(session._id, {
+      currentIndex: nextIndex,
+      ...(nextIndex >= order.length ? { completedAt: Date.now() } : {}),
+    });
+    return { saved: true };
+  },
+});
+
+/** Reveal the next five frozen assignments without changing their order. */
+export const extendBatch = mutation({
+  args: { sessionToken: v.string() },
+  handler: async (ctx, args) => {
+    const { session, campaign } = await campaignSession(ctx, args.sessionToken);
+    if (campaign.status !== "open") throw new Error("This comparison is closed.");
+    const order = session.campaignOrder ?? [];
+    const total = order.length;
+    const currentVisibleCount = Math.min(
+      session.visibleCount ?? INITIAL_BATCH_SIZE,
+      total,
+    );
+    const decisions = await decisionsForSession(ctx, session);
+    if (order.slice(0, currentVisibleCount).some(
+      (entry) => !decisions.has(String(entry.matchupId)),
+    )) {
+      throw new Error("Complete the current five comparisons before adding more.");
+    }
+    const visibleCount = Math.min(
+      total,
+      currentVisibleCount + INITIAL_BATCH_SIZE,
+    );
+    await ctx.db.patch(session._id, { visibleCount });
+    return { visibleCount, total };
+  },
+});
+
+/** Reviewer-safe campaign progress and current blind matchup metadata. */
+export const getReview = query({
+  args: { sessionToken: v.string() },
+  handler: async (ctx, args) => {
+    const { session, campaign } = await campaignSession(ctx, args.sessionToken);
+    const order = session.campaignOrder ?? [];
+    const visibleCount = Math.min(session.visibleCount ?? INITIAL_BATCH_SIZE, order.length);
+    const decisions = await decisionsForSession(ctx, session);
+    let currentIndex = Math.min(session.currentIndex ?? 0, Math.max(0, visibleCount - 1));
+    while (currentIndex < visibleCount && decisions.has(String(order[currentIndex]?.matchupId))) {
+      currentIndex++;
+    }
+    const entry = currentIndex < visibleCount ? order[currentIndex] : undefined;
+    const matchup = entry ? await ctx.db.get(entry.matchupId) : null;
+    const candidateStep = matchup
+      ? await ctx.db
+          .query("agentTraceSteps")
+          .withIndex("by_trace_and_index", (q) =>
+            q.eq("agentTraceId", matchup.leftTraceId).eq("stepIndex", matchup.divergenceStepIndex),
+          )
+          .unique()
+      : null;
+    return {
+      title: "Blind comparison",
+      status: campaign.status,
+      progress: {
+        judged: decisions.size,
+        visible: visibleCount,
+        total: order.length,
+      },
+      batchComplete: entry === undefined,
+      allComplete: decisions.size >= order.length,
+      current: matchup && entry ? {
+        position: currentIndex,
+        firstLabel: "A",
+        secondLabel: "B",
+        firstSide: entry.leftFirst ? "left" as const : "right" as const,
+        secondSide: entry.leftFirst ? "right" as const : "left" as const,
+        comparable: matchup.comparabilityStatus === "valid",
+        divergenceStepIndex: matchup.divergenceStepIndex,
+        candidateStep: candidateStep ? {
+          stepIndex: candidateStep.stepIndex,
+          kind: candidateStep.kind,
+        } : {
+          stepIndex: matchup.divergenceStepIndex,
+          kind: "message" as const,
+        },
+      } : null,
+    };
+  },
+});
+
+interface ContentStepPlan {
+  readonly meta: StepMeta;
+  readonly storageId?: Id<"_storage">;
+}
+
+interface CurrentContentPlan {
+  readonly leftFirst: boolean;
+  readonly prefix: ReadonlyArray<ContentStepPlan>;
+  readonly left: ContentStepPlan | null;
+  readonly right: ContentStepPlan | null;
+}
+
+interface ReviewContent {
+  readonly context: string;
+  readonly firstCandidate: string;
+  readonly secondCandidate: string;
+}
+
+const stepMeta = (step: Doc<"agentTraceSteps">): StepMeta => ({
+  kind: step.kind,
+  role: step.role,
+  toolName: step.toolName,
+  label: step.label,
+  policy: step.policy,
+  action: step.action,
+  reason: step.reason,
+});
+
+export const currentContentPlan = internalQuery({
+  args: { sessionToken: v.string() },
+  handler: async (ctx, args): Promise<CurrentContentPlan | null> => {
+    const { session, campaign } = await campaignSession(ctx, args.sessionToken);
+    if (campaign.status !== "open") return null;
+    const order = session.campaignOrder ?? [];
+    const visibleCount = Math.min(session.visibleCount ?? INITIAL_BATCH_SIZE, order.length);
+    const decisions = await decisionsForSession(ctx, session);
+    let index = Math.min(session.currentIndex ?? 0, Math.max(0, visibleCount - 1));
+    while (index < visibleCount && decisions.has(String(order[index]?.matchupId))) index++;
+    const entry = index < visibleCount ? order[index] : undefined;
+    if (!entry) return null;
+    const matchup = await ctx.db.get(entry.matchupId);
+    if (!matchup) return null;
+    const [leftSteps, rightSteps] = await Promise.all([
+      ctx.db.query("agentTraceSteps").withIndex("by_trace_and_index", (q) => q.eq("agentTraceId", matchup.leftTraceId)).collect(),
+      ctx.db.query("agentTraceSteps").withIndex("by_trace_and_index", (q) => q.eq("agentTraceId", matchup.rightTraceId)).collect(),
+    ]);
+    const prefix = leftSteps.filter((step) => step.stepIndex < matchup.divergenceStepIndex);
+    const left = leftSteps.find((step) => step.stepIndex === matchup.divergenceStepIndex);
+    const right = rightSteps.find((step) => step.stepIndex === matchup.divergenceStepIndex);
+    return {
+      leftFirst: entry.leftFirst,
+      prefix: prefix.map((step) => ({ meta: stepMeta(step), storageId: step.blindBodyStorageId })),
+      left: left ? { meta: stepMeta(left), storageId: left.blindBodyStorageId } : null,
+      right: right ? { meta: stepMeta(right), storageId: right.blindBodyStorageId } : null,
+    };
+  },
+});
+
+async function readStoredJson(
+  ctx: { storage: { get: (id: Id<"_storage">) => Promise<Blob | null> } },
+  storageId: Id<"_storage"> | undefined,
+): Promise<unknown> {
+  if (!storageId) return null;
+  const blob = await ctx.storage.get(storageId);
+  if (!blob) return null;
+  try { return JSON.parse(await blob.text()); } catch { return null; }
+}
+
+/** Lazy content action for the current campaign card; provenance never returns. */
+export const getCurrentContent = action({
+  args: { sessionToken: v.string() },
+  handler: async (ctx, args): Promise<ReviewContent> => {
+    const plan: CurrentContentPlan | null = await ctx.runQuery(
+      internal.comparisonCampaigns.currentContentPlan,
+      args,
+    );
+    if (!plan) return { context: "", firstCandidate: "", secondCandidate: "" };
+    const prefixBodies: string[] = [];
+    for (const step of plan.prefix) {
+      const body = await readStoredJson(ctx, step.storageId);
+      prefixBodies.push(renderStep(step.meta, body));
+    }
+    const leftBody = await readStoredJson(ctx, plan.left?.storageId);
+    const rightBody = await readStoredJson(ctx, plan.right?.storageId);
+    const left = plan.left ? renderStep(plan.left.meta, leftBody).replace(/^assistant: /, "") : "";
+    const right = plan.right ? renderStep(plan.right.meta, rightBody).replace(/^assistant: /, "") : "";
+    const context = prefixBodies.join("\n").replace(/^user: /, "");
+    return {
+      context,
+      firstCandidate: plan.leftFirst ? left : right,
+      secondCandidate: plan.leftFirst ? right : left,
+    };
+  },
+});

--- a/convex/exports.ts
+++ b/convex/exports.ts
@@ -183,12 +183,22 @@ interface TrajectoryPlanRow {
 }
 
 export const gatherTrajectoryPlan = internalQuery({
-  args: { projectId: v.id("projects"), format: FORMAT },
+  args: {
+    projectId: v.id("projects"),
+    format: FORMAT,
+    campaignId: v.optional(v.id("comparisonCampaigns")),
+  },
   handler: async (
     ctx,
     args,
   ): Promise<{ plan: TrajectoryPlanRow[]; stats: ExportSourceStats }> => {
     await requireProjectRole(ctx, args.projectId, ["owner", "editor"]);
+    if (args.campaignId !== undefined) {
+      const campaign = await ctx.db.get(args.campaignId);
+      if (!campaign || campaign.projectId !== args.projectId) {
+        throw new Error("Comparison campaign not found.");
+      }
+    }
     const stepsOf = (traceId: Id<"agentTraces">) =>
       ctx.db
         .query("agentTraceSteps")
@@ -199,10 +209,13 @@ export const gatherTrajectoryPlan = internalQuery({
     const reviewerIds = new Set<string>();
 
     if (args.format === "dpo") {
-      const matchups = await ctx.db
+      const allMatchups = await ctx.db
         .query("agentTraceMatchups")
         .withIndex("by_project", (q) => q.eq("projectId", args.projectId))
         .collect();
+      const matchups = args.campaignId === undefined
+        ? allMatchups
+        : allMatchups.filter((matchup) => matchup.campaignId === args.campaignId);
       for (const m of matchups) {
         const [leftTrace, rightTrace] = await Promise.all([
           ctx.db.get(m.leftTraceId),
@@ -226,7 +239,10 @@ export const gatherTrajectoryPlan = internalQuery({
         const directional = decisions.filter(
           (decision) => decision.winner === "left" || decision.winner === "right",
         );
-        if (decisions.some((decision) => decision.winner === "tie" || decision.winner === "skip")) {
+        if (decisions.some((decision) =>
+          decision.winner === "tie" ||
+          decision.winner === "neither" ||
+          decision.winner === "skip")) {
           plan.push({ privacyClass, metadata: {}, excludeReason: "no_preference" });
           continue;
         }
@@ -353,6 +369,7 @@ export const generateExport = action({
     format: FORMAT,
     // Explicit consent to include prod-sensitive (confidential/pii/phi) rows.
     allowSensitive: v.optional(v.boolean()),
+    campaignId: v.optional(v.id("comparisonCampaigns")),
   },
   handler: async (
     ctx,
@@ -363,6 +380,9 @@ export const generateExport = action({
     excludedCount: number;
     manifest: ExportManifest;
   }> => {
+    if (args.campaignId !== undefined && args.source !== "trajectory") {
+      throw new Error("Campaign exports use the trajectory source.");
+    }
     if (args.format === "annotated") {
       throw new Error("Annotated export isn’t available yet — use DPO or SFT.");
     }
@@ -384,6 +404,7 @@ export const generateExport = action({
       const res = await ctx.runQuery(internal.exports.gatherTrajectoryPlan, {
         projectId: args.projectId,
         format: args.format,
+        campaignId: args.campaignId,
       });
       const hydrated = await hydrateTrajectory(ctx, res.plan, args.format);
       classified = hydrated.rows;

--- a/convex/lib/pairedComparisonCsv.ts
+++ b/convex/lib/pairedComparisonCsv.ts
@@ -1,0 +1,2 @@
+/** Convex bundle entry point for the shared paired-comparison CSV adapter. */
+export * from "../../src/lib/evals/pairedComparisonCsv";

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -731,6 +731,32 @@ const schema = defineSchema({
     updatedAt: v.number(),
   }).index("by_project", ["projectId"]),
 
+  // #341: owner-created blind comparison campaign over comparable trace
+  // matchups. The share token only permits joining; reviewer content and votes
+  // require a separate user-bound opaque session token.
+  comparisonCampaigns: defineTable({
+    projectId: v.id("projects"),
+    name: v.string(),
+    status: v.union(
+      v.literal("importing"),
+      v.literal("draft"),
+      v.literal("open"),
+      v.literal("closed"),
+    ),
+    shareToken: v.string(),
+    importKey: v.string(),
+    caseCount: v.optional(v.number()),
+    judgmentCount: v.optional(v.number()),
+    rawPayloadStorageId: v.optional(v.id("_storage")),
+    createdById: v.id("users"),
+    createdAt: v.number(),
+    openedAt: v.optional(v.number()),
+    closedAt: v.optional(v.number()),
+  })
+    .index("by_project", ["projectId"])
+    .index("by_share_token", ["shareToken"])
+    .index("by_project_import", ["projectId", "importKey"]),
+
   // #264 (M31 Trajectory Spine): parent row for a normalized agent-run trace.
   // Deliberately tiny — metadata + usage rollups only, NO step content — so it
   // stays well under the Convex ~1MiB doc cap regardless of trace length. Step
@@ -899,6 +925,11 @@ const schema = defineSchema({
     projectId: v.id("projects"),
     leftTraceId: v.id("agentTraces"),
     rightTraceId: v.id("agentTraces"),
+    // Present for matchups created through a paired comparison campaign.
+    campaignId: v.optional(v.id("comparisonCampaigns")),
+    caseKey: v.optional(v.string()),
+    segment: v.optional(v.string()),
+    sortOrder: v.optional(v.number()),
     // Length of the shared prefix; both sides diverge at this step index.
     divergenceStepIndex: v.number(),
     leftBlindLabel: v.string(),
@@ -908,7 +939,9 @@ const schema = defineSchema({
     invalidReason: v.optional(v.literal("prefix_mismatch")),
   })
     .index("by_project", ["projectId"])
-    .index("by_left", ["leftTraceId"]),
+    .index("by_left", ["leftTraceId"])
+    .index("by_campaign", ["campaignId"])
+    .index("by_campaign_case", ["campaignId", "caseKey"]),
 
   // One immutable logical decision per (matchup, reviewer). Reviewers can
   // revise their own row, but never overwrite another reviewer's judgment.
@@ -916,17 +949,35 @@ const schema = defineSchema({
     projectId: v.id("projects"),
     reviewerUserId: v.id("users"),
     token: v.string(),
-    kind: v.union(v.literal("trace"), v.literal("matchup")),
+    kind: v.union(
+      v.literal("trace"),
+      v.literal("matchup"),
+      v.literal("campaign"),
+    ),
     // Session-scoped randomized presentation order prevents one global
     // left/right ordering from biasing every reviewer.
     leftFirst: v.optional(v.boolean()),
     agentTraceId: v.optional(v.id("agentTraces")),
     matchupId: v.optional(v.id("agentTraceMatchups")),
+    campaignId: v.optional(v.id("comparisonCampaigns")),
+    reviewerDisplayName: v.optional(v.string()),
+    campaignOrder: v.optional(
+      v.array(
+        v.object({
+          matchupId: v.id("agentTraceMatchups"),
+          leftFirst: v.boolean(),
+        }),
+      ),
+    ),
+    currentIndex: v.optional(v.number()),
+    visibleCount: v.optional(v.number()),
+    completedAt: v.optional(v.number()),
   })
     .index("by_token", ["token"])
     .index("by_reviewer", ["reviewerUserId"])
     .index("by_trace_and_reviewer", ["agentTraceId", "reviewerUserId"])
-    .index("by_matchup_and_reviewer", ["matchupId", "reviewerUserId"]),
+    .index("by_matchup_and_reviewer", ["matchupId", "reviewerUserId"])
+    .index("by_campaign_and_reviewer", ["campaignId", "reviewerUserId"]),
 
   agentTraceMatchupDecisions: defineTable({
     matchupId: v.id("agentTraceMatchups"),
@@ -936,8 +987,10 @@ const schema = defineSchema({
       v.literal("left"),
       v.literal("right"),
       v.literal("tie"),
+      v.literal("neither"),
       v.literal("skip"),
     ),
+    note: v.optional(v.string()),
     reasonTags: v.array(
       v.union(
         v.literal("tone"),

--- a/convex/tests/comparisonCampaigns.test.ts
+++ b/convex/tests/comparisonCampaigns.test.ts
@@ -1,0 +1,378 @@
+/// <reference types="vite/client" />
+import { convexTest } from "convex-test";
+import { describe, expect, test, vi } from "vitest";
+
+import { api, internal } from "../_generated/api";
+import schema from "../schema";
+
+function pairedCsvWithRows(count: number): string {
+  return [
+    "case_id,context,candidate_a,candidate_b,candidate_a_model,candidate_b_model,segment",
+    ...Array.from({ length: count }, (_, index) =>
+      `case-${index + 1},Context ${index + 1},Reply A ${index + 1},Reply B ${index + 1},gpt-4o,luna,segment-${index % 2}`,
+    ),
+  ].join("\n");
+}
+
+const pairedCsv = [
+  "case_id,context,candidate_a,candidate_b,candidate_a_model,candidate_b_model,segment",
+  "case-1,Customer asks to reschedule,What day works for you?,Choose a different day.,gpt-4o,luna,scheduling",
+  "case-2,Customer asks to stop texts,I will opt you out now.,Okay.,gpt-4o,luna,opt-out",
+].join("\n");
+
+async function seed() {
+  const t = convexTest(schema);
+  const ids = await t.run(async (ctx) => {
+    const ownerUserId = await ctx.db.insert("users", {
+      name: "Owner",
+      email: "owner@test.com",
+    });
+    const guestUserId = await ctx.db.insert("users", {
+      name: "Guest",
+      isAnonymous: true,
+    });
+    const orgId = await ctx.db.insert("organizations", {
+      name: "Org",
+      slug: "org",
+      createdById: ownerUserId,
+    });
+    await ctx.db.insert("organizationMembers", {
+      organizationId: orgId,
+      userId: ownerUserId,
+      role: "owner",
+    });
+    const projectId = await ctx.db.insert("projects", {
+      organizationId: orgId,
+      name: "Marcia SMS",
+      createdById: ownerUserId,
+    });
+    await ctx.db.insert("projectCollaborators", {
+      projectId,
+      userId: ownerUserId,
+      role: "owner",
+      invitedById: ownerUserId,
+      invitedAt: Date.now(),
+    });
+    return { ownerUserId, guestUserId, projectId };
+  });
+  return {
+    t,
+    ids,
+    asOwner: t.withIdentity({
+      subject: `${ids.ownerUserId}|owner-session`,
+      tokenIdentifier: `test|${ids.ownerUserId}`,
+    }),
+    asGuest: t.withIdentity({
+      subject: `${ids.guestUserId}|guest-session`,
+      tokenIdentifier: `test|${ids.guestUserId}`,
+    }),
+  };
+}
+
+describe("blind comparison campaigns", () => {
+  test("imports paired CSV into one campaign backed by comparable trajectories", async () => {
+    const { asOwner, ids } = await seed();
+
+    const imported = await asOwner.action(api.comparisonCampaigns.importPairedCsv, {
+      projectId: ids.projectId,
+      name: "4o vs Luna",
+      csv: pairedCsv,
+    });
+
+    expect(imported).toMatchObject({
+      importedCases: 2,
+      deduped: false,
+      summary: { rows: 2, valid: 2, invalid: 0 },
+    });
+    expect(JSON.stringify(imported.summary)).not.toContain("reschedule");
+
+    const ownerView = await asOwner.query(api.comparisonCampaigns.getOwnerCampaign, {
+      campaignId: imported.campaignId,
+    });
+    expect(ownerView).toMatchObject({
+      name: "4o vs Luna",
+      status: "draft",
+      caseCount: 2,
+      comparableCount: 2,
+      invalidCount: 0,
+    });
+    expect(ownerView.candidates).toEqual([
+      { model: "gpt-4o", harness: "paired_csv" },
+      { model: "luna", harness: "paired_csv" },
+    ]);
+
+    const repeated = await asOwner.action(api.comparisonCampaigns.importPairedCsv, {
+      projectId: ids.projectId,
+      name: "4o vs Luna",
+      csv: pairedCsv,
+    });
+    expect(repeated).toMatchObject({
+      campaignId: imported.campaignId,
+      importedCases: 0,
+      deduped: true,
+    });
+
+    await expect(asOwner.action(api.comparisonCampaigns.importPairedCsv, {
+      projectId: ids.projectId,
+      name: "Incomplete",
+      csv: "case_id,context,candidate_a,candidate_b\ncase-secret,Sensitive context,,Reply",
+    })).rejects.toThrow(/1 invalid row.*fix every row/i);
+  });
+
+  test("redeems a share link for a user-bound opaque guest session", async () => {
+    const { asOwner, asGuest, ids, t } = await seed();
+    const imported = await asOwner.action(api.comparisonCampaigns.importPairedCsv, {
+      projectId: ids.projectId,
+      name: "4o vs Luna",
+      csv: pairedCsv,
+    });
+    const ownerView = await asOwner.query(api.comparisonCampaigns.getOwnerCampaign, {
+      campaignId: imported.campaignId,
+    });
+    await asOwner.mutation(api.comparisonCampaigns.openCampaign, {
+      campaignId: imported.campaignId,
+    });
+
+    await expect(asGuest.mutation(api.comparisonCampaigns.joinCampaign, {
+      shareToken: ownerView.shareToken,
+      displayName: "   ",
+    })).rejects.toThrow(/display name/i);
+    const joined = await asGuest.mutation(api.comparisonCampaigns.joinCampaign, {
+      shareToken: ownerView.shareToken,
+      displayName: "Dan",
+    });
+    expect(joined.sessionToken).toMatch(/^[a-f0-9]{32}$/);
+    expect(joined.sessionToken).not.toBe(ownerView.shareToken);
+    await expect(asGuest.query(api.agentTraceReviewSessions.getMatchup, {
+      token: joined.sessionToken,
+    })).rejects.toThrow(/campaign review flow/i);
+
+    const review = await asGuest.query(api.comparisonCampaigns.getReview, {
+      sessionToken: joined.sessionToken,
+    });
+    expect(review).toMatchObject({
+      title: "Blind comparison",
+      status: "open",
+      progress: { judged: 0, visible: 2, total: 2 },
+      current: {
+        firstLabel: "A",
+        secondLabel: "B",
+        comparable: true,
+        divergenceStepIndex: 1,
+      },
+    });
+    const serialized = JSON.stringify(review);
+    expect(serialized).not.toContain("agentTraceId");
+    expect(serialized).not.toContain("matchupId");
+    expect(serialized).not.toContain("4o vs Luna");
+    expect(serialized).not.toContain("Marcia SMS");
+    expect(serialized).not.toContain("gpt-4o");
+    expect(serialized).not.toContain("luna");
+    expect(serialized).not.toContain(ids.projectId);
+
+    const content = await asGuest.action(api.comparisonCampaigns.getCurrentContent, {
+      sessionToken: joined.sessionToken,
+    });
+    expect(content.context).toContain("Customer asks to");
+    expect(content.firstCandidate).not.toBe(content.secondCandidate);
+    expect(content.firstCandidate.length).toBeGreaterThan(0);
+    expect(content.secondCandidate.length).toBeGreaterThan(0);
+    expect(JSON.stringify(content)).not.toContain("gpt-4o");
+
+    const side = review.current?.firstSide;
+    if (!side) throw new Error("Missing blind matchup side");
+    await asGuest.mutation(api.agentTraceReviewSessions.addMatchupComment, {
+      token: joined.sessionToken,
+      side,
+      target: { kind: "tool_call", stepIndex: 1 },
+      comment: "This call used the wrong arguments.",
+      label: "issue",
+      tags: ["accuracy"],
+    });
+    const comments = await asGuest.query(api.agentTraceReviewSessions.listMatchupComments, {
+      token: joined.sessionToken,
+      side,
+    });
+    expect(comments).toMatchObject([{
+      target: { kind: "tool_call", stepIndex: 1 },
+      comment: "This call used the wrong arguments.",
+      mine: true,
+    }]);
+
+    const collaborators = await t.run(async (ctx) =>
+      ctx.db
+        .query("projectCollaborators")
+        .withIndex("by_project_and_user", (q) =>
+          q.eq("projectId", ids.projectId).eq("userId", ids.guestUserId),
+        )
+        .collect(),
+    );
+    expect(collaborators).toEqual([]);
+
+    const resumed = await asGuest.mutation(api.comparisonCampaigns.joinCampaign, {
+      shareToken: ownerView.shareToken,
+      displayName: "Dan",
+    });
+    expect(resumed.sessionToken).toBe(joined.sessionToken);
+  });
+
+  test("preserves anonymous campaign reviewers during orphan cleanup", async () => {
+    const { asOwner, asGuest, ids, t } = await seed();
+    const imported = await asOwner.action(api.comparisonCampaigns.importPairedCsv, {
+      projectId: ids.projectId,
+      name: "Cleanup protection",
+      csv: pairedCsv,
+    });
+    const ownerView = await asOwner.query(api.comparisonCampaigns.getOwnerCampaign, {
+      campaignId: imported.campaignId,
+    });
+    await asOwner.mutation(api.comparisonCampaigns.openCampaign, {
+      campaignId: imported.campaignId,
+    });
+    await asGuest.mutation(api.comparisonCampaigns.joinCampaign, {
+      shareToken: ownerView.shareToken,
+      displayName: "Persistent guest",
+    });
+
+    vi.useFakeTimers();
+    vi.setSystemTime(Date.now() + 2 * 24 * 60 * 60 * 1_000);
+    try {
+      const cleanup = await t.mutation(internal.anonCleanup.cleanupAnonUsers, {});
+      expect(cleanup.deleted).toBe(0);
+      expect(await t.run(async (ctx) => ctx.db.get(ids.guestUserId))).not.toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("saves five distinct choices idempotently and offers five more", async () => {
+    const { asOwner, asGuest, ids, t } = await seed();
+    const imported = await asOwner.action(api.comparisonCampaigns.importPairedCsv, {
+      projectId: ids.projectId,
+      name: "Six cases",
+      csv: pairedCsvWithRows(6),
+    });
+    const ownerView = await asOwner.query(api.comparisonCampaigns.getOwnerCampaign, {
+      campaignId: imported.campaignId,
+    });
+    await asOwner.mutation(api.comparisonCampaigns.openCampaign, {
+      campaignId: imported.campaignId,
+    });
+    const { sessionToken } = await asGuest.mutation(api.comparisonCampaigns.joinCampaign, {
+      shareToken: ownerView.shareToken,
+      displayName: "Reviewer",
+    });
+
+    await expect(asGuest.mutation(api.agentTraceReviewSessions.decideMatchup, {
+      token: sessionToken,
+      winner: "left",
+      reasonTags: [],
+    })).rejects.toThrow(/campaign review flow/i);
+    await expect(asGuest.mutation(api.comparisonCampaigns.extendBatch, {
+      sessionToken,
+    })).rejects.toThrow(/complete the current five/i);
+
+    const choices = ["first", "second", "same", "neither", "cannot_judge"] as const;
+    for (const choice of choices) {
+      const current = await asGuest.query(api.comparisonCampaigns.getReview, { sessionToken });
+      if (!current.current) throw new Error("Missing review item");
+      await asGuest.mutation(api.comparisonCampaigns.submitChoice, {
+        sessionToken,
+        position: current.current.position,
+        choice,
+        note: choice === "neither" ? "Both miss the policy." : undefined,
+      });
+    }
+    let review = await asGuest.query(api.comparisonCampaigns.getReview, { sessionToken });
+    expect(review).toMatchObject({
+      progress: { judged: 5, visible: 5, total: 6 },
+      batchComplete: true,
+      allComplete: false,
+      current: null,
+    });
+
+    const decisions = await t.run(async (ctx) => ctx.db.query("agentTraceMatchupDecisions").collect());
+    expect(decisions).toHaveLength(5);
+    const winners = decisions.map((decision) => decision.winner);
+    expect(winners.filter((winner) => winner === "left" || winner === "right")).toHaveLength(2);
+    expect(winners).toEqual(expect.arrayContaining(["tie", "neither", "skip"]));
+    expect(decisions.find((decision) => decision.winner === "neither")?.note)
+      .toBe("Both miss the policy.");
+
+    await asGuest.mutation(api.comparisonCampaigns.extendBatch, { sessionToken });
+    review = await asGuest.query(api.comparisonCampaigns.getReview, { sessionToken });
+    expect(review.progress).toEqual({ judged: 5, visible: 6, total: 6 });
+    expect(review.current).not.toBeNull();
+
+    if (!review.current) throw new Error("Missing extended review item");
+    const finalPosition = review.current.position;
+    await asGuest.mutation(api.comparisonCampaigns.submitChoice, {
+      sessionToken,
+      position: finalPosition,
+      choice: "first",
+    });
+    await asGuest.mutation(api.comparisonCampaigns.submitChoice, {
+      sessionToken,
+      position: finalPosition,
+      choice: "second",
+    });
+    review = await asGuest.query(api.comparisonCampaigns.getReview, { sessionToken });
+    expect(review).toMatchObject({
+      progress: { judged: 6, visible: 6, total: 6 },
+      allComplete: true,
+    });
+    expect(await t.run(async (ctx) => (await ctx.db.query("agentTraceMatchupDecisions").collect()).length))
+      .toBe(6);
+
+    const results = await asOwner.query(api.comparisonCampaigns.getOwnerCampaign, {
+      campaignId: imported.campaignId,
+    });
+    expect(results.results).toMatchObject({
+      judgments: 6,
+      reviewers: 1,
+      same: 1,
+      neither: 1,
+      cannotJudge: 1,
+    });
+    expect(results.results.leftWins + results.results.rightWins).toBe(3);
+    expect(results.results.agreementRate).toBeNull();
+    expect(results.reviewerNames).toEqual(["Reviewer"]);
+    expect(results.feedback).toMatchObject([{
+      reviewerName: "Reviewer",
+      outcome: "Neither acceptable",
+      note: "Both miss the policy.",
+    }]);
+    expect(await asOwner.query(api.comparisonCampaigns.listCampaigns, {
+      projectId: ids.projectId,
+    })).toMatchObject([{
+      id: imported.campaignId,
+      caseCount: 6,
+      judgments: 6,
+    }]);
+
+    const exported = await asOwner.action(api.exports.generateExport, {
+      projectId: ids.projectId,
+      campaignId: imported.campaignId,
+      source: "trajectory",
+      format: "dpo",
+    });
+    expect(exported).toMatchObject({ rowCount: 3, excludedCount: 3 });
+    expect(exported.manifest).toMatchObject({
+      format: "dpo",
+      source_units: 6,
+      reviewers: 1,
+    });
+
+    await asOwner.mutation(api.comparisonCampaigns.closeCampaign, {
+      campaignId: imported.campaignId,
+    });
+    await expect(asGuest.mutation(api.comparisonCampaigns.submitChoice, {
+      sessionToken,
+      position: 5,
+      choice: "first",
+    })).rejects.toThrow(/closed/i);
+    expect(await asGuest.action(api.comparisonCampaigns.getCurrentContent, {
+      sessionToken,
+    })).toEqual({ context: "", firstCandidate: "", secondCandidate: "" });
+  });
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,6 +38,7 @@ const NotFound = lazy(() => import("./routes/errors/NotFound").then(m => ({ defa
 const Denied = lazy(() => import("./routes/errors/Denied").then(m => ({ default: m.Denied })));
 const QuickCompare = lazy(() => import("./routes/compare/QuickCompare").then(m => ({ default: m.QuickCompare })));
 const ReviewDemo = lazy(() => import("./routes/review/DemoDeck").then(m => ({ default: m.DemoDeck })));
+const ComparisonReview = lazy(() => import("./routes/review/ComparisonReview").then(m => ({ default: m.ComparisonReview })));
 const SessionDeck = lazy(() => import("./routes/review/SessionDeck").then(m => ({ default: m.SessionDeck })));
 const ReviewRunStarter = lazy(() => import("./routes/review/ReviewStarter").then(m => ({ default: m.ReviewRunStarter })));
 const ReviewCycleStarter = lazy(() => import("./routes/review/ReviewStarter").then(m => ({ default: m.ReviewCycleStarter })));
@@ -51,6 +52,8 @@ const CycleDetail = lazy(() => import("./routes/orgs/projects/cycles/CycleDetail
 const VersionDashboard = lazy(() => import("./routes/orgs/projects/cycles/VersionDashboard").then(m => ({ default: m.VersionDashboard })));
 const EvaluatePage = lazy(() => import("./routes/orgs/projects/EvaluatePage").then(m => ({ default: m.EvaluatePage })));
 const ExportTraining = lazy(() => import("./routes/orgs/projects/ExportTraining").then(m => ({ default: m.ExportTraining })));
+const ComparisonCampaignNew = lazy(() => import("./routes/orgs/projects/ComparisonCampaignNew").then(m => ({ default: m.ComparisonCampaignNew })));
+const ComparisonCampaignDetail = lazy(() => import("./routes/orgs/projects/ComparisonCampaignDetail").then(m => ({ default: m.ComparisonCampaignDetail })));
 const IngestEndpoint = lazy(() => import("./routes/orgs/projects/IngestEndpoint").then(m => ({ default: m.IngestEndpoint })));
 const ImportRuns = lazy(() => import("./routes/orgs/projects/ImportRuns").then(m => ({ default: m.ImportRuns })));
 const TraceList = lazy(() => import("./routes/traces/TraceList").then(m => ({ default: m.TraceList })));
@@ -73,6 +76,7 @@ export function App() {
         <Route path="/auth/sign-in" element={<AuthGatePublic />} />
         <Route path="/compare" element={<QuickCompare />} />
         <Route path="/review/demo" element={<ReviewDemo />} />
+        <Route path="/review/campaign/:shareToken" element={<ComparisonReview />} />
         <Route path="/invite/:token" element={<InviteLanding />} />
         <Route path="/legal/terms" element={<Terms />} />
         <Route path="/legal/privacy" element={<Privacy />} />
@@ -126,6 +130,8 @@ export function App() {
                 element={<CycleDetail />}
               />
               <Route path="evaluate" element={<EvaluatePage />} />
+              <Route path="comparisons/new" element={<ComparisonCampaignNew />} />
+              <Route path="comparisons/:campaignId" element={<ComparisonCampaignDetail />} />
               <Route path="export" element={<ExportTraining />} />
               <Route path="ingest" element={<IngestEndpoint />} />
               <Route path="traces" element={<TraceList />} />

--- a/src/lib/evals/comparisonControls.test.ts
+++ b/src/lib/evals/comparisonControls.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { comparisonChoiceForKey, comparisonChoiceForSwipe } from "./comparisonControls";
+
+describe("blind comparison controls", () => {
+  it.each([
+    ["ArrowLeft", "first"],
+    ["ArrowRight", "second"],
+    ["=", "same"],
+    ["n", "neither"],
+    ["N", "neither"],
+    ["s", "cannot_judge"],
+    ["S", "cannot_judge"],
+    ["Enter", null],
+  ])("maps %s to %s", (key, expected) => {
+    expect(comparisonChoiceForKey(key)).toBe(expected);
+  });
+
+  it("maps directional swipes without triggering near the threshold", () => {
+    expect(comparisonChoiceForSwipe(-91)).toBe("first");
+    expect(comparisonChoiceForSwipe(91)).toBe("second");
+    expect(comparisonChoiceForSwipe(-90)).toBeNull();
+    expect(comparisonChoiceForSwipe(90)).toBeNull();
+    expect(comparisonChoiceForSwipe(0)).toBeNull();
+  });
+});

--- a/src/lib/evals/comparisonControls.ts
+++ b/src/lib/evals/comparisonControls.ts
@@ -1,0 +1,24 @@
+export type VisibleComparisonChoice =
+  | "first"
+  | "second"
+  | "same"
+  | "neither"
+  | "cannot_judge";
+
+export function comparisonChoiceForKey(key: string): VisibleComparisonChoice | null {
+  if (key === "ArrowLeft") return "first";
+  if (key === "ArrowRight") return "second";
+  if (key === "=") return "same";
+  if (key.toLowerCase() === "n") return "neither";
+  if (key.toLowerCase() === "s") return "cannot_judge";
+  return null;
+}
+
+export function comparisonChoiceForSwipe(
+  horizontalOffset: number,
+  threshold = 90,
+): "first" | "second" | null {
+  if (horizontalOffset < -threshold) return "first";
+  if (horizontalOffset > threshold) return "second";
+  return null;
+}

--- a/src/lib/evals/pairedComparisonCsv.test.ts
+++ b/src/lib/evals/pairedComparisonCsv.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "vitest";
+
+import { parsePairedComparisonCsv } from "./pairedComparisonCsv";
+
+const csv = [
+  "case_id,context,candidate_a,candidate_b,candidate_a_model,candidate_b_model,segment,privacy_class",
+  'sms-1,"Customer: Can I move my appointment?","Absolutely — what day works?","Sure. Pick another date.",gpt-4o,luna,scheduling,internal',
+  'sms-2,"Customer: Stop texting me","I’ll opt you out now.","Okay, goodbye.",gpt-4o,luna,opt-out,confidential',
+].join("\n");
+
+describe("paired comparison CSV", () => {
+  test("normalizes each row into two traces with an identical context prefix", () => {
+    const batch = parsePairedComparisonCsv(csv);
+
+    expect(batch.summary).toEqual({
+      rows: 2,
+      valid: 2,
+      invalid: 0,
+      missingContext: 0,
+      missingCandidateA: 0,
+      missingCandidateB: 0,
+      invalidRows: [],
+      segments: ["opt-out", "scheduling"],
+    });
+    expect(batch.cases).toHaveLength(2);
+
+    const first = batch.cases[0];
+    expect(first?.caseKey).toBe("sms-1");
+    expect(first?.segment).toBe("scheduling");
+    expect(first?.candidateA.model).toBe("gpt-4o");
+    expect(first?.candidateB.model).toBe("luna");
+    expect(first?.candidateA.privacy.class).toBe("internal");
+    expect(first?.candidateA.steps[0]).toEqual(first?.candidateB.steps[0]);
+    expect(first?.candidateA.final_answer).toBe("Absolutely — what day works?");
+    expect(first?.candidateB.final_answer).toBe("Sure. Pick another date.");
+    expect(first?.candidateA.trace_id).not.toBe(first?.candidateB.trace_id);
+
+    expect(JSON.stringify(batch.summary)).not.toContain("move my appointment");
+    expect(JSON.stringify(batch.summary)).not.toContain("opt you out");
+  });
+
+  test("reports incomplete rows without echoing content", () => {
+    const result = parsePairedComparisonCsv([
+      "case_id,context,candidate_a,candidate_b",
+      "missing-context,,left,right",
+      "missing-a,context,,right",
+      "missing-b,context,left,",
+      "valid,context,left,right",
+    ].join("\n"));
+
+    expect(result.summary).toMatchObject({
+      rows: 4,
+      valid: 1,
+      invalid: 3,
+      missingContext: 1,
+      missingCandidateA: 1,
+      missingCandidateB: 1,
+      invalidRows: [2, 3, 4],
+    });
+    expect(result.cases).toHaveLength(1);
+  });
+
+  test("rejects duplicate case ids, unknown privacy classes, and missing headers", () => {
+    expect(() => parsePairedComparisonCsv([
+      "case_id,context,candidate_a,candidate_b",
+      "same,context,left,right",
+      "same,context,left,right",
+    ].join("\n"))).toThrow(/case_id.*unique/i);
+
+    const invalidPrivacy = parsePairedComparisonCsv([
+      "case_id,context,candidate_a,candidate_b,privacy_class",
+      "row,context,left,right,secret",
+    ].join("\n"));
+    expect(invalidPrivacy.summary).toMatchObject({ valid: 0, invalid: 1, invalidRows: [2] });
+
+    expect(() => parsePairedComparisonCsv("case_id,context,candidate_a\nrow,context,left"))
+      .toThrow(/candidate_b/i);
+  });
+});

--- a/src/lib/evals/pairedComparisonCsv.ts
+++ b/src/lib/evals/pairedComparisonCsv.ts
@@ -1,0 +1,226 @@
+/**
+ * Strict paired-response CSV adapter for blind comparison campaigns.
+ *
+ * One valid row becomes two normalized traces with a byte-identical context
+ * prefix. Candidate provenance stays on the traces and is never part of the
+ * reviewer-facing summary returned by this module.
+ */
+import {
+  normalizeEvalRecordV1,
+  type AgentRunTrace,
+  type PrivacyClass,
+} from "./agentTrace.core";
+import { CSV_IMPORT_MAX_ROWS, parseCsvRows } from "./csvTrace.core";
+
+const REQUIRED_HEADERS = [
+  "case_id",
+  "context",
+  "candidate_a",
+  "candidate_b",
+] as const;
+
+/** One comparable case parsed from the paired CSV boundary. */
+export interface PairedComparisonCase {
+  readonly caseKey: string;
+  readonly segment?: string;
+  readonly candidateA: AgentRunTrace;
+  readonly candidateB: AgentRunTrace;
+}
+
+/** Content-free paired CSV receipt safe for UI rendering and logs. */
+export interface PairedComparisonCsvSummary {
+  readonly rows: number;
+  readonly valid: number;
+  readonly invalid: number;
+  readonly missingContext: number;
+  readonly missingCandidateA: number;
+  readonly missingCandidateB: number;
+  readonly invalidRows: ReadonlyArray<number>;
+  readonly segments: ReadonlyArray<string>;
+}
+
+/** Parsed comparison cases plus their content-free receipt. */
+export interface PairedComparisonCsvBatch {
+  readonly cases: ReadonlyArray<PairedComparisonCase>;
+  readonly summary: PairedComparisonCsvSummary;
+}
+
+function parsePrivacyClass(value: string | undefined): PrivacyClass | undefined {
+  switch (value) {
+    case undefined:
+    case "":
+      return undefined;
+    case "public":
+    case "internal":
+    case "confidential":
+    case "pii":
+    case "phi":
+      return value;
+    default:
+      return undefined;
+  }
+}
+
+function contentHash(value: string): string {
+  let hash = 0xcbf29ce484222325n;
+  const mask = 0xffffffffffffffffn;
+  for (let index = 0; index < value.length; index++) {
+    hash ^= BigInt(value.charCodeAt(index));
+    hash = (hash * 0x100000001b3n) & mask;
+  }
+  return hash.toString(16).padStart(16, "0");
+}
+
+function makeCandidateTrace(input: {
+  readonly caseKey: string;
+  readonly side: "a" | "b";
+  readonly context: string;
+  readonly output: string;
+  readonly model?: string;
+  readonly harness?: string;
+  readonly product?: string;
+  readonly environment?: string;
+  readonly privacyClass?: PrivacyClass;
+  readonly segment?: string;
+}): AgentRunTrace {
+  const recordId = `comparison-${input.caseKey}-${input.side}-${contentHash([
+    input.context,
+    input.output,
+    input.model ?? "",
+    input.harness ?? "",
+    input.product ?? "",
+    input.environment ?? "",
+    input.privacyClass ?? "",
+    input.segment ?? "",
+  ].join("\u0000"))}`;
+  return normalizeEvalRecordV1({
+    version: "1",
+    id: recordId,
+    model: input.model,
+    input: {
+      messages: [{ role: "user", content: input.context }],
+    },
+    output: { content: input.output },
+    product: input.product ?? "paired-comparison",
+    environment: input.environment,
+    harness: {
+      name: input.harness ?? "paired_csv",
+      sdk: "paired-csv",
+    },
+    metadata: {
+      comparison_case: input.caseKey,
+      candidate_slot: input.side,
+      ...(input.segment === undefined ? {} : { segment: input.segment }),
+    },
+    privacy_class: input.privacyClass,
+  });
+}
+
+/** Parse strict paired CSV rows into comparable normalized candidate traces. */
+export function parsePairedComparisonCsv(csv: string): PairedComparisonCsvBatch {
+  const rows = parseCsvRows(csv);
+  const headerRow = rows[0];
+  if (!headerRow) throw new Error("CSV must contain a header row.");
+  const headers = headerRow.map((header) => header.trim());
+  if (new Set(headers).size !== headers.length) {
+    throw new Error("CSV header names must be unique.");
+  }
+  const indexByHeader = new Map(headers.map((header, index) => [header, index]));
+  for (const required of REQUIRED_HEADERS) {
+    if (!indexByHeader.has(required)) {
+      throw new Error(`Paired CSV requires a ${required} column.`);
+    }
+  }
+
+  const dataRows = rows.slice(1);
+  if (dataRows.length > CSV_IMPORT_MAX_ROWS) {
+    throw new Error(`Paired CSV has more than ${CSV_IMPORT_MAX_ROWS} data rows.`);
+  }
+
+  const valueAt = (row: ReadonlyArray<string>, header: string): string | undefined => {
+    const index = indexByHeader.get(header);
+    if (index === undefined) return undefined;
+    const value = row[index]?.trim();
+    return value ? value : undefined;
+  };
+
+  const cases: PairedComparisonCase[] = [];
+  const invalidRows: number[] = [];
+  const segments = new Set<string>();
+  const seenCaseKeys = new Set<string>();
+  let missingContext = 0;
+  let missingCandidateA = 0;
+  let missingCandidateB = 0;
+
+  for (let index = 0; index < dataRows.length; index++) {
+    const row = dataRows[index] ?? [];
+    const lineNumber = index + 2;
+    const caseKey = valueAt(row, "case_id");
+    const context = valueAt(row, "context");
+    const candidateA = valueAt(row, "candidate_a");
+    const candidateB = valueAt(row, "candidate_b");
+    const privacyRaw = valueAt(row, "privacy_class");
+    const privacyClass = parsePrivacyClass(privacyRaw);
+
+    if (context === undefined) missingContext++;
+    if (candidateA === undefined) missingCandidateA++;
+    if (candidateB === undefined) missingCandidateB++;
+    if (
+      caseKey === undefined ||
+      context === undefined ||
+      candidateA === undefined ||
+      candidateB === undefined ||
+      (privacyRaw !== undefined && privacyClass === undefined)
+    ) {
+      invalidRows.push(lineNumber);
+      continue;
+    }
+    if (seenCaseKeys.has(caseKey)) {
+      throw new Error(`CSV case_id values must be unique; duplicate at row ${lineNumber}.`);
+    }
+    seenCaseKeys.add(caseKey);
+
+    const segment = valueAt(row, "segment");
+    if (segment !== undefined) segments.add(segment);
+    const shared = {
+      caseKey,
+      context,
+      product: valueAt(row, "product"),
+      environment: valueAt(row, "environment"),
+      privacyClass,
+      segment,
+    };
+    cases.push({
+      caseKey,
+      segment,
+      candidateA: makeCandidateTrace({
+        ...shared,
+        side: "a",
+        output: candidateA,
+        model: valueAt(row, "candidate_a_model"),
+        harness: valueAt(row, "candidate_a_harness"),
+      }),
+      candidateB: makeCandidateTrace({
+        ...shared,
+        side: "b",
+        output: candidateB,
+        model: valueAt(row, "candidate_b_model"),
+        harness: valueAt(row, "candidate_b_harness"),
+      }),
+    });
+  }
+
+  return {
+    cases,
+    summary: {
+      rows: dataRows.length,
+      valid: cases.length,
+      invalid: invalidRows.length,
+      missingContext,
+      missingCandidateA,
+      missingCandidateB,
+      invalidRows: invalidRows.slice(0, 100),
+      segments: [...segments].sort(),
+    },
+  };
+}

--- a/src/routes/orgs/projects/ComparisonCampaignDetail.tsx
+++ b/src/routes/orgs/projects/ComparisonCampaignDetail.tsx
@@ -1,0 +1,83 @@
+import { useState } from "react";
+import { useAction, useMutation, useQuery } from "convex/react";
+import { Link, useParams } from "react-router-dom";
+import { ArrowLeft, Download, EyeOff, Lock } from "lucide-react";
+import { api } from "../../../../convex/_generated/api";
+import type { Id } from "../../../../convex/_generated/dataModel";
+import { useProject } from "@/contexts/ProjectContext";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { CopyButton } from "@/components/ui/copy-button";
+import { friendlyError } from "@/lib/errors";
+
+const labels = [
+  ["leftWins", "Candidate A"], ["rightWins", "Candidate B"], ["same", "Same"],
+  ["neither", "Neither acceptable"], ["cannotJudge", "Cannot judge"],
+] as const;
+
+export function ComparisonCampaignDetail() {
+  const { projectId } = useProject();
+  const { orgSlug, campaignId } = useParams<{ orgSlug: string; campaignId: string }>();
+  const id = campaignId as Id<"comparisonCampaigns">;
+  const campaign = useQuery(api.comparisonCampaigns.getOwnerCampaign, { campaignId: id });
+  const openCampaign = useMutation(api.comparisonCampaigns.openCampaign);
+  const closeCampaign = useMutation(api.comparisonCampaigns.closeCampaign);
+  const generateExport = useAction(api.exports.generateExport);
+  const downloadExport = useAction(api.exports.downloadExport);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState("");
+  const base = `/orgs/${orgSlug}/projects/${projectId}`;
+
+  if (campaign === undefined) return <div className="p-6 text-sm text-muted-foreground">Loading comparison…</div>;
+  const reviewUrl = `${window.location.origin}/review/campaign/${campaign.shareToken}`;
+  const campaignName = campaign.name;
+
+  async function open() {
+    setBusy(true); setError("");
+    try { await openCampaign({ campaignId: id }); }
+    catch (cause: unknown) { setError(friendlyError(cause, "Could not open this comparison.")); }
+    finally { setBusy(false); }
+  }
+
+  async function close() {
+    if (!window.confirm("Close this campaign? Reviewers will no longer be able to submit choices.")) return;
+    setBusy(true); setError("");
+    try { await closeCampaign({ campaignId: id }); }
+    catch (cause: unknown) { setError(friendlyError(cause, "Could not close this comparison.")); }
+    finally { setBusy(false); }
+  }
+
+  async function download() {
+    setBusy(true); setError("");
+    try {
+      const data = await generateExport({ projectId, campaignId: id, source: "trajectory", format: "dpo" });
+      if (data.rowCount === 0) throw new Error("This campaign has no directional preferences to export yet.");
+      const { url } = await downloadExport({ exportId: data.exportId });
+      const anchor = document.createElement("a"); anchor.href = url; anchor.download = `${campaignName.replace(/[^a-z0-9]+/gi, "-").toLowerCase()}-dpo.jsonl`; anchor.click();
+    } catch (cause: unknown) { setError(friendlyError(cause, "Could not export this comparison.")); }
+    finally { setBusy(false); }
+  }
+
+  return <div className="mx-auto max-w-5xl p-6">
+    <Link to={`${base}/evaluate`} className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"><ArrowLeft className="h-3.5 w-3.5" /> Reviews</Link>
+    <div className="mt-3 flex flex-wrap items-start justify-between gap-4">
+      <div><h1 className="text-2xl font-bold">{campaign.name}</h1><p className="mt-1 text-sm text-muted-foreground">{campaign.caseCount} paired cases · {campaign.status}</p></div>
+      <div className="flex gap-2">{campaign.status === "draft" && <Button onClick={open} disabled={busy}>Open for review</Button>}{campaign.status === "open" && <Button variant="outline" onClick={close} disabled={busy}><Lock className="h-4 w-4" /> Close</Button>}<Button variant="outline" onClick={download} disabled={busy}><Download className="h-4 w-4" /> Export JSONL</Button></div>
+    </div>
+    {error && <p className="mt-3 text-sm text-destructive" role="alert">{error}</p>}
+    <div className="mt-6 grid gap-4 lg:grid-cols-4">
+      <Card className="lg:col-span-2"><CardHeader><CardTitle className="text-base">Review link</CardTitle></CardHeader><CardContent>
+        <div className="flex items-center gap-2 rounded-lg border bg-muted/30 p-3"><EyeOff className="h-4 w-4 shrink-0 text-primary" /><code className="min-w-0 flex-1 truncate text-xs">{reviewUrl}</code><CopyButton text={reviewUrl} label="Copy review link" /></div>
+        <p className="mt-2 text-xs text-muted-foreground">Share in Slack. Reviewers enter a display name and get five randomized blind comparisons at a time.</p>
+      </CardContent></Card>
+      <Card><CardHeader><CardTitle className="text-base">Coverage</CardTitle></CardHeader><CardContent><div className="text-3xl font-semibold">{campaign.results.reviewedCases}/{campaign.caseCount}</div><p className="text-sm text-muted-foreground">cases · {campaign.results.judgments} judgments</p><p className="mt-2 truncate text-xs text-muted-foreground">{campaign.reviewerNames.join(", ") || "Awaiting reviewers"}</p></CardContent></Card>
+      <Card><CardHeader><CardTitle className="text-base">Agreement</CardTitle></CardHeader><CardContent><div className="text-3xl font-semibold">{campaign.results.agreementRate === null ? "—" : `${Math.round(campaign.results.agreementRate * 100)}%`}</div><p className="text-sm text-muted-foreground">{campaign.results.agreementRate === null ? "Needs 2+ reviewers per case" : `majority agreement across ${campaign.results.agreementCases} cases`}</p></CardContent></Card>
+    </div>
+    <Card className="mt-4"><CardHeader><CardTitle className="text-base">Results</CardTitle></CardHeader><CardContent>
+      <div className="mb-4 flex flex-wrap gap-x-6 gap-y-1 text-xs text-muted-foreground"><span><strong className="text-foreground">Candidate A:</strong> {campaign.candidateA.join(", ")}</span><span><strong className="text-foreground">Candidate B:</strong> {campaign.candidateB.join(", ")}</span></div>
+      <div className="grid gap-3 sm:grid-cols-5">{labels.map(([key, label]) => <div key={key} className="rounded-lg border p-3"><div className="text-2xl font-semibold">{campaign.results[key]}</div><div className="text-xs text-muted-foreground">{label}</div></div>)}</div>
+      <p className="mt-4 text-xs text-muted-foreground">A/B is the canonical import order, independent of each reviewer’s randomized first/second presentation. JSONL includes only directional preferences; same, neither, and cannot judge remain in results but are excluded from training rows.</p>
+    </CardContent></Card>
+    {campaign.feedback.length > 0 && <Card className="mt-4"><CardHeader><CardTitle className="text-base">Reviewer notes</CardTitle></CardHeader><CardContent className="space-y-3">{campaign.feedback.map((item, index) => <div key={`${item.caseKey}-${item.reviewerName}-${index}`} className="rounded-lg border p-3"><div className="flex flex-wrap items-center justify-between gap-2 text-xs text-muted-foreground"><span>{item.caseKey} · {item.reviewerName}</span><span>{item.outcome}</span></div><p className="mt-2 whitespace-pre-wrap text-sm">{item.note}</p></div>)}</CardContent></Card>}
+  </div>;
+}

--- a/src/routes/orgs/projects/ComparisonCampaignNew.tsx
+++ b/src/routes/orgs/projects/ComparisonCampaignNew.tsx
@@ -1,0 +1,113 @@
+import { useState } from "react";
+import { useAction } from "convex/react";
+import { Link, useNavigate, useParams } from "react-router-dom";
+import { ArrowLeft, Download, Upload } from "lucide-react";
+
+import { api } from "../../../../convex/_generated/api";
+import { useProject } from "@/contexts/ProjectContext";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { friendlyError } from "@/lib/errors";
+
+const MAX_BYTES = 8 * 1024 * 1024;
+const TEMPLATE = [
+  "case_id,context,candidate_a,candidate_b,candidate_a_model,candidate_b_model,segment,privacy_class",
+  'case-1,"Customer message and prior context","First possible reply","Second possible reply",model-a,model-b,scheduling,internal',
+].join("\n");
+
+export function ComparisonCampaignNew() {
+  const { projectId } = useProject();
+  const { orgSlug } = useParams<{ orgSlug: string }>();
+  const navigate = useNavigate();
+  const importCsv = useAction(api.comparisonCampaigns.importPairedCsv);
+  const [name, setName] = useState("");
+  const [csv, setCsv] = useState("");
+  const [fileName, setFileName] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState("");
+  const base = `/orgs/${orgSlug}/projects/${projectId}`;
+
+  async function selectFile(event: React.ChangeEvent<HTMLInputElement>) {
+    const file = event.target.files?.[0];
+    if (!file) return;
+    if (file.size > MAX_BYTES) {
+      setError(`${file.name} is over the 8 MB limit. Split it and try again.`);
+      return;
+    }
+    setError("");
+    setFileName(file.name);
+    setCsv(await file.text());
+    if (!name) setName(file.name.replace(/\.csv$/i, ""));
+  }
+
+  async function submit(event: React.FormEvent) {
+    event.preventDefault();
+    if (!name.trim() || !csv || busy) return;
+    setBusy(true);
+    setError("");
+    try {
+      const result = await importCsv({ projectId, name: name.trim(), csv });
+      navigate(`${base}/comparisons/${result.campaignId}`);
+    } catch (cause: unknown) {
+      setError(friendlyError(cause, "Could not import this comparison CSV."));
+      setBusy(false);
+    }
+  }
+
+  function downloadTemplate() {
+    const url = URL.createObjectURL(new Blob([TEMPLATE], { type: "text/csv" }));
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = "blindbench-paired-comparison.csv";
+    anchor.click();
+    URL.revokeObjectURL(url);
+  }
+
+  return (
+    <div className="mx-auto max-w-3xl p-6">
+      <Link to={`${base}/evaluate`} className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground">
+        <ArrowLeft className="h-3.5 w-3.5" /> Reviews
+      </Link>
+      <header className="mt-3">
+        <h1 className="text-2xl font-bold">Create a blind comparison</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Upload two completed attempts for each shared context. Blind Bench runs nothing—it only presents and records the review.
+        </p>
+      </header>
+
+      <Card className="mt-6">
+        <CardHeader><CardTitle className="text-base">Paired CSV</CardTitle></CardHeader>
+        <CardContent>
+          <form onSubmit={submit} className="space-y-4">
+            <div className="space-y-1.5">
+              <Label htmlFor="comparison-name">Comparison name</Label>
+              <Input id="comparison-name" value={name} onChange={(event) => setName(event.target.value)} placeholder="4o vs Luna — July SMS" maxLength={120} />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="comparison-file">CSV file</Label>
+              <label htmlFor="comparison-file" className="flex cursor-pointer items-center gap-2 rounded-lg border border-dashed px-4 py-8 text-sm text-muted-foreground hover:border-primary/50 hover:text-foreground">
+                <Upload className="h-4 w-4" /> {fileName || "Choose paired responses…"}
+              </label>
+              <input id="comparison-file" type="file" accept=".csv,text/csv" onChange={selectFile} className="sr-only" />
+              <p className="text-xs text-muted-foreground">
+                Required: <code>case_id</code>, <code>context</code>, <code>candidate_a</code>, <code>candidate_b</code>. Optional model, harness, segment, environment, product, and privacy columns.
+              </p>
+              <Button type="button" variant="ghost" size="sm" onClick={downloadTemplate}>
+                <Download className="h-3.5 w-3.5" /> Download template
+              </Button>
+            </div>
+            <div className="rounded-lg border border-amber-500/40 bg-amber-500/5 p-3 text-xs text-muted-foreground">
+              Free-text context and replies are stored as supplied. Upload only data this workspace is approved to review and train on.
+            </div>
+            {error && <p className="text-sm text-destructive" role="alert">{error}</p>}
+            <Button type="submit" disabled={busy || !name.trim() || !csv}>
+              {busy ? "Importing…" : "Create comparison"}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/routes/orgs/projects/EvaluatePage.tsx
+++ b/src/routes/orgs/projects/EvaluatePage.tsx
@@ -6,7 +6,7 @@ import { CycleStatusPill } from "@/components/CycleStatusPill";
 import { EmptyState } from "@/components/EmptyState";
 import { buttonVariants } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
-import { ArrowRight, ClipboardCheck, Layers, Plus } from "lucide-react";
+import { ArrowRight, ClipboardCheck, EyeOff, Layers, Plus } from "lucide-react";
 
 export function EvaluatePage() {
   const { projectId, role } = useProject();
@@ -17,8 +17,12 @@ export function EvaluatePage() {
     api.reviewCycles.list,
     role !== "evaluator" ? { projectId } : "skip",
   );
+  const comparisons = useQuery(
+    api.comparisonCampaigns.listCampaigns,
+    role !== "evaluator" ? { projectId } : "skip",
+  );
 
-  const isLoading = cycles === undefined;
+  const isLoading = cycles === undefined || comparisons === undefined;
 
   const basePath = `/orgs/${orgSlug}/projects/${projectId}`;
 
@@ -59,6 +63,7 @@ export function EvaluatePage() {
   }
 
   const hasAnything =
+    (comparisons?.length ?? 0) > 0 ||
     openCycles.length > 0 ||
     draftCycles.length > 0 ||
     pastItems.length > 0;
@@ -68,11 +73,10 @@ export function EvaluatePage() {
       <div className="flex items-center justify-between">
         <h1 className="text-xl font-semibold">Evaluate</h1>
         <div className="flex items-center gap-2">
-          <Link
-            to={`${basePath}/cycles/new`}
-            className={buttonVariants({ size: "sm" })}
-          >
-            <Plus className="mr-1.5 h-4 w-4" />
+          <Link to={`${basePath}/comparisons/new`} className={buttonVariants({ size: "sm" })}>
+            <Plus className="mr-1.5 h-4 w-4" /> New comparison
+          </Link>
+          <Link to={`${basePath}/cycles/new`} className={buttonVariants({ size: "sm", variant: "outline" })}>
             New cycle
           </Link>
         </div>
@@ -81,15 +85,21 @@ export function EvaluatePage() {
       {!hasAnything ? (
         <EmptyState
           icon={ClipboardCheck}
-          heading="Pool runs into a Review Cycle to evaluate them blind"
-          description="Once you have completed runs, group them here so reviewers can rate outputs without seeing which version produced what."
+          heading="Compare completed attempts without exposing their source"
+          description="Import paired responses for a fast blind comparison, or pool existing runs into a review cycle."
           action={{
-            label: "Start a cycle",
-            onClick: () => navigate(`${basePath}/cycles/new`),
+            label: "New blind comparison",
+            onClick: () => navigate(`${basePath}/comparisons/new`),
           }}
         />
       ) : (
         <div className="max-w-2xl space-y-6">
+          {(comparisons?.length ?? 0) > 0 && <section className="space-y-3">
+            <h2 className="text-sm font-semibold text-muted-foreground uppercase tracking-wide">Blind comparisons</h2>
+            {comparisons?.map((comparison) => <Link key={comparison.id} to={`${basePath}/comparisons/${comparison.id}`} className="flex items-center justify-between rounded-lg border px-4 py-3 transition-colors hover:bg-muted/50">
+              <div className="flex min-w-0 flex-1 items-center gap-3"><EyeOff className="h-4 w-4 shrink-0 text-primary" /><div className="min-w-0"><p className="truncate text-sm font-medium">{comparison.name}</p><p className="text-xs text-muted-foreground">{comparison.caseCount} cases · {comparison.judgments} judgments · {comparison.status}</p></div></div><ArrowRight className="h-4 w-4 text-muted-foreground" />
+            </Link>)}
+          </section>}
           {/* Active items — need attention now */}
           {(openCycles.length > 0 || draftCycles.length > 0) && (
             <section className="space-y-3">

--- a/src/routes/review/ComparisonReview.tsx
+++ b/src/routes/review/ComparisonReview.tsx
@@ -1,0 +1,172 @@
+import { useEffect, useState } from "react";
+import { useAuthActions } from "@convex-dev/auth/react";
+import { useAction, useConvexAuth, useMutation, useQuery } from "convex/react";
+import { AnimatePresence, motion, useReducedMotion, type PanInfo } from "motion/react";
+import { useParams } from "react-router-dom";
+import { ArrowLeft, ArrowRight, Check, EyeOff, MessageSquarePlus } from "lucide-react";
+import { api } from "../../../convex/_generated/api";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { friendlyError } from "@/lib/errors";
+import {
+  comparisonChoiceForKey,
+  comparisonChoiceForSwipe,
+  type VisibleComparisonChoice,
+} from "@/lib/evals/comparisonControls";
+
+type VisibleChoice = VisibleComparisonChoice;
+type SessionToken = string;
+
+export function ComparisonReview() {
+  const { shareToken = "" } = useParams<{ shareToken: string }>();
+  const { isAuthenticated, isLoading } = useConvexAuth();
+  const { signIn } = useAuthActions();
+  const [name, setName] = useState("");
+  const [started, setStarted] = useState(false);
+  const [error, setError] = useState("");
+
+  async function begin(event: React.FormEvent) {
+    event.preventDefault();
+    if (!name.trim()) return;
+    setError("");
+    try {
+      if (!isAuthenticated) await signIn("anonymous");
+      setStarted(true);
+    } catch (cause: unknown) {
+      setError(friendlyError(cause, "Could not start this review."));
+    }
+  }
+
+  if (isLoading) return <ReviewShell><p className="text-sm text-muted-foreground">Preparing blind review…</p></ReviewShell>;
+  if (started && isAuthenticated) return <JoinedReview shareToken={shareToken} reviewerName={name.trim()} />;
+
+  return <ReviewShell>
+    <div className="mx-auto max-w-md text-center">
+      <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-2xl bg-primary/10 text-primary"><EyeOff className="h-6 w-6" /></div>
+      <h1 className="mt-5 text-2xl font-semibold tracking-tight">Blind comparison</h1>
+      <p className="mt-2 text-sm leading-6 text-muted-foreground">Review five paired attempts without seeing which model or system produced them. Your name is shown only to the workspace owner.</p>
+      <form onSubmit={begin} className="mt-6 space-y-3 text-left">
+        <label htmlFor="reviewer-name" className="text-sm font-medium">Your display name</label>
+        <Input id="reviewer-name" autoFocus value={name} onChange={(event) => setName(event.target.value)} placeholder="Dan" maxLength={80} />
+        {error && <p className="text-sm text-destructive" role="alert">{error}</p>}
+        <Button className="w-full" type="submit" disabled={!name.trim()}>Start five reviews</Button>
+      </form>
+      <p className="mt-4 text-xs text-muted-foreground">No Blind Bench account required. This link does not grant project access.</p>
+    </div>
+  </ReviewShell>;
+}
+
+function JoinedReview({ shareToken, reviewerName }: { shareToken: string; reviewerName: string }) {
+  const join = useMutation(api.comparisonCampaigns.joinCampaign);
+  const [token, setToken] = useState<SessionToken | null>(null);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    let cancelled = false;
+    void join({ shareToken, displayName: reviewerName }).then((result) => {
+      if (!cancelled) setToken(result.sessionToken);
+    }).catch((cause: unknown) => {
+      if (!cancelled) setError(friendlyError(cause, "This review link could not be opened."));
+    });
+    return () => { cancelled = true; };
+  }, [join, reviewerName, shareToken]);
+
+  if (error) return <ReviewShell><p className="text-sm text-destructive" role="alert">{error}</p></ReviewShell>;
+  if (!token) return <ReviewShell><p className="text-sm text-muted-foreground">Opening review…</p></ReviewShell>;
+  return <ReviewDeck token={token} />;
+}
+
+function ReviewDeck({ token }: { token: SessionToken }) {
+  const review = useQuery(api.comparisonCampaigns.getReview, { sessionToken: token });
+  const getContent = useAction(api.comparisonCampaigns.getCurrentContent);
+  const submit = useMutation(api.comparisonCampaigns.submitChoice);
+  const addFive = useMutation(api.comparisonCampaigns.extendBatch);
+  const addComment = useMutation(api.agentTraceReviewSessions.addMatchupComment);
+  const reduceMotion = useReducedMotion();
+  const [content, setContent] = useState<{ context: string; firstCandidate: string; secondCandidate: string } | null>(null);
+  const [note, setNote] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState("");
+
+  const position = review?.current?.position;
+  const reviewStatus = review?.status;
+  useEffect(() => {
+    if (position === undefined || reviewStatus !== "open") { setContent(null); return; }
+    let cancelled = false;
+    setContent(null);
+    void getContent({ sessionToken: token }).then((next) => { if (!cancelled) setContent(next); }).catch((cause: unknown) => { if (!cancelled) setError(friendlyError(cause, "Could not load this comparison.")); });
+    return () => { cancelled = true; };
+  }, [getContent, position, reviewStatus, token]);
+
+  async function choose(choice: VisibleChoice) {
+    if (busy || !review?.current) return;
+    setBusy(true); setError("");
+    try {
+      await submit({ sessionToken: token, position: review.current.position, choice, note: note.trim() || undefined });
+      setNote("");
+    } catch (cause: unknown) { setError(friendlyError(cause, "Could not save this judgment.")); }
+    finally { setBusy(false); }
+  }
+
+  useEffect(() => {
+    function keydown(event: KeyboardEvent) {
+      const tag = (event.target as HTMLElement | null)?.tagName;
+      if (tag === "INPUT" || tag === "TEXTAREA" || event.metaKey || event.ctrlKey || event.altKey) return;
+      const choice = comparisonChoiceForKey(event.key);
+      if (choice) { event.preventDefault(); void choose(choice); }
+    }
+    window.addEventListener("keydown", keydown);
+    return () => window.removeEventListener("keydown", keydown);
+  });
+
+  if (review === undefined) return <ReviewShell><p className="text-sm text-muted-foreground">Loading comparison…</p></ReviewShell>;
+  if (review.status === "closed") return <ReviewShell><div className="mx-auto max-w-md text-center"><LockNotice /></div></ReviewShell>;
+  if (review.batchComplete) return <ReviewShell>
+    <div className="mx-auto max-w-md text-center"><div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-primary/10 text-primary"><Check className="h-6 w-6" /></div><h1 className="mt-4 text-2xl font-semibold">Batch complete</h1><p className="mt-2 text-sm text-muted-foreground">You reviewed {review.progress.judged} of {review.progress.total} cases in this campaign.</p>{!review.allComplete && <Button className="mt-6" onClick={() => void addFive({ sessionToken: token })}>Review 5 more</Button>}</div>
+  </ReviewShell>;
+
+  const current = review.current;
+  if (!current || !content) return <ReviewShell><p className="text-sm text-muted-foreground">Loading next pair…</p></ReviewShell>;
+  const commentTarget = (side: typeof current.firstSide) => ({
+    side,
+    target: current.candidateStep.kind === "tool_call"
+      ? { kind: "tool_call" as const, stepIndex: current.candidateStep.stepIndex }
+      : { kind: "step" as const, stepIndex: current.candidateStep.stepIndex },
+  });
+
+  return <ReviewShell wide>
+    <header className="mb-4 flex items-center justify-between gap-4"><div><p className="text-xs font-medium uppercase tracking-wider text-muted-foreground">{review.title}</p><h1 className="text-lg font-semibold">Which attempt is better?</h1></div><div className="text-right text-xs text-muted-foreground"><div>{review.progress.judged + 1} / {review.progress.visible}</div><div className="mt-1 h-1.5 w-24 overflow-hidden rounded-full bg-muted"><div className="h-full bg-primary" style={{ width: `${(review.progress.judged / review.progress.visible) * 100}%` }} /></div></div></header>
+    {content.context && <section className="mb-4 max-h-48 overflow-auto rounded-xl border bg-muted/30 p-4"><p className="mb-2 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">Shared context</p><pre className="whitespace-pre-wrap font-sans text-sm leading-6">{content.context}</pre></section>}
+    <AnimatePresence mode="wait">
+      <motion.div key={current.position} drag="x" dragConstraints={{ left: 0, right: 0 }} dragElastic={0.18} onDragEnd={(_, info: PanInfo) => { const choice = comparisonChoiceForSwipe(info.offset.x); if (choice) void choose(choice); }} initial={reduceMotion ? false : { opacity: 0, y: 8 }} animate={{ opacity: 1, y: 0 }} exit={reduceMotion ? undefined : { opacity: 0, scale: 0.98 }} className="grid touch-pan-y gap-3 md:grid-cols-2">
+        <CandidateCard label="Attempt 1" content={content.firstCandidate} shortcut="←" disabled={busy} onChoose={() => void choose("first")} onComment={(comment) => addComment({ token, ...commentTarget(current.firstSide), comment, label: "thought" })} />
+        <CandidateCard label="Attempt 2" content={content.secondCandidate} shortcut="→" disabled={busy} onChoose={() => void choose("second")} onComment={(comment) => addComment({ token, ...commentTarget(current.secondSide), comment, label: "thought" })} />
+      </motion.div>
+    </AnimatePresence>
+    <div className="mt-4 grid grid-cols-3 gap-2"><Button variant="outline" onClick={() => void choose("same")} disabled={busy}>Same <kbd className="ml-2 text-[10px]">=</kbd></Button><Button variant="outline" onClick={() => void choose("neither")} disabled={busy}>Neither <kbd className="ml-2 text-[10px]">N</kbd></Button><Button variant="outline" onClick={() => void choose("cannot_judge")} disabled={busy}>Cannot judge <kbd className="ml-2 text-[10px]">S</kbd></Button></div>
+    <Textarea className="mt-3 min-h-16" value={note} onChange={(event) => setNote(event.target.value)} placeholder="Optional note about this choice…" maxLength={2_000} />
+    {error && <p className="mt-2 text-sm text-destructive" role="alert">{error}</p>}
+    <p className="mt-3 text-center text-xs text-muted-foreground"><ArrowLeft className="inline h-3 w-3" /> / <ArrowRight className="inline h-3 w-3" /> keys, click, or swipe horizontally</p>
+  </ReviewShell>;
+}
+
+function CandidateCard({ label, content, shortcut, disabled, onChoose, onComment }: { label: string; content: string; shortcut: string; disabled: boolean; onChoose: () => void; onComment: (comment: string) => Promise<unknown> }) {
+  const [commenting, setCommenting] = useState(false); const [comment, setComment] = useState(""); const [commentError, setCommentError] = useState(""); const [saving, setSaving] = useState(false);
+  async function saveComment() {
+    if (!comment.trim() || saving) return;
+    setSaving(true); setCommentError("");
+    try { await onComment(comment.trim()); setComment(""); setCommenting(false); }
+    catch (cause: unknown) { setCommentError(friendlyError(cause, "Could not save this step comment.")); }
+    finally { setSaving(false); }
+  }
+  return <article className="flex min-h-64 flex-col rounded-2xl border bg-background shadow-sm"><button type="button" disabled={disabled} onClick={onChoose} className="flex flex-1 flex-col p-5 text-left outline-none ring-primary/40 hover:bg-muted/20 focus-visible:ring-2"><div className="flex w-full justify-between text-xs font-semibold uppercase tracking-wider text-muted-foreground"><span>{label}</span><kbd>{shortcut}</kbd></div><pre className="mt-4 whitespace-pre-wrap font-sans text-sm leading-6">{content}</pre></button><div className="border-t p-3">{commenting ? <><div className="flex gap-2"><Input value={comment} onChange={(event) => setComment(event.target.value)} placeholder="Step-level comment…" maxLength={2_000} /><Button size="sm" variant="outline" disabled={saving} onClick={() => void saveComment()}>Save</Button></div>{commentError && <p className="mt-2 text-xs text-destructive" role="alert">{commentError}</p>}</> : <button type="button" onClick={() => setCommenting(true)} className="inline-flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground"><MessageSquarePlus className="h-3.5 w-3.5" /> Comment on this step</button>}</div></article>;
+}
+
+function LockNotice() {
+  return <><div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-muted text-muted-foreground"><Check className="h-6 w-6" /></div><h1 className="mt-4 text-2xl font-semibold">Review closed</h1><p className="mt-2 text-sm text-muted-foreground">The workspace owner has closed this comparison. Your saved judgments are preserved.</p></>;
+}
+
+function ReviewShell({ children, wide = false }: { children: React.ReactNode; wide?: boolean }) {
+  return <main className="min-h-screen bg-muted/20 p-4 sm:p-8"><div className={`mx-auto ${wide ? "max-w-6xl" : "max-w-xl"}`}><div className="mb-8 flex items-center gap-2 text-sm font-semibold"><EyeOff className="h-4 w-4 text-primary" /> Blind Bench</div>{children}</div></main>;
+}

--- a/src/routes/traces/traceSteps.tsx
+++ b/src/routes/traces/traceSteps.tsx
@@ -8,7 +8,7 @@
  * trace stays responsive. No real ids or provenance attributes reach the DOM.
  */
 import { Fragment, useEffect, useState } from "react";
-import { usePaginatedQuery, useMutation, useAction } from "convex/react";
+import { usePaginatedQuery, useMutation, useAction, useQuery } from "convex/react";
 import type { FunctionReturnType } from "convex/server";
 import { api } from "../../../convex/_generated/api";
 import type { Id } from "../../../convex/_generated/dataModel";
@@ -274,6 +274,7 @@ function StepCard({
           agentTraceId={agentTraceId}
           reviewToken={reviewToken}
           step={step}
+          matchupSide={matchupSide}
           comments={comments}
         />
       )}
@@ -296,16 +297,20 @@ function StepComments({
   agentTraceId,
   reviewToken,
   step,
+  matchupSide,
   comments,
 }: {
   agentTraceId?: Id<"agentTraces">;
   reviewToken?: string;
   step: TraceStep;
+  matchupSide?: "left" | "right";
   comments: TraceComment[];
 }) {
   const addOwnerComment = useMutation(api.agentTraceReview.addComment);
   const addReviewComment = useMutation(api.agentTraceReviewSessions.addComment);
-  const deleteComment = useMutation(api.agentTraceReview.deleteComment);
+  const addMatchupComment = useMutation(api.agentTraceReviewSessions.addMatchupComment);
+  const deleteOwnerComment = useMutation(api.agentTraceReview.deleteComment);
+  const deleteMatchupComment = useMutation(api.agentTraceReviewSessions.deleteMatchupComment);
 
   const [composing, setComposing] = useState(false);
   const [body, setBody] = useState("");
@@ -328,7 +333,16 @@ function StepComments({
       const target = step.kind === "tool_call"
         ? { kind: "tool_call" as const, stepIndex: step.stepIndex }
         : { kind: "step" as const, stepIndex: step.stepIndex };
-      if (reviewToken !== undefined) {
+      if (reviewToken !== undefined && matchupSide !== undefined) {
+        await addMatchupComment({
+          token: reviewToken,
+          side: matchupSide,
+          target,
+          comment: body,
+          label,
+          tags: tags.length ? tags : undefined,
+        });
+      } else if (reviewToken !== undefined) {
         await addReviewComment({
           token: reviewToken,
           target,
@@ -359,7 +373,11 @@ function StepComments({
 
   async function remove(commentId: TraceComment["_id"]) {
     try {
-      await deleteComment({ commentId });
+      if (reviewToken !== undefined && matchupSide !== undefined) {
+        await deleteMatchupComment({ token: reviewToken, side: matchupSide, commentId });
+      } else {
+        await deleteOwnerComment({ commentId });
+      }
     } catch {
       // A failed delete is non-blocking; the row simply stays.
     }
@@ -578,7 +596,8 @@ function MatchupTokenSteps({
     { token, side },
     { initialNumItems: 50 },
   );
-  return <StepListResults {...page} reviewToken={token} matchupSide={side} divergenceStepIndex={divergenceStepIndex} />;
+  const comments = useQuery(api.agentTraceReviewSessions.listMatchupComments, { token, side });
+  return <StepListResults {...page} reviewToken={token} matchupSide={side} comments={comments} divergenceStepIndex={divergenceStepIndex} />;
 }
 
 function StepListResults({


### PR DESCRIPTION
## Summary

Adds the focused paired-comparison campaign slice from #341:

- strict paired CSV import into the existing `agentTraces` / `agentTraceMatchups` spine
- owner draft/open/closed campaign lifecycle with an opaque Slack-friendly share link
- anonymous, user-bound guest sessions with frozen randomized order and five-item batches
- mobile/desktop reviewer deck with click, keyboard arrows, and horizontal swipe/drag
- five distinct judgments: candidate 1, candidate 2, same, neither acceptable, cannot judge
- optional judgment notes and step/tool-call comments
- owner coverage, majority agreement, reviewer names/notes, and canonical A/B results
- campaign-filtered provider-neutral DPO JSONL export

## Blind-review and auth boundaries

- The share token only redeems a separate user-bound session token.
- Campaign guests receive no project collaborator role.
- Guest projections omit campaign/project names, model/harness provenance, real trace/matchup IDs, and owner result data.
- Generic matchup result/decision APIs reject campaign sessions.
- Closed campaigns reject new judgments and content reads.
- Anonymous cleanup preserves guests with opaque review sessions.
- Tie, neither, cannot-judge, disagreement, and non-comparable cases remain results but do not become DPO rows.

## Verification

Fresh `npm run test:all`:

- production TypeScript + Vite build passed
- eval tests: **23 files / 189 tests passed**
- Convex tests: **35 files / 284 tests passed**
- Playwright component tests: **8 passed**

Focused additions:

- paired CSV parser and content-free error receipt tests
- keyboard/swipe control mapping tests
- four Convex campaign tests covering import/dedup, opaque guest sessions, blinding, tool comments, five outcomes, batching, idempotent revisions, results, export, closure, generic-API bypass rejection, and anonymous cleanup

Manual commit-pinned walkthrough on `5eafca2`:

- desktop (1440×1000): anonymous join → blind deck → Arrow Left advanced 1/5 to 2/5
- mobile (390×844): anonymous join → stacked deck → horizontal drag advanced 1/5 to 2/5
- zero browser console/page errors
- reviewer DOM contained no campaign/project/model provenance

## Non-goals

- no provider credential or direct fine-tuning push
- no redesign of advanced trajectory alignment; campaigns reuse the current comparable trace-step contract
- no merge or deployment in this PR

Closes #341
