### PR TITLE
M33.8: Make paired comparisons import-first

### DIFF
--- a/src/routes/orgs/projects/ComparisonCampaignNew.tsx
+++ b/src/routes/orgs/projects/ComparisonCampaignNew.tsx
@@ -1,113 +1,16 @@
-import { useState } from "react";
-import { useAction } from "convex/react";
-import { Link, useNavigate, useParams } from "react-router-dom";
-import { ArrowLeft, Download, Upload } from "lucide-react";
+import { Navigate, useParams } from "react-router-dom";
 
-import { api } from "../../../../convex/_generated/api";
 import { useProject } from "@/contexts/ProjectContext";
-import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import { friendlyError } from "@/lib/errors";
 
-const MAX_BYTES = 8 * 1024 * 1024;
-const TEMPLATE = [
-  "case_id,context,candidate_a,candidate_b,candidate_a_model,candidate_b_model,segment,privacy_class",
-  'case-1,"Customer message and prior context","First possible reply","Second possible reply",model-a,model-b,scheduling,internal',
-].join("\n");
-
+/** Preserve old campaign-creation links while keeping Import as the front door. */
 export function ComparisonCampaignNew() {
   const { projectId } = useProject();
   const { orgSlug } = useParams<{ orgSlug: string }>();
-  const navigate = useNavigate();
-  const importCsv = useAction(api.comparisonCampaigns.importPairedCsv);
-  const [name, setName] = useState("");
-  const [csv, setCsv] = useState("");
-  const [fileName, setFileName] = useState("");
-  const [busy, setBusy] = useState(false);
-  const [error, setError] = useState("");
-  const base = `/orgs/${orgSlug}/projects/${projectId}`;
-
-  async function selectFile(event: React.ChangeEvent<HTMLInputElement>) {
-    const file = event.target.files?.[0];
-    if (!file) return;
-    if (file.size > MAX_BYTES) {
-      setError(`${file.name} is over the 8 MB limit. Split it and try again.`);
-      return;
-    }
-    setError("");
-    setFileName(file.name);
-    setCsv(await file.text());
-    if (!name) setName(file.name.replace(/\.csv$/i, ""));
-  }
-
-  async function submit(event: React.FormEvent) {
-    event.preventDefault();
-    if (!name.trim() || !csv || busy) return;
-    setBusy(true);
-    setError("");
-    try {
-      const result = await importCsv({ projectId, name: name.trim(), csv });
-      navigate(`${base}/comparisons/${result.campaignId}`);
-    } catch (cause: unknown) {
-      setError(friendlyError(cause, "Could not import this comparison CSV."));
-      setBusy(false);
-    }
-  }
-
-  function downloadTemplate() {
-    const url = URL.createObjectURL(new Blob([TEMPLATE], { type: "text/csv" }));
-    const anchor = document.createElement("a");
-    anchor.href = url;
-    anchor.download = "blindbench-paired-comparison.csv";
-    anchor.click();
-    URL.revokeObjectURL(url);
-  }
 
   return (
-    <div className="mx-auto max-w-3xl p-6">
-      <Link to={`${base}/evaluate`} className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground">
-        <ArrowLeft className="h-3.5 w-3.5" /> Reviews
-      </Link>
-      <header className="mt-3">
-        <h1 className="text-2xl font-bold">Create a blind comparison</h1>
-        <p className="mt-1 text-sm text-muted-foreground">
-          Upload two completed attempts for each shared context. Blind Bench runs nothing—it only presents and records the review.
-        </p>
-      </header>
-
-      <Card className="mt-6">
-        <CardHeader><CardTitle className="text-base">Paired CSV</CardTitle></CardHeader>
-        <CardContent>
-          <form onSubmit={submit} className="space-y-4">
-            <div className="space-y-1.5">
-              <Label htmlFor="comparison-name">Comparison name</Label>
-              <Input id="comparison-name" value={name} onChange={(event) => setName(event.target.value)} placeholder="4o vs Luna — July SMS" maxLength={120} />
-            </div>
-            <div className="space-y-1.5">
-              <Label htmlFor="comparison-file">CSV file</Label>
-              <label htmlFor="comparison-file" className="flex cursor-pointer items-center gap-2 rounded-lg border border-dashed px-4 py-8 text-sm text-muted-foreground hover:border-primary/50 hover:text-foreground">
-                <Upload className="h-4 w-4" /> {fileName || "Choose paired responses…"}
-              </label>
-              <input id="comparison-file" type="file" accept=".csv,text/csv" onChange={selectFile} className="sr-only" />
-              <p className="text-xs text-muted-foreground">
-                Required: <code>case_id</code>, <code>context</code>, <code>candidate_a</code>, <code>candidate_b</code>. Optional model, harness, segment, environment, product, and privacy columns.
-              </p>
-              <Button type="button" variant="ghost" size="sm" onClick={downloadTemplate}>
-                <Download className="h-3.5 w-3.5" /> Download template
-              </Button>
-            </div>
-            <div className="rounded-lg border border-amber-500/40 bg-amber-500/5 p-3 text-xs text-muted-foreground">
-              Free-text context and replies are stored as supplied. Upload only data this workspace is approved to review and train on.
-            </div>
-            {error && <p className="text-sm text-destructive" role="alert">{error}</p>}
-            <Button type="submit" disabled={busy || !name.trim() || !csv}>
-              {busy ? "Importing…" : "Create comparison"}
-            </Button>
-          </form>
-        </CardContent>
-      </Card>
-    </div>
+    <Navigate
+      to={`/orgs/${orgSlug}/projects/${projectId}/import?source=paired`}
+      replace
+    />
   );
 }

--- a/src/routes/orgs/projects/EvaluatePage.tsx
+++ b/src/routes/orgs/projects/EvaluatePage.tsx
@@ -73,7 +73,7 @@ export function EvaluatePage() {
       <div className="flex items-center justify-between">
         <h1 className="text-xl font-semibold">Evaluate</h1>
         <div className="flex items-center gap-2">
-          <Link to={`${basePath}/comparisons/new`} className={buttonVariants({ size: "sm" })}>
+          <Link to={`${basePath}/import?source=paired`} className={buttonVariants({ size: "sm" })}>
             <Plus className="mr-1.5 h-4 w-4" /> New comparison
           </Link>
           <Link to={`${basePath}/cycles/new`} className={buttonVariants({ size: "sm", variant: "outline" })}>
@@ -89,7 +89,7 @@ export function EvaluatePage() {
           description="Import paired responses for a fast blind comparison, or pool existing runs into a review cycle."
           action={{
             label: "New blind comparison",
-            onClick: () => navigate(`${basePath}/comparisons/new`),
+            onClick: () => navigate(`${basePath}/import?source=paired`),
           }}
         />
       ) : (

--- a/src/routes/orgs/projects/ImportRuns.ct.spec.tsx
+++ b/src/routes/orgs/projects/ImportRuns.ct.spec.tsx
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/experimental-ct-react";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
 import type { Doc, Id } from "../../../../convex/_generated/dataModel";
 import { ProjectProvider } from "@/contexts/ProjectContext";
 import { ImportRuns } from "./ImportRuns";
@@ -13,7 +13,7 @@ const project = {
   createdById: "user_import_test",
 } as Doc<"projects">;
 
-test("ingestion-first surface exposes CSV, OTLP, Pi, and Claude Code", async ({ mount }) => {
+test("import surface exposes paired comparisons alongside completed-run sources", async ({ mount }) => {
   const component = await mount(
     <MemoryRouter>
       <ProjectProvider value={{ project, projectId, role: "owner" }}>
@@ -22,14 +22,62 @@ test("ingestion-first surface exposes CSV, OTLP, Pi, and Claude Code", async ({ 
     </MemoryRouter>,
   );
 
-  await expect(component.getByRole("heading", { name: "Import completed runs" })).toBeVisible();
-  for (const source of ["CSV", "OpenTelemetry", "Pi session", "Claude Code"]) {
+  await expect(component.getByRole("heading", { name: "Import runs and comparisons" })).toBeVisible();
+  for (const source of ["Paired comparison", "CSV", "OpenTelemetry", "Pi session", "Claude Code"]) {
     await expect(component.getByRole("listitem").filter({ hasText: source })).toBeVisible();
   }
   await expect(component).toContainText("does not execute your harness");
 });
 
-test("CSV upload discovers headers and requires input/output mapping", async ({ mount }) => {
+test("paired comparison source can be opened directly from Review", async ({ mount }) => {
+  const component = await mount(
+    <MemoryRouter initialEntries={["/orgs/org/projects/project/import?source=paired"]}>
+      <ProjectProvider value={{ project, projectId, role: "owner" }}>
+        <ImportRuns />
+      </ProjectProvider>
+    </MemoryRouter>,
+  );
+
+  await expect(component.getByRole("listitem").filter({ hasText: "Paired comparison" }))
+    .toHaveAttribute("aria-pressed", "true");
+  await expect(component.getByLabel("Comparison name")).toBeVisible();
+  await expect(component.getByRole("button", { name: "Create comparison" })).toBeDisabled();
+});
+
+test("paired CSV upload is auto-detected and opens the new comparison", async ({ mount }) => {
+  const component = await mount(
+    <MemoryRouter initialEntries={["/orgs/org/projects/project_import_test/import"]}>
+      <ProjectProvider value={{ project, projectId, role: "owner" }}>
+        <Routes>
+          <Route path="/orgs/:orgSlug/projects/:projectId/import" element={<ImportRuns />} />
+          <Route
+            path="/orgs/:orgSlug/projects/:projectId/comparisons/:campaignId"
+            element={<p>Comparison opened</p>}
+          />
+        </Routes>
+      </ProjectProvider>
+    </MemoryRouter>,
+  );
+
+  await component.locator("#run-import-file").setInputFiles({
+    name: "alpha-vs-beta.csv",
+    mimeType: "text/csv",
+    buffer: Buffer.from([
+      "case_id,context,candidate_a,candidate_b,candidate_a_model,candidate_b_model",
+      "case-1,shared prompt,first answer,second answer,alpha,beta",
+    ].join("\\n")),
+  });
+
+  await expect(component.getByRole("listitem").filter({ hasText: "Paired comparison" }))
+    .toHaveAttribute("aria-pressed", "true");
+  await expect(component.getByLabel("Comparison name")).toHaveValue("alpha-vs-beta");
+  await expect(component.getByRole("button", { name: "Create comparison" })).toBeEnabled();
+  await expect(component).not.toContainText("Map CSV columns");
+  await component.getByRole("button", { name: "Create comparison" }).click();
+  await expect(component.getByText("Comparison opened")).toBeVisible();
+});
+
+test("flat CSV upload discovers headers and requires input/output mapping", async ({ mount }) => {
   const component = await mount(
     <MemoryRouter>
       <ProjectProvider value={{ project, projectId, role: "owner" }}>

--- a/src/routes/orgs/projects/ImportRuns.tsx
+++ b/src/routes/orgs/projects/ImportRuns.tsx
@@ -1,11 +1,12 @@
 import { useMemo, useState } from "react";
 import { useAction } from "convex/react";
-import { Link } from "react-router-dom";
+import { Link, useNavigate, useParams, useSearchParams } from "react-router-dom";
 import type { FunctionReturnType } from "convex/server";
 import { api } from "../../../../convex/_generated/api";
 import { useProject } from "@/contexts/ProjectContext";
 import { Button, buttonVariants } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { friendlyError } from "@/lib/errors";
 import { cn } from "@/lib/utils";
@@ -16,13 +17,14 @@ import {
 import {
   Braces,
   CheckCircle2,
+  Download,
   FileSpreadsheet,
   Route,
   ShieldAlert,
   Upload,
 } from "lucide-react";
 
-type ImportSource = "csv" | "otlp" | "pi" | "claude_code";
+type ImportSource = "paired" | "csv" | "otlp" | "pi" | "claude_code";
 type CsvResult = FunctionReturnType<typeof api.csvImport.importMappedCsv>;
 type OtlpResult = FunctionReturnType<typeof api.otlpFileImport.importOtlpJson>;
 type PiResult = FunctionReturnType<typeof api.piImport.importPiSession>;
@@ -32,8 +34,19 @@ type ImportResult = CsvResult | OtlpResult | PiResult | ClaudeResult;
 type MappingField = Exclude<keyof CsvTraceMapping, "metadataColumns">;
 
 const MAX_BYTES = 8 * 1024 * 1024;
+const PAIRED_TEMPLATE = [
+  "case_id,context,candidate_a,candidate_b,candidate_a_model,candidate_b_model,segment,privacy_class",
+  'case-1,"Shared prompt or prior conversation","First completed attempt","Second completed attempt",model-a,model-b,demo,internal',
+].join("\n");
 
 const SOURCES = [
+  {
+    id: "paired",
+    title: "Paired comparison",
+    description: "Upload 2 completed attempts for every shared context and start a blind review.",
+    accept: ".csv,text/csv",
+    icon: FileSpreadsheet,
+  },
   {
     id: "csv",
     title: "CSV",
@@ -104,6 +117,13 @@ const FIELD_GUESSES: Record<MappingField, ReadonlyArray<string>> = {
   privacyClassColumn: ["privacy_class", "sensitivity"],
 };
 
+const PAIRED_HEADERS = ["case_id", "context", "candidate_a", "candidate_b"] as const;
+
+function isPairedComparisonCsv(headers: ReadonlyArray<string>): boolean {
+  const headerSet = new Set(headers);
+  return PAIRED_HEADERS.every((header) => headerSet.has(header));
+}
+
 function guessMapping(headers: ReadonlyArray<string>): Partial<Record<MappingField, string>> {
   const lower = new Map(headers.map((header) => [header.toLowerCase(), header]));
   const mapping: Partial<Record<MappingField, string>> = {};
@@ -118,13 +138,20 @@ function guessMapping(headers: ReadonlyArray<string>): Partial<Record<MappingFie
 
 export function ImportRuns() {
   const { projectId } = useProject();
+  const { orgSlug } = useParams<{ orgSlug: string }>();
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const importCsv = useAction(api.csvImport.importMappedCsv);
+  const importPairedCsv = useAction(api.comparisonCampaigns.importPairedCsv);
   const importOtlp = useAction(api.otlpFileImport.importOtlpJson);
   const importPi = useAction(api.piImport.importPiSession);
   const importClaude = useAction(api.claudeCodeImport.importClaudeCodeSession);
 
-  const [source, setSource] = useState<ImportSource>("csv");
+  const [source, setSource] = useState<ImportSource>(
+    searchParams.get("source") === "paired" ? "paired" : "csv",
+  );
   const [fileName, setFileName] = useState("");
+  const [comparisonName, setComparisonName] = useState("");
   const [payload, setPayload] = useState("");
   const [csvHeaders, setCsvHeaders] = useState<ReadonlyArray<string>>([]);
   const [csvRows, setCsvRows] = useState(0);
@@ -142,10 +169,14 @@ export function ImportRuns() {
   const csvReady =
     source !== "csv" ||
     (mapping.inputColumn !== undefined && mapping.outputColumn !== undefined);
+  const pairedReady =
+    source !== "paired" ||
+    (comparisonName.trim().length > 0 && isPairedComparisonCsv(csvHeaders));
 
   function resetFile(nextSource: ImportSource) {
     setSource(nextSource);
     setFileName("");
+    setComparisonName("");
     setPayload("");
     setCsvHeaders([]);
     setCsvRows(0);
@@ -167,27 +198,52 @@ export function ImportRuns() {
     const text = await file.text();
     setFileName(file.name);
     setPayload(text);
-    if (source === "csv") {
+    if (source === "csv" || source === "paired") {
       try {
         const rows = parseCsvRows(text);
         const headers = rows[0]?.map((header) => header.trim()) ?? [];
         if (headers.length === 0) throw new Error("CSV must contain a header row.");
         setCsvHeaders(headers);
         setCsvRows(Math.max(0, rows.length - 1));
-        setMapping(guessMapping(headers));
+        if (isPairedComparisonCsv(headers)) {
+          setSource("paired");
+          setMapping({});
+          setMetadataColumns([]);
+          setComparisonName((current) => current || file.name.replace(/\.csv$/i, ""));
+        } else if (source === "paired") {
+          setError("Paired comparison CSV requires case_id, context, candidate_a, and candidate_b columns.");
+        } else {
+          setMapping(guessMapping(headers));
+        }
       } catch (cause: unknown) {
         setError(friendlyError(cause, "Could not read this CSV file."));
       }
     }
   }
 
+  function downloadPairedTemplate() {
+    const url = URL.createObjectURL(new Blob([PAIRED_TEMPLATE], { type: "text/csv" }));
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = "blindbench-paired-comparison.csv";
+    anchor.click();
+    URL.revokeObjectURL(url);
+  }
+
   async function handleImport() {
-    if (!payload || !csvReady || busy) return;
+    if (!payload || !csvReady || !pairedReady || busy) return;
     setBusy(true);
     setError("");
     setResult(null);
     try {
-      if (source === "csv") {
+      if (source === "paired") {
+        const result = await importPairedCsv({
+          projectId,
+          name: comparisonName.trim(),
+          csv: payload,
+        });
+        navigate(`/orgs/${orgSlug}/projects/${projectId}/comparisons/${result.campaignId}`);
+      } else if (source === "csv") {
         const inputColumn = mapping.inputColumn;
         const outputColumn = mapping.outputColumn;
         if (!inputColumn || !outputColumn) {
@@ -233,7 +289,7 @@ export function ImportRuns() {
       <header>
         <div className="flex items-center gap-2">
           <Upload aria-hidden="true" className="h-5 w-5 text-primary" />
-          <h1 className="text-2xl font-bold">Import completed runs</h1>
+          <h1 className="text-2xl font-bold">Import runs and comparisons</h1>
         </div>
         <p className="mt-1 max-w-2xl text-sm text-muted-foreground">
           Bring traces from the systems you already run. Blind Bench stores and
@@ -241,7 +297,7 @@ export function ImportRuns() {
         </p>
       </header>
 
-      <div className="mt-6 grid gap-3 sm:grid-cols-2 lg:grid-cols-4" role="list" aria-label="Import source">
+      <div className="mt-6 grid gap-3 sm:grid-cols-2 lg:grid-cols-5" role="list" aria-label="Import source">
         {SOURCES.map((item) => {
           const Icon = item.icon;
           const selected = source === item.id;
@@ -270,6 +326,24 @@ export function ImportRuns() {
           <CardTitle className="text-base">{selectedSource.title} file</CardTitle>
         </CardHeader>
         <CardContent className="space-y-4">
+          {source === "paired" && (
+            <div className="space-y-1.5">
+              <Label htmlFor="comparison-name">Comparison name</Label>
+              <Input
+                id="comparison-name"
+                value={comparisonName}
+                onChange={(event) => setComparisonName(event.target.value)}
+                placeholder="Alpha vs Beta — support replies"
+                maxLength={120}
+              />
+              <p className="text-xs text-muted-foreground">
+                Upload 2 completed attempts for every shared context. Required columns: <code>case_id</code>, <code>context</code>, <code>candidate_a</code>, and <code>candidate_b</code>.
+              </p>
+              <Button type="button" variant="ghost" size="sm" onClick={downloadPairedTemplate}>
+                <Download aria-hidden="true" className="h-3.5 w-3.5" /> Download template
+              </Button>
+            </div>
+          )}
           <label
             htmlFor="run-import-file"
             className="flex cursor-pointer items-center gap-2 rounded-md border border-dashed px-4 py-6 text-sm text-muted-foreground hover:border-primary/50 hover:text-foreground"
@@ -305,8 +379,8 @@ export function ImportRuns() {
 
           {error && <p className="text-sm text-destructive" role="alert">{error}</p>}
 
-          <Button onClick={handleImport} disabled={busy || !payload || !csvReady}>
-            {busy ? "Importing…" : "Import runs"}
+          <Button onClick={handleImport} disabled={busy || !payload || !csvReady || !pairedReady}>
+            {busy ? "Importing…" : source === "paired" ? "Create comparison" : "Import runs"}
           </Button>
         </CardContent>
       </Card>

--- a/src/routes/traces/__smoke__/convexReactMock.tsx
+++ b/src/routes/traces/__smoke__/convexReactMock.tsx
@@ -33,6 +33,7 @@ const FIXTURE_BODY = {
 // depends on the action fn, so a fresh fn each render would loop forever.
 const noop = () => {};
 const getBodyFn = async () => FIXTURE_BODY;
+const importPairedComparison = async () => ({ campaignId: "campaign-import-test" });
 const noopMutation = async () => undefined;
 const createImportProject = async () => ({ orgSlug: "test-org", projectId: "test-project" });
 const PAGINATED = {
@@ -46,7 +47,14 @@ export function usePaginatedQuery() {
   return PAGINATED;
 }
 
-export function useAction() {
+export function useAction(action?: unknown) {
+  try {
+    if (getFunctionName(action as never) === "comparisonCampaigns:importPairedCsv") {
+      return importPairedComparison;
+    }
+  } catch {
+    // Keep unrelated component-test actions on the stable body fixture.
+  }
   return getBodyFn;
 }
 


### PR DESCRIPTION
## Summary

Fixes the confusing split between Import and Review for paired comparisons:

- adds **Paired comparison** as an explicit source on the project Import screen
- auto-detects `case_id`, `context`, `candidate_a`, and `candidate_b` when a user uploads a paired file through ordinary CSV
- switches directly from CSV mapping to comparison setup, pre-filling the campaign name from the filename
- creates the campaign through the existing secure `comparisonCampaigns.importPairedCsv` action and opens its detail page
- keeps the paired CSV template download on the Import surface
- sends **Review → New comparison** and legacy `/comparisons/new` links back to `Import?source=paired`
- preserves flat CSV, OTLP, Pi session, and Claude Code imports unchanged

## UX outcome

The expected flow is now:

`Import → upload paired CSV → name comparison → create → share/review`

Users no longer need to understand that paired rows are represented differently from standalone completed runs.

## Verification

Fresh `npm run test:all`:

- production TypeScript + Vite build passed
- eval tests: **23 files / 189 tests passed**
- Convex tests: **35 files / 284 tests passed**
- Playwright component tests: **10 passed**

New component coverage verifies:

- the paired-comparison source is visible on Import
- Review can deep-link directly to paired setup
- paired CSVs uploaded through normal CSV are auto-detected
- comparison creation navigates to the resulting campaign
- ordinary flat CSV mapping still works

## Non-goals

- no Cloudflare adapter removal in this PR
- no campaign review/results redesign
- no merge or production deployment

Closes #343
