### PR TITLE
M34: simplify Blind Bench around Runs, Reviews, Results

### DIFF
--- a/convex/agentTraceReviewSessions.ts
+++ b/convex/agentTraceReviewSessions.ts
@@ -16,6 +16,10 @@ import { internal } from "./_generated/api";
 import type { Doc, Id } from "./_generated/dataModel";
 import { requireAuth } from "./lib/auth";
 import { blindStepView, blindTraceView } from "./lib/blindProjection";
+import {
+  activeVerdictReviewItem,
+  resolveVerdictCampaignSession,
+} from "./verdictReviewCampaigns";
 
 const LABEL = v.union(
   v.literal("suggestion"),
@@ -77,6 +81,10 @@ async function sessionForUser(
     }
     return session;
   }
+  if (session.kind === "verdict_campaign") {
+    await resolveVerdictCampaignSession(ctx, token, { requireOpen: true });
+    return session;
+  }
   const collaborator = await ctx.db
     .query("projectCollaborators")
     .withIndex("by_project_and_user", (q) =>
@@ -96,14 +104,30 @@ async function traceSession(
   readonly session: Doc<"agentTraceReviewSessions">;
   readonly trace: Doc<"agentTraces">;
   readonly userId: Id<"users">;
+  readonly verdictItem?: Doc<"verdictReviewItems">;
+  readonly verdictCampaign?: Doc<"verdictReviewCampaigns">;
 }> {
   const session = await sessionForUser(ctx, token);
+  if (session.kind === "verdict_campaign") {
+    const { campaign } = await resolveVerdictCampaignSession(ctx, token, {
+      requireOpen: true,
+    });
+    const active = await activeVerdictReviewItem(ctx, session);
+    if (!active) throw new Error("This review is complete.");
+    return {
+      session,
+      trace: active.trace,
+      userId: session.reviewerUserId,
+      verdictItem: active.item,
+      verdictCampaign: campaign,
+    };
+  }
   if (session.kind !== "trace" || session.agentTraceId === undefined) {
-    throw new Error("This review link is not a trajectory session.");
+    throw new Error("This review link is not a run-review session.");
   }
   const trace = await ctx.db.get(session.agentTraceId);
   if (!trace || trace.projectId !== session.projectId) {
-    throw new Error("Review trajectory is no longer available.");
+    throw new Error("Review run is no longer available.");
   }
   return { session, trace, userId: session.reviewerUserId };
 }
@@ -319,28 +343,33 @@ export const getStepBody = action({
   },
 });
 
-/** List comments for one opaque trajectory session. */
+/** List only the caller's comments for the active opaque run-review item. */
 export const listComments = query({
   args: { token: v.string() },
   handler: async (ctx, args) => {
-    const { trace, userId } = await traceSession(ctx, args.token);
+    const { trace, userId, verdictCampaign } = await traceSession(ctx, args.token);
     const rows = await ctx.db
       .query("agentTraceComments")
       .withIndex("by_trace", (q) => q.eq("agentTraceId", trace._id))
       .collect();
-    return rows.filter((row) => row.userId === userId).map((row) => ({
-      _id: row._id,
-      target: row.target,
-      comment: row.comment,
-      label: row.label,
-      tags: row.tags ?? [],
-      mine: row.userId === userId,
-      createdAt: row._creationTime,
-    }));
+    return rows
+      .filter((row) =>
+        row.userId === userId &&
+        row.verdictCampaignId === verdictCampaign?._id,
+      )
+      .map((row) => ({
+        _id: row._id,
+        target: row.target,
+        comment: row.comment,
+        label: row.label,
+        tags: row.tags ?? [],
+        mine: true,
+        createdAt: row._creationTime,
+      }));
   },
 });
 
-/** Add a step/trace comment through an opaque trajectory session. */
+/** Add a step/trace comment through an opaque run-review session. */
 export const addComment = mutation({
   args: {
     token: v.string(),
@@ -350,7 +379,7 @@ export const addComment = mutation({
     tags: v.optional(v.array(TAG)),
   },
   handler: async (ctx, args): Promise<Id<"agentTraceComments">> => {
-    const { trace, userId } = await traceSession(ctx, args.token);
+    const { trace, userId, verdictCampaign } = await traceSession(ctx, args.token);
     const body = args.comment.trim();
     if (!body) throw new Error("Add a comment before saving.");
     if (
@@ -363,6 +392,7 @@ export const addComment = mutation({
       agentTraceId: trace._id,
       projectId: trace.projectId,
       userId,
+      verdictCampaignId: verdictCampaign?._id,
       target: args.target,
       comment: body,
       label: args.label,
@@ -371,11 +401,20 @@ export const addComment = mutation({
   },
 });
 
-/** Return the caller's verdict for one opaque trajectory session. */
+/** Return the caller's verdict for the active opaque run-review item. */
 export const myVerdict = query({
   args: { token: v.string() },
   handler: async (ctx, args) => {
-    const { trace, userId } = await traceSession(ctx, args.token);
+    const { trace, userId, verdictItem } = await traceSession(ctx, args.token);
+    if (verdictItem) {
+      const decision = await ctx.db
+        .query("verdictReviewDecisions")
+        .withIndex("by_item_and_user", (q) =>
+          q.eq("itemId", verdictItem._id).eq("userId", userId),
+        )
+        .unique();
+      return decision ? { rating: decision.rating, note: decision.note } : null;
+    }
     const verdict = await ctx.db
       .query("agentTraceVerdicts")
       .withIndex("by_trace_and_user", (q) =>
@@ -386,11 +425,56 @@ export const myVerdict = query({
   },
 });
 
-/** Upsert the caller's verdict through an opaque trajectory session. */
+/** Save a verdict and advance a campaign session, or upsert a standalone verdict. */
 export const setVerdict = mutation({
   args: { token: v.string(), rating: RATING, note: v.optional(v.string()) },
   handler: async (ctx, args) => {
-    const { trace, userId } = await traceSession(ctx, args.token);
+    const {
+      session,
+      trace,
+      userId,
+      verdictItem,
+      verdictCampaign,
+    } = await traceSession(ctx, args.token);
+    const note = args.note?.trim().slice(0, 2_000) || undefined;
+    if (verdictItem && verdictCampaign) {
+      const existing = await ctx.db
+        .query("verdictReviewDecisions")
+        .withIndex("by_item_and_user", (q) =>
+          q.eq("itemId", verdictItem._id).eq("userId", userId),
+        )
+        .unique();
+      let decisionId: Id<"verdictReviewDecisions">;
+      if (existing) {
+        await ctx.db.patch(existing._id, {
+          rating: args.rating,
+          note,
+          decidedAt: Date.now(),
+        });
+        decisionId = existing._id;
+      } else {
+        decisionId = await ctx.db.insert("verdictReviewDecisions", {
+          campaignId: verdictCampaign._id,
+          itemId: verdictItem._id,
+          projectId: trace.projectId,
+          agentTraceId: trace._id,
+          userId,
+          rating: args.rating,
+          note,
+          decidedAt: Date.now(),
+        });
+        await ctx.db.patch(verdictCampaign._id, {
+          judgmentCount: verdictCampaign.judgmentCount + 1,
+        });
+      }
+      const nextIndex = (session.currentIndex ?? 0) + 1;
+      const total = session.traceOrder?.length ?? 0;
+      await ctx.db.patch(session._id, {
+        currentIndex: nextIndex,
+        ...(nextIndex >= total ? { completedAt: Date.now() } : {}),
+      });
+      return decisionId;
+    }
     const existing = await ctx.db
       .query("agentTraceVerdicts")
       .withIndex("by_trace_and_user", (q) =>
@@ -398,7 +482,7 @@ export const setVerdict = mutation({
       )
       .unique();
     if (existing) {
-      await ctx.db.patch(existing._id, { rating: args.rating, note: args.note });
+      await ctx.db.patch(existing._id, { rating: args.rating, note });
       return existing._id;
     }
     return await ctx.db.insert("agentTraceVerdicts", {
@@ -406,7 +490,7 @@ export const setVerdict = mutation({
       projectId: trace.projectId,
       userId,
       rating: args.rating,
-      note: args.note,
+      note,
     });
   },
 });

--- a/convex/exports.ts
+++ b/convex/exports.ts
@@ -187,6 +187,7 @@ export const gatherTrajectoryPlan = internalQuery({
     projectId: v.id("projects"),
     format: FORMAT,
     campaignId: v.optional(v.id("comparisonCampaigns")),
+    verdictCampaignId: v.optional(v.id("verdictReviewCampaigns")),
   },
   handler: async (
     ctx,
@@ -197,6 +198,18 @@ export const gatherTrajectoryPlan = internalQuery({
       const campaign = await ctx.db.get(args.campaignId);
       if (!campaign || campaign.projectId !== args.projectId) {
         throw new Error("Comparison campaign not found.");
+      }
+      if (campaign.status !== "closed") {
+        throw new Error("Close the comparison review before exporting training data.");
+      }
+    }
+    if (args.verdictCampaignId !== undefined) {
+      const campaign = await ctx.db.get(args.verdictCampaignId);
+      if (!campaign || campaign.projectId !== args.projectId) {
+        throw new Error("Run review not found.");
+      }
+      if (campaign.status !== "closed") {
+        throw new Error("Close the run review before exporting training data.");
       }
     }
     const stepsOf = (traceId: Id<"agentTraces">) =>
@@ -209,6 +222,9 @@ export const gatherTrajectoryPlan = internalQuery({
     const reviewerIds = new Set<string>();
 
     if (args.format === "dpo") {
+      if (args.verdictCampaignId !== undefined) {
+        throw new Error("Run verdict reviews export as SFT, not DPO.");
+      }
       const allMatchups = await ctx.db
         .query("agentTraceMatchups")
         .withIndex("by_project", (q) => q.eq("projectId", args.projectId))
@@ -283,36 +299,92 @@ export const gatherTrajectoryPlan = internalQuery({
         });
       }
     } else if (args.format === "sft") {
-      const traces = await ctx.db
-        .query("agentTraces")
-        .withIndex("by_project", (q) => q.eq("projectId", args.projectId))
-        .collect();
-      for (const tr of traces) {
-        if (tr.status !== "ready") continue;
-        const verdicts = await ctx.db
-          .query("agentTraceVerdicts")
-          .withIndex("by_trace", (q) => q.eq("agentTraceId", tr._id))
+      if (args.verdictCampaignId !== undefined) {
+        const verdictCampaignId = args.verdictCampaignId;
+        const items = await ctx.db
+          .query("verdictReviewItems")
+          .withIndex("by_campaign", (q) => q.eq("campaignId", verdictCampaignId))
           .collect();
-        if (!verdicts.some((vd) => vd.rating === "best")) continue;
-        if (verdicts.some((vd) => vd.rating === "weak")) {
+        for (const item of items) {
+          const tr = await ctx.db.get(item.agentTraceId);
+          if (!tr || tr.status !== "ready") continue;
+          const verdicts = await ctx.db
+            .query("verdictReviewDecisions")
+            .withIndex("by_item", (q) => q.eq("itemId", item._id))
+            .collect();
+          for (const verdict of verdicts) reviewerIds.add(verdict.userId);
+          if (verdicts.some((verdict) => verdict.rating === "weak")) {
+            plan.push({
+              privacyClass: tr.privacyClass,
+              metadata: { reviewer_count: verdicts.length },
+              excludeReason: "review_disagreement",
+            });
+            continue;
+          }
+          if (!verdicts.some((verdict) => verdict.rating === "best")) {
+            plan.push({
+              privacyClass: tr.privacyClass,
+              metadata: { reviewer_count: verdicts.length },
+              excludeReason: "no_approved_verdict",
+            });
+            continue;
+          }
+          const steps = await stepsOf(tr._id);
           plan.push({
             privacyClass: tr.privacyClass,
-            metadata: {},
-            excludeReason: "review_disagreement",
+            metadata: { verdict: "best", reviewer_count: verdicts.length },
+            messages: steps
+              .filter((step) =>
+                step.kind === "message" &&
+                ["system", "user", "assistant"].includes(step.role ?? ""),
+              )
+              .map((step) => ({
+                meta: metaOf(step),
+                storageId: step.fullBodyStorageId,
+              })),
+            finalAnswer: tr.finalAnswerStorageId,
           });
-          for (const verdict of verdicts) reviewerIds.add(verdict.userId);
-          continue;
         }
-        const steps = await stepsOf(tr._id);
-        plan.push({
-          privacyClass: tr.privacyClass,
-          metadata: { verdict: "best" },
-          messages: steps
-            .filter((s) => s.kind === "message" && ["system", "user", "assistant"].includes(s.role ?? ""))
-            .map((s) => ({ meta: metaOf(s), storageId: s.fullBodyStorageId })),
-          finalAnswer: tr.finalAnswerStorageId,
-        });
-        for (const vd of verdicts) if (vd.rating === "best") reviewerIds.add(vd.userId);
+      } else {
+        const traces = await ctx.db
+          .query("agentTraces")
+          .withIndex("by_project", (q) => q.eq("projectId", args.projectId))
+          .collect();
+        for (const tr of traces) {
+          if (tr.status !== "ready") continue;
+          const verdicts = await ctx.db
+            .query("agentTraceVerdicts")
+            .withIndex("by_trace", (q) => q.eq("agentTraceId", tr._id))
+            .collect();
+          if (!verdicts.some((verdict) => verdict.rating === "best")) continue;
+          if (verdicts.some((verdict) => verdict.rating === "weak")) {
+            plan.push({
+              privacyClass: tr.privacyClass,
+              metadata: {},
+              excludeReason: "review_disagreement",
+            });
+            for (const verdict of verdicts) reviewerIds.add(verdict.userId);
+            continue;
+          }
+          const steps = await stepsOf(tr._id);
+          plan.push({
+            privacyClass: tr.privacyClass,
+            metadata: { verdict: "best" },
+            messages: steps
+              .filter((step) =>
+                step.kind === "message" &&
+                ["system", "user", "assistant"].includes(step.role ?? ""),
+              )
+              .map((step) => ({
+                meta: metaOf(step),
+                storageId: step.fullBodyStorageId,
+              })),
+            finalAnswer: tr.finalAnswerStorageId,
+          });
+          for (const verdict of verdicts) {
+            if (verdict.rating === "best") reviewerIds.add(verdict.userId);
+          }
+        }
       }
     }
     return { plan, stats: { sourceUnits: plan.length, reviewers: reviewerIds.size } };
@@ -370,6 +442,7 @@ export const generateExport = action({
     // Explicit consent to include prod-sensitive (confidential/pii/phi) rows.
     allowSensitive: v.optional(v.boolean()),
     campaignId: v.optional(v.id("comparisonCampaigns")),
+    verdictCampaignId: v.optional(v.id("verdictReviewCampaigns")),
   },
   handler: async (
     ctx,
@@ -380,8 +453,17 @@ export const generateExport = action({
     excludedCount: number;
     manifest: ExportManifest;
   }> => {
-    if (args.campaignId !== undefined && args.source !== "trajectory") {
-      throw new Error("Campaign exports use the trajectory source.");
+    if (
+      (args.campaignId !== undefined || args.verdictCampaignId !== undefined) &&
+      args.source !== "trajectory"
+    ) {
+      throw new Error("Review exports use the trajectory source.");
+    }
+    if (args.campaignId !== undefined && args.verdictCampaignId !== undefined) {
+      throw new Error("Export one review at a time.");
+    }
+    if (args.verdictCampaignId !== undefined && args.format !== "sft") {
+      throw new Error("Run verdict reviews export as SFT.");
     }
     if (args.format === "annotated") {
       throw new Error("Annotated export isn’t available yet — use DPO or SFT.");
@@ -405,6 +487,7 @@ export const generateExport = action({
         projectId: args.projectId,
         format: args.format,
         campaignId: args.campaignId,
+        verdictCampaignId: args.verdictCampaignId,
       });
       const hydrated = await hydrateTrajectory(ctx, res.plan, args.format);
       classified = hydrated.rows;

--- a/convex/lib/trainingExport.ts
+++ b/convex/lib/trainingExport.ts
@@ -78,6 +78,7 @@ export interface ExcludedRow {
     | "non_comparable_prefix"
     | "review_disagreement"
     | "no_preference"
+    | "no_approved_verdict"
     | "invalid_sft_shape";
   privacyClass: PrivacyClass;
 }

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -757,6 +757,70 @@ const schema = defineSchema({
     .index("by_share_token", ["shareToken"])
     .index("by_project_import", ["projectId", "importKey"]),
 
+  // #346: no-account blind review of one or more completed runs. Items and
+  // decisions are child rows so campaign size and reviewer count never push a
+  // single Convex document toward its size limit.
+  verdictReviewCampaigns: defineTable({
+    projectId: v.id("projects"),
+    name: v.string(),
+    instructions: v.optional(v.string()),
+    status: v.union(
+      v.literal("draft"),
+      v.literal("open"),
+      v.literal("closed"),
+    ),
+    shareToken: v.string(),
+    itemCount: v.number(),
+    judgmentCount: v.number(),
+    createdById: v.id("users"),
+    createdAt: v.number(),
+    openedAt: v.optional(v.number()),
+    closedAt: v.optional(v.number()),
+  })
+    .index("by_project", ["projectId"])
+    .index("by_share_token", ["shareToken"]),
+
+  verdictReviewItems: defineTable({
+    campaignId: v.id("verdictReviewCampaigns"),
+    projectId: v.id("projects"),
+    agentTraceId: v.id("agentTraces"),
+    sortOrder: v.number(),
+  })
+    .index("by_campaign", ["campaignId"])
+    .index("by_campaign_and_trace", ["campaignId", "agentTraceId"]),
+
+  verdictReviewDecisions: defineTable({
+    campaignId: v.id("verdictReviewCampaigns"),
+    itemId: v.id("verdictReviewItems"),
+    projectId: v.id("projects"),
+    agentTraceId: v.id("agentTraces"),
+    userId: v.id("users"),
+    rating: v.union(
+      v.literal("best"),
+      v.literal("acceptable"),
+      v.literal("weak"),
+    ),
+    note: v.optional(v.string()),
+    decidedAt: v.number(),
+  })
+    .index("by_campaign", ["campaignId"])
+    .index("by_item", ["itemId"])
+    .index("by_campaign_and_user", ["campaignId", "userId"])
+    .index("by_item_and_user", ["itemId", "userId"]),
+
+  // Approved imported runs that should remain in the project's durable
+  // regression corpus. Promotion is idempotent per (project, trace).
+  regressionCases: defineTable({
+    projectId: v.id("projects"),
+    agentTraceId: v.id("agentTraces"),
+    verdictCampaignId: v.id("verdictReviewCampaigns"),
+    createdById: v.id("users"),
+    createdAt: v.number(),
+  })
+    .index("by_project", ["projectId"])
+    .index("by_project_and_trace", ["projectId", "agentTraceId"])
+    .index("by_campaign", ["verdictCampaignId"]),
+
   // #264 (M31 Trajectory Spine): parent row for a normalized agent-run trace.
   // Deliberately tiny — metadata + usage rollups only, NO step content — so it
   // stays well under the Convex ~1MiB doc cap regardless of trace length. Step
@@ -868,6 +932,7 @@ const schema = defineSchema({
     agentTraceId: v.id("agentTraces"),
     projectId: v.id("projects"),
     userId: v.id("users"),
+    verdictCampaignId: v.optional(v.id("verdictReviewCampaigns")),
     target: v.union(
       v.object({ kind: v.literal("trace") }),
       v.object({ kind: v.literal("step"), stepIndex: v.number() }),
@@ -953,6 +1018,7 @@ const schema = defineSchema({
       v.literal("trace"),
       v.literal("matchup"),
       v.literal("campaign"),
+      v.literal("verdict_campaign"),
     ),
     // Session-scoped randomized presentation order prevents one global
     // left/right ordering from biasing every reviewer.
@@ -960,6 +1026,7 @@ const schema = defineSchema({
     agentTraceId: v.optional(v.id("agentTraces")),
     matchupId: v.optional(v.id("agentTraceMatchups")),
     campaignId: v.optional(v.id("comparisonCampaigns")),
+    verdictCampaignId: v.optional(v.id("verdictReviewCampaigns")),
     reviewerDisplayName: v.optional(v.string()),
     campaignOrder: v.optional(
       v.array(
@@ -969,6 +1036,7 @@ const schema = defineSchema({
         }),
       ),
     ),
+    traceOrder: v.optional(v.array(v.id("agentTraces"))),
     currentIndex: v.optional(v.number()),
     visibleCount: v.optional(v.number()),
     completedAt: v.optional(v.number()),
@@ -977,7 +1045,11 @@ const schema = defineSchema({
     .index("by_reviewer", ["reviewerUserId"])
     .index("by_trace_and_reviewer", ["agentTraceId", "reviewerUserId"])
     .index("by_matchup_and_reviewer", ["matchupId", "reviewerUserId"])
-    .index("by_campaign_and_reviewer", ["campaignId", "reviewerUserId"]),
+    .index("by_campaign_and_reviewer", ["campaignId", "reviewerUserId"])
+    .index("by_verdict_campaign_and_reviewer", [
+      "verdictCampaignId",
+      "reviewerUserId",
+    ]),
 
   agentTraceMatchupDecisions: defineTable({
     matchupId: v.id("agentTraceMatchups"),

--- a/convex/tests/comparisonCampaigns.test.ts
+++ b/convex/tests/comparisonCampaigns.test.ts
@@ -350,6 +350,9 @@ describe("blind comparison campaigns", () => {
       judgments: 6,
     }]);
 
+    await asOwner.mutation(api.comparisonCampaigns.closeCampaign, {
+      campaignId: imported.campaignId,
+    });
     const exported = await asOwner.action(api.exports.generateExport, {
       projectId: ids.projectId,
       campaignId: imported.campaignId,
@@ -363,9 +366,6 @@ describe("blind comparison campaigns", () => {
       reviewers: 1,
     });
 
-    await asOwner.mutation(api.comparisonCampaigns.closeCampaign, {
-      campaignId: imported.campaignId,
-    });
     await expect(asGuest.mutation(api.comparisonCampaigns.submitChoice, {
       sessionToken,
       position: 5,

--- a/convex/tests/verdictReviewCampaigns.test.ts
+++ b/convex/tests/verdictReviewCampaigns.test.ts
@@ -1,0 +1,283 @@
+/// <reference types="vite/client" />
+import { convexTest } from "convex-test";
+import { describe, expect, test } from "vitest";
+import { api } from "../_generated/api";
+import type { Id } from "../_generated/dataModel";
+import schema from "../schema";
+import {
+  normalizeJeevesClogRun,
+  type AgentRunTrace,
+  type JeevesClogRunExport,
+} from "../lib/agentTrace";
+
+const asJson = <T>(value: T): T => JSON.parse(JSON.stringify(value)) as T;
+
+type TestIdentity = ReturnType<ReturnType<typeof convexTest>["withIdentity"]>;
+
+function run(runId: string, answer: string): JeevesClogRunExport {
+  return {
+    run_id: runId,
+    product: "support",
+    harness: { name: "pi", version: "3", sdk: "pi_session_jsonl" },
+    model: "claude-sonnet",
+    steps: [
+      { type: "message", role: "user", content: `Handle ${runId}` },
+      { type: "message", role: "assistant", content: answer },
+    ],
+    final_answer: answer,
+    usage: { total_tokens: 100 },
+  };
+}
+
+async function persist(
+  identity: TestIdentity,
+  projectId: Id<"projects">,
+  value: JeevesClogRunExport,
+): Promise<Id<"agentTraces">> {
+  const result = await identity.action(api.agentTraces.persistTrace, {
+    projectId,
+    trace: asJson(normalizeJeevesClogRun(value)) as unknown as AgentRunTrace,
+  });
+  return result.agentTraceId;
+}
+
+async function seed() {
+  const t = convexTest(schema);
+  const ids = await t.run(async (ctx) => {
+    const owner = await ctx.db.insert("users", { name: "Owner", email: "owner@test.com" });
+    const guest1 = await ctx.db.insert("users", { name: "Guest 1", isAnonymous: true });
+    const guest2 = await ctx.db.insert("users", { name: "Guest 2", isAnonymous: true });
+    const orgId = await ctx.db.insert("organizations", {
+      name: "Org",
+      slug: "org",
+      createdById: owner,
+    });
+    await ctx.db.insert("organizationMembers", {
+      organizationId: orgId,
+      userId: owner,
+      role: "owner",
+    });
+    const projectId = await ctx.db.insert("projects", {
+      organizationId: orgId,
+      name: "Support quality",
+      createdById: owner,
+    });
+    await ctx.db.insert("projectCollaborators", {
+      projectId,
+      userId: owner,
+      role: "owner",
+      invitedById: owner,
+      invitedAt: Date.now(),
+    });
+    return { owner, guest1, guest2, projectId };
+  });
+  const identity = (userId: Id<"users">) => t.withIdentity({
+    subject: `${userId}|session`,
+    tokenIdentifier: `test|${userId}`,
+  });
+  return {
+    t,
+    ids,
+    asOwner: identity(ids.owner),
+    asGuest1: identity(ids.guest1),
+    asGuest2: identity(ids.guest2),
+  };
+}
+
+describe("verdict review campaigns", () => {
+  test("creates one opaque no-account batch review and keeps reviewer decisions independent", async () => {
+    const { t, ids, asOwner, asGuest1, asGuest2 } = await seed();
+    const first = await persist(asOwner, ids.projectId, run("case-1", "First answer"));
+    const second = await persist(asOwner, ids.projectId, run("case-2", "Second answer"));
+
+    const campaignId = await asOwner.mutation(api.verdictReviewCampaigns.create, {
+      projectId: ids.projectId,
+      name: "Support run review",
+      instructions: "Check correctness and policy compliance.",
+      traceIds: [first, second],
+    });
+    const ownerView = await asOwner.query(api.verdictReviewCampaigns.getOwnerCampaign, {
+      campaignId,
+    });
+    expect(ownerView).toMatchObject({
+      name: "Support run review",
+      status: "draft",
+      itemCount: 2,
+      instructions: "Check correctness and policy compliance.",
+      results: { judgments: 0, reviewers: 0, reviewedRuns: 0 },
+    });
+
+    await asOwner.mutation(api.verdictReviewCampaigns.openCampaign, { campaignId });
+    const firstSession = await asGuest1.mutation(api.verdictReviewCampaigns.joinCampaign, {
+      shareToken: ownerView.shareToken,
+      displayName: "Reviewer One",
+    });
+    const secondSession = await asGuest2.mutation(api.verdictReviewCampaigns.joinCampaign, {
+      shareToken: ownerView.shareToken,
+      displayName: "Reviewer Two",
+    });
+    expect(firstSession.sessionToken).not.toBe(secondSession.sessionToken);
+    expect(firstSession.sessionToken).not.toBe(ownerView.shareToken);
+
+    const reviewerState = await asGuest1.query(api.verdictReviewCampaigns.getReview, {
+      sessionToken: firstSession.sessionToken,
+    });
+    expect(reviewerState).toMatchObject({
+      title: "Blind run review",
+      instructions: "Check correctness and policy compliance.",
+      progress: { judged: 0, total: 2 },
+      complete: false,
+    });
+    const serialized = JSON.stringify(reviewerState);
+    expect(serialized).not.toContain(first);
+    expect(serialized).not.toContain(second);
+    expect(serialized).not.toContain("claude-sonnet");
+    expect(serialized).not.toContain("pi_session_jsonl");
+    expect(serialized).not.toContain(ids.projectId);
+
+    const trace = await asGuest1.query(api.agentTraceReviewSessions.getTrace, {
+      token: firstSession.sessionToken,
+    });
+    expect(trace).not.toHaveProperty("model");
+    expect(trace).not.toHaveProperty("harnessName");
+    await asGuest1.mutation(api.agentTraceReviewSessions.addComment, {
+      token: firstSession.sessionToken,
+      target: { kind: "step", stepIndex: 1 },
+      comment: "The answer skips the refund rule.",
+      label: "issue",
+      tags: ["accuracy"],
+    });
+    await asGuest1.mutation(api.agentTraceReviewSessions.setVerdict, {
+      token: firstSession.sessionToken,
+      rating: "weak",
+      note: "Policy miss.",
+    });
+    expect((await asGuest1.query(api.verdictReviewCampaigns.getReview, {
+      sessionToken: firstSession.sessionToken,
+    })).progress.judged).toBe(1);
+    await asGuest1.mutation(api.agentTraceReviewSessions.setVerdict, {
+      token: firstSession.sessionToken,
+      rating: "acceptable",
+    });
+
+    await asGuest2.mutation(api.agentTraceReviewSessions.setVerdict, {
+      token: secondSession.sessionToken,
+      rating: "best",
+      note: "Looks correct.",
+    });
+    await asGuest2.mutation(api.agentTraceReviewSessions.setVerdict, {
+      token: secondSession.sessionToken,
+      rating: "acceptable",
+    });
+
+    const results = await asOwner.query(api.verdictReviewCampaigns.getOwnerCampaign, {
+      campaignId,
+    });
+    expect(results.results).toMatchObject({
+      judgments: 4,
+      reviewers: 2,
+      reviewedRuns: 2,
+      best: 1,
+      acceptable: 2,
+      weak: 1,
+    });
+    expect(results.results.disagreementRuns).toBeGreaterThan(0);
+    expect(results.comments).toMatchObject([{
+      reviewerName: "Reviewer One",
+      comment: "The answer skips the refund rule.",
+      target: { kind: "step", stepIndex: 1 },
+    }]);
+
+    const decisions = await t.run(async (ctx) =>
+      ctx.db.query("verdictReviewDecisions").collect(),
+    );
+    expect(decisions).toHaveLength(4);
+    expect(new Set(decisions.map((decision) => decision.userId)).size).toBe(2);
+    expect(await t.run(async (ctx) =>
+      ctx.db.query("projectCollaborators").withIndex("by_user", (q) =>
+        q.eq("userId", ids.guest1),
+      ).collect(),
+    )).toEqual([]);
+  });
+
+  test("closed strong consensus becomes an SFT row and an idempotent regression case", async () => {
+    const { ids, asOwner, asGuest1, asGuest2 } = await seed();
+    const traceId = await persist(asOwner, ids.projectId, run("case-approved", "Approved answer"));
+    const campaignId = await asOwner.mutation(api.verdictReviewCampaigns.create, {
+      projectId: ids.projectId,
+      name: "Approved run",
+      traceIds: [traceId],
+    });
+    const ownerView = await asOwner.query(api.verdictReviewCampaigns.getOwnerCampaign, {
+      campaignId,
+    });
+    await asOwner.mutation(api.verdictReviewCampaigns.openCampaign, { campaignId });
+    for (const [identity, displayName] of [[asGuest1, "One"], [asGuest2, "Two"]] as const) {
+      const { sessionToken } = await identity.mutation(api.verdictReviewCampaigns.joinCampaign, {
+        shareToken: ownerView.shareToken,
+        displayName,
+      });
+      await identity.mutation(api.agentTraceReviewSessions.setVerdict, {
+        token: sessionToken,
+        rating: "best",
+      });
+    }
+    await asOwner.mutation(api.verdictReviewCampaigns.closeCampaign, { campaignId });
+
+    const promoted = await asOwner.mutation(api.verdictReviewCampaigns.promoteAcceptedRuns, {
+      campaignId,
+    });
+    expect(promoted).toEqual({ added: 1, alreadyPresent: 0, excluded: 0 });
+    expect(await asOwner.mutation(api.verdictReviewCampaigns.promoteAcceptedRuns, {
+      campaignId,
+    })).toEqual({ added: 0, alreadyPresent: 1, excluded: 0 });
+
+    const exported = await asOwner.action(api.exports.generateExport, {
+      projectId: ids.projectId,
+      verdictCampaignId: campaignId,
+      source: "trajectory",
+      format: "sft",
+    });
+    expect(exported).toMatchObject({ rowCount: 1, excludedCount: 0 });
+    expect(exported.manifest).toMatchObject({
+      format: "sft",
+      source_units: 1,
+      reviewers: 2,
+    });
+  });
+
+  test("rejects owner self-review, closes submissions, and resumes a guest idempotently", async () => {
+    const { ids, asOwner, asGuest1 } = await seed();
+    const traceId = await persist(asOwner, ids.projectId, run("case-1", "Answer"));
+    const campaignId = await asOwner.mutation(api.verdictReviewCampaigns.create, {
+      projectId: ids.projectId,
+      name: "Policy review",
+      traceIds: [traceId],
+    });
+    const ownerView = await asOwner.query(api.verdictReviewCampaigns.getOwnerCampaign, {
+      campaignId,
+    });
+    await asOwner.mutation(api.verdictReviewCampaigns.openCampaign, { campaignId });
+
+    await expect(asOwner.mutation(api.verdictReviewCampaigns.joinCampaign, {
+      shareToken: ownerView.shareToken,
+      displayName: "Owner",
+    })).rejects.toThrow(/guest window/i);
+
+    const joined = await asGuest1.mutation(api.verdictReviewCampaigns.joinCampaign, {
+      shareToken: ownerView.shareToken,
+      displayName: "Guest",
+    });
+    const resumed = await asGuest1.mutation(api.verdictReviewCampaigns.joinCampaign, {
+      shareToken: ownerView.shareToken,
+      displayName: "Guest",
+    });
+    expect(resumed.sessionToken).toBe(joined.sessionToken);
+
+    await asOwner.mutation(api.verdictReviewCampaigns.closeCampaign, { campaignId });
+    await expect(asGuest1.mutation(api.agentTraceReviewSessions.setVerdict, {
+      token: joined.sessionToken,
+      rating: "acceptable",
+    })).rejects.toThrow(/closed|expired/i);
+  });
+});

--- a/convex/verdictReviewCampaigns.ts
+++ b/convex/verdictReviewCampaigns.ts
@@ -1,0 +1,454 @@
+/** No-account blind verdict campaigns over one or more imported runs. */
+import { v } from "convex/values";
+import { mutation, query, type MutationCtx, type QueryCtx } from "./_generated/server";
+import type { Doc, Id } from "./_generated/dataModel";
+import { requireAuth, requireProjectRole } from "./lib/auth";
+import { generateToken } from "./lib/crypto";
+import { fisherYatesShuffle } from "./lib/shuffle";
+
+const MAX_ITEMS = 50;
+type ReadCtx = QueryCtx | MutationCtx;
+
+/** Resolve a user-bound verdict campaign session and enforce its lifecycle. */
+export async function resolveVerdictCampaignSession(
+  ctx: ReadCtx,
+  token: string,
+  options: { readonly requireOpen: boolean },
+): Promise<{
+  readonly userId: Id<"users">;
+  readonly session: Doc<"agentTraceReviewSessions">;
+  readonly campaign: Doc<"verdictReviewCampaigns">;
+}> {
+  const userId = await requireAuth(ctx);
+  const session = await ctx.db
+    .query("agentTraceReviewSessions")
+    .withIndex("by_token", (q) => q.eq("token", token))
+    .unique();
+  if (
+    !session ||
+    session.reviewerUserId !== userId ||
+    session.kind !== "verdict_campaign" ||
+    session.verdictCampaignId === undefined
+  ) {
+    throw new Error("Review session not found or expired.");
+  }
+  const campaign = await ctx.db.get(session.verdictCampaignId);
+  if (!campaign || campaign.projectId !== session.projectId) {
+    throw new Error("Review session not found or expired.");
+  }
+  if (options.requireOpen && campaign.status !== "open") {
+    throw new Error("This review is closed.");
+  }
+  return { userId, session, campaign };
+}
+
+/** Return the active trace and item without exposing either identifier to clients. */
+export async function activeVerdictReviewItem(
+  ctx: ReadCtx,
+  session: Doc<"agentTraceReviewSessions">,
+): Promise<{
+  readonly trace: Doc<"agentTraces">;
+  readonly item: Doc<"verdictReviewItems">;
+} | null> {
+  if (session.kind !== "verdict_campaign" || session.verdictCampaignId === undefined) {
+    return null;
+  }
+  const campaignId = session.verdictCampaignId;
+  const order = session.traceOrder ?? [];
+  const index = session.currentIndex ?? 0;
+  const traceId = order[index];
+  if (traceId === undefined) return null;
+  const [trace, item] = await Promise.all([
+    ctx.db.get(traceId),
+    ctx.db
+      .query("verdictReviewItems")
+      .withIndex("by_campaign_and_trace", (q) =>
+        q.eq("campaignId", campaignId).eq("agentTraceId", traceId),
+      )
+      .unique(),
+  ]);
+  if (!trace || !item || trace.projectId !== session.projectId) {
+    throw new Error("Review run is no longer available.");
+  }
+  return { trace, item };
+}
+
+/** Create a draft verdict review over up to fifty ready runs. */
+export const create = mutation({
+  args: {
+    projectId: v.id("projects"),
+    name: v.string(),
+    instructions: v.optional(v.string()),
+    traceIds: v.array(v.id("agentTraces")),
+  },
+  handler: async (ctx, args): Promise<Id<"verdictReviewCampaigns">> => {
+    const { userId } = await requireProjectRole(ctx, args.projectId, ["owner", "editor"]);
+    const name = args.name.trim();
+    if (!name) throw new Error("Add a review name.");
+    const seenTraceIds = new Set<string>();
+    const traceIds = args.traceIds.filter((traceId) => {
+      const key = String(traceId);
+      if (seenTraceIds.has(key)) return false;
+      seenTraceIds.add(key);
+      return true;
+    });
+    if (traceIds.length === 0) throw new Error("Select at least one run to review.");
+    if (traceIds.length > MAX_ITEMS) {
+      throw new Error(`Select at most ${MAX_ITEMS} runs per review.`);
+    }
+    for (const traceId of traceIds) {
+      const trace = await ctx.db.get(traceId);
+      if (!trace || trace.projectId !== args.projectId || trace.status !== "ready") {
+        throw new Error("Every selected run must be ready and belong to this project.");
+      }
+    }
+    const instructions = args.instructions?.trim().slice(0, 2_000) || undefined;
+    const campaignId = await ctx.db.insert("verdictReviewCampaigns", {
+      projectId: args.projectId,
+      name: name.slice(0, 120),
+      instructions,
+      status: "draft",
+      shareToken: generateToken(),
+      itemCount: traceIds.length,
+      judgmentCount: 0,
+      createdById: userId,
+      createdAt: Date.now(),
+    });
+    for (let sortOrder = 0; sortOrder < traceIds.length; sortOrder++) {
+      const agentTraceId = traceIds[sortOrder];
+      if (agentTraceId === undefined) continue;
+      await ctx.db.insert("verdictReviewItems", {
+        campaignId,
+        projectId: args.projectId,
+        agentTraceId,
+        sortOrder,
+      });
+    }
+    return campaignId;
+  },
+});
+
+/** List verdict reviews for the unified owner Reviews/Results surfaces. */
+export const listCampaigns = query({
+  args: { projectId: v.id("projects") },
+  handler: async (ctx, args) => {
+    await requireProjectRole(ctx, args.projectId, ["owner", "editor"]);
+    const campaigns = await ctx.db
+      .query("verdictReviewCampaigns")
+      .withIndex("by_project", (q) => q.eq("projectId", args.projectId))
+      .order("desc")
+      .take(100);
+    return await Promise.all(
+      campaigns.map(async (campaign) => {
+        const decisions = await ctx.db
+          .query("verdictReviewDecisions")
+          .withIndex("by_campaign", (q) => q.eq("campaignId", campaign._id))
+          .collect();
+        return {
+          id: campaign._id,
+          mode: "verdict" as const,
+          name: campaign.name,
+          status: campaign.status,
+          itemCount: campaign.itemCount,
+          reviewedRuns: new Set(decisions.map((decision) => String(decision.itemId))).size,
+          reviewers: new Set(decisions.map((decision) => String(decision.userId))).size,
+          judgments: decisions.length,
+          createdAt: campaign.createdAt,
+        };
+      }),
+    );
+  },
+});
+
+/** Owner/editor campaign summary with reviewer identity and source provenance. */
+export const getOwnerCampaign = query({
+  args: { campaignId: v.id("verdictReviewCampaigns") },
+  handler: async (ctx, args) => {
+    const campaign = await ctx.db.get(args.campaignId);
+    if (!campaign) throw new Error("Review not found.");
+    await requireProjectRole(ctx, campaign.projectId, ["owner", "editor"]);
+    const [items, decisions, sessions, regressionCases] = await Promise.all([
+      ctx.db
+        .query("verdictReviewItems")
+        .withIndex("by_campaign", (q) => q.eq("campaignId", campaign._id))
+        .collect(),
+      ctx.db
+        .query("verdictReviewDecisions")
+        .withIndex("by_campaign", (q) => q.eq("campaignId", campaign._id))
+        .collect(),
+      ctx.db
+        .query("agentTraceReviewSessions")
+        .withIndex("by_verdict_campaign_and_reviewer", (q) =>
+          q.eq("verdictCampaignId", campaign._id),
+        )
+        .collect(),
+      ctx.db
+        .query("regressionCases")
+        .withIndex("by_campaign", (q) => q.eq("verdictCampaignId", campaign._id))
+        .collect(),
+    ]);
+    const displayNameByUser = new Map(
+      sessions.map((session) => [String(session.reviewerUserId), session.reviewerDisplayName]),
+    );
+    const reviewerIds = new Set(decisions.map((decision) => String(decision.userId)));
+    const reviewerNameById = new Map<string, string>();
+    for (const reviewerId of reviewerIds) {
+      const id = decisions.find((decision) => String(decision.userId) === reviewerId)?.userId;
+      if (id === undefined) continue;
+      const user = await ctx.db.get(id);
+      reviewerNameById.set(
+        reviewerId,
+        displayNameByUser.get(reviewerId)?.trim() || user?.name?.trim() || "Guest reviewer",
+      );
+    }
+
+    const decisionsByItem = new Map<string, Array<Doc<"verdictReviewDecisions">>>();
+    for (const decision of decisions) {
+      const key = String(decision.itemId);
+      const rows = decisionsByItem.get(key) ?? [];
+      rows.push(decision);
+      decisionsByItem.set(key, rows);
+    }
+    let disagreementRuns = 0;
+    for (const rows of decisionsByItem.values()) {
+      if (new Set(rows.map((row) => row.rating)).size > 1) disagreementRuns++;
+    }
+    const runs: Array<{
+      readonly traceId: Id<"agentTraces">;
+      readonly product: string;
+      readonly harness: string;
+      readonly model?: string;
+      readonly judgments: number;
+    }> = [];
+    for (const item of items) {
+      const trace = await ctx.db.get(item.agentTraceId);
+      if (!trace) continue;
+      runs.push({
+        traceId: trace._id,
+        product: trace.product,
+        harness: trace.harnessName,
+        model: trace.model,
+        judgments: decisionsByItem.get(String(item._id))?.length ?? 0,
+      });
+    }
+
+    const comments: Array<{
+      readonly reviewerName: string;
+      readonly comment: string;
+      readonly target: Doc<"agentTraceComments">["target"];
+      readonly traceId: Id<"agentTraces">;
+    }> = [];
+    for (const item of items) {
+      const rows = await ctx.db
+        .query("agentTraceComments")
+        .withIndex("by_trace", (q) => q.eq("agentTraceId", item.agentTraceId))
+        .collect();
+      for (const row of rows) {
+        if (row.verdictCampaignId !== campaign._id) continue;
+        comments.push({
+          reviewerName: reviewerNameById.get(String(row.userId)) ?? "Guest reviewer",
+          comment: row.comment,
+          target: row.target,
+          traceId: row.agentTraceId,
+        });
+      }
+    }
+
+    return {
+      id: campaign._id,
+      projectId: campaign.projectId,
+      name: campaign.name,
+      instructions: campaign.instructions,
+      status: campaign.status,
+      shareToken: campaign.shareToken,
+      itemCount: items.length,
+      reviewerNames: [...reviewerNameById.values()].sort((left, right) =>
+        left.localeCompare(right),
+      ),
+      regressionCount: regressionCases.length,
+      runs,
+      comments,
+      results: {
+        judgments: decisions.length,
+        reviewers: reviewerIds.size,
+        reviewedRuns: decisionsByItem.size,
+        best: decisions.filter((decision) => decision.rating === "best").length,
+        acceptable: decisions.filter((decision) => decision.rating === "acceptable").length,
+        weak: decisions.filter((decision) => decision.rating === "weak").length,
+        disagreementRuns,
+      },
+    };
+  },
+});
+
+/** Open a draft verdict review and return its share token. */
+export const openCampaign = mutation({
+  args: { campaignId: v.id("verdictReviewCampaigns") },
+  handler: async (ctx, args) => {
+    const campaign = await ctx.db.get(args.campaignId);
+    if (!campaign) throw new Error("Review not found.");
+    await requireProjectRole(ctx, campaign.projectId, ["owner", "editor"]);
+    if (campaign.status !== "draft" && campaign.status !== "open") {
+      throw new Error("Only a draft review can be opened.");
+    }
+    if (campaign.status === "draft") {
+      await ctx.db.patch(campaign._id, { status: "open", openedAt: Date.now() });
+    }
+    return { shareToken: campaign.shareToken };
+  },
+});
+
+/** Close a verdict review while preserving every submitted judgment. */
+export const closeCampaign = mutation({
+  args: { campaignId: v.id("verdictReviewCampaigns") },
+  handler: async (ctx, args) => {
+    const campaign = await ctx.db.get(args.campaignId);
+    if (!campaign) throw new Error("Review not found.");
+    await requireProjectRole(ctx, campaign.projectId, ["owner", "editor"]);
+    if (campaign.status !== "open" && campaign.status !== "closed") {
+      throw new Error("Only an open review can be closed.");
+    }
+    if (campaign.status === "open") {
+      await ctx.db.patch(campaign._id, { status: "closed", closedAt: Date.now() });
+    }
+    return { closed: true };
+  },
+});
+
+/** Promote majority-approved runs from a closed review into the regression corpus. */
+export const promoteAcceptedRuns = mutation({
+  args: { campaignId: v.id("verdictReviewCampaigns") },
+  handler: async (ctx, args) => {
+    const campaign = await ctx.db.get(args.campaignId);
+    if (!campaign) throw new Error("Review not found.");
+    const { userId } = await requireProjectRole(ctx, campaign.projectId, [
+      "owner",
+      "editor",
+    ]);
+    if (campaign.status !== "closed") {
+      throw new Error("Close the review before promoting regression cases.");
+    }
+    const items = await ctx.db
+      .query("verdictReviewItems")
+      .withIndex("by_campaign", (q) => q.eq("campaignId", campaign._id))
+      .collect();
+    let added = 0;
+    let alreadyPresent = 0;
+    let excluded = 0;
+    for (const item of items) {
+      const decisions = await ctx.db
+        .query("verdictReviewDecisions")
+        .withIndex("by_item", (q) => q.eq("itemId", item._id))
+        .collect();
+      const approved = decisions.filter(
+        (decision) => decision.rating === "best" || decision.rating === "acceptable",
+      ).length;
+      const weak = decisions.filter((decision) => decision.rating === "weak").length;
+      if (decisions.length === 0 || approved <= weak) {
+        excluded++;
+        continue;
+      }
+      const existing = await ctx.db
+        .query("regressionCases")
+        .withIndex("by_project_and_trace", (q) =>
+          q.eq("projectId", campaign.projectId).eq("agentTraceId", item.agentTraceId),
+        )
+        .unique();
+      if (existing) {
+        alreadyPresent++;
+        continue;
+      }
+      await ctx.db.insert("regressionCases", {
+        projectId: campaign.projectId,
+        agentTraceId: item.agentTraceId,
+        verdictCampaignId: campaign._id,
+        createdById: userId,
+        createdAt: Date.now(),
+      });
+      added++;
+    }
+    return { added, alreadyPresent, excluded };
+  },
+});
+
+/** Redeem a public share token for one stable, reviewer-bound opaque session. */
+export const joinCampaign = mutation({
+  args: { shareToken: v.string(), displayName: v.string() },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx);
+    const campaign = await ctx.db
+      .query("verdictReviewCampaigns")
+      .withIndex("by_share_token", (q) => q.eq("shareToken", args.shareToken))
+      .unique();
+    if (!campaign || campaign.status !== "open") {
+      throw new Error("This review is not open.");
+    }
+    const collaborator = await ctx.db
+      .query("projectCollaborators")
+      .withIndex("by_project_and_user", (q) =>
+        q.eq("projectId", campaign.projectId).eq("userId", userId),
+      )
+      .unique();
+    if (collaborator?.role === "owner" || collaborator?.role === "editor") {
+      throw new Error("Open this review link in a guest window to preserve blinding.");
+    }
+    const displayName = args.displayName.trim().slice(0, 80);
+    if (!displayName) throw new Error("Add your display name before starting.");
+    const existing = await ctx.db
+      .query("agentTraceReviewSessions")
+      .withIndex("by_verdict_campaign_and_reviewer", (q) =>
+        q.eq("verdictCampaignId", campaign._id).eq("reviewerUserId", userId),
+      )
+      .unique();
+    if (existing) {
+      if (existing.reviewerDisplayName !== displayName) {
+        await ctx.db.patch(existing._id, { reviewerDisplayName: displayName });
+      }
+      return { sessionToken: existing.token };
+    }
+    const items = await ctx.db
+      .query("verdictReviewItems")
+      .withIndex("by_campaign", (q) => q.eq("campaignId", campaign._id))
+      .collect();
+    if (items.length === 0) throw new Error("This review has no runs.");
+    const token = generateToken();
+    await ctx.db.insert("agentTraceReviewSessions", {
+      projectId: campaign.projectId,
+      reviewerUserId: userId,
+      token,
+      kind: "verdict_campaign",
+      verdictCampaignId: campaign._id,
+      reviewerDisplayName: displayName,
+      traceOrder: fisherYatesShuffle(items).map((item) => item.agentTraceId),
+      currentIndex: 0,
+      visibleCount: items.length,
+    });
+    return { sessionToken: token };
+  },
+});
+
+/** Reviewer-safe campaign progress; run and project identifiers never cross the wire. */
+export const getReview = query({
+  args: { sessionToken: v.string() },
+  handler: async (ctx, args) => {
+    const { userId, session, campaign } = await resolveVerdictCampaignSession(
+      ctx,
+      args.sessionToken,
+      { requireOpen: false },
+    );
+    const decisions = await ctx.db
+      .query("verdictReviewDecisions")
+      .withIndex("by_campaign_and_user", (q) =>
+        q.eq("campaignId", campaign._id).eq("userId", userId),
+      )
+      .collect();
+    const total = session.traceOrder?.length ?? campaign.itemCount;
+    return {
+      title: "Blind run review",
+      instructions: campaign.instructions,
+      status: campaign.status,
+      progress: { judged: decisions.length, total },
+      complete: decisions.length >= total || session.completedAt !== undefined,
+    };
+  },
+});

--- a/docs/canonical-demo-loop.md
+++ b/docs/canonical-demo-loop.md
@@ -5,14 +5,12 @@ it without understanding the whole platform.
 
 ## One path we lead with
 
+The product model and primary navigation are **Run → Review → Judgment → Result** and **Runs · Reviews · Results**.
+
 1. **Bring in completed runs** — mapped CSV, native `eval-record` v1, OTLP JSON or live OTLP, Pi session JSONL, Claude Code JSONL, Gateway logs, or another thin adapter. The adapter choice is not the story; every path normalizes into the same agent-trace spine.
-2. **Send one blind review link** — a domain expert opens the run or matchup
-   without version/model/harness provenance. For trajectories, the promise is
-   bias reduction, not perfect anonymity.
-3. **Get a verdict** — rating, step comment, or A/B next-action choice. Optimize
-   for time-to-verdict over full-trace inspection.
-4. **Route it back** — use the verdict as a regression case, training export
-   row, or cited revision input.
+2. **Create one review** — choose only **Score runs** or **Compare attempts**, select runs, confirm reviewer guidance and blind preview, then open and share one opaque link.
+3. **Get a judgment** — a domain expert sees run context/outcome/steps without owner-visible version/model/harness provenance, then submits a verdict, preference, or comment. For multi-step runs, the promise is bias reduction, not perfect anonymity.
+4. **Use the result** — after closing the review, copy an evidence summary, promote eligible regression cases, or export eligible SFT/DPO rows. Every ineligible row is counted and explained.
 
 ## Guardrails
 
@@ -30,7 +28,7 @@ it without understanding the whole platform.
 
 The loop is activated when a workspace completes:
 
-`agent run imported → blind review opened → verdict/comment submitted → result reused`
+`run imported → review created/opened → opaque link opened → judgment submitted → review closed → result reused`
 
 Until this is repeatable, new adapters and matrix features should be pilot- or
 demo-driven only.

--- a/playwright-ct.config.ts
+++ b/playwright-ct.config.ts
@@ -26,6 +26,10 @@ export default defineConfig({
             dir,
             "src/routes/traces/__smoke__/convexReactMock.tsx",
           ),
+          "@convex-dev/auth/react": resolve(
+            dir,
+            "src/routes/traces/__smoke__/convexAuthMock.ts",
+          ),
         },
       },
     },

--- a/project-docs/Blind Bench - Architecture.md
+++ b/project-docs/Blind Bench - Architecture.md
@@ -18,6 +18,17 @@ tags:
 
 ---
 
+## Current canonical product flow (M34)
+
+The primary product model is **Run → Review → Judgment → Result**.
+
+- A **Run** is any completed AI execution: a single response or a multi-step agent trace with messages and tool calls.
+- A **Review** selects runs, a rubric, and one of two owner-visible modes: **Score runs** or **Compare attempts**. Campaigns, sessions, items, matchups, and opaque tokens are storage/orchestration details, not separate product pillars.
+- A **Judgment** is a blind verdict, preference, annotation, or comment. Reviewer queries return blinded content only; provenance is joined back only on authenticated owner/editor result queries.
+- A **Result** aggregates coverage, distribution, disagreement, comments, and explicit reuse eligibility. Closed results may produce evidence summaries, regression cases, SFT rows, or comparable DPO rows with exclusion counts.
+
+The project shell exposes **Runs · Reviews · Results**. Imports and live sources support Runs; prompt versions, execution, variables, and test cases remain isolated under the secondary **Tools / Prompt playground** area. This section takes precedence over older prompt-first or review-cycle navigation descriptions below.
+
 ## Table of Contents
 
 1. [Overview](#overview)

--- a/project-docs/Blind Bench - Build Plan.md
+++ b/project-docs/Blind Bench - Build Plan.md
@@ -18,7 +18,7 @@ This doc expands the architecture doc's 10-bullet Next Steps into demoable miles
 
 The numbering starts at M0 to mirror "milestone zero = setup" conventions. Milestones are strictly sequential on the critical path except where the dependency graph below says otherwise.
 
-> **Milestone coverage note (2026-07-07).** This doc formally covers M0–M7, with a handful of later milestones (M21, M26, M29) retro-inserted where they earned a full spec. Milestones **M8–M30** are tracked in GH issues (the source of truth per `CLAUDE.md`) and the strategy docs; they are not backfilled here. This file resumes at **M31 — Trajectory Spine**, which formalizes the approved [[Blind Bench - Agent Trace Strategy]] (Noah, 2026-07-07).
+> **Milestone coverage note (2026-07-10).** This doc formally covers M0–M7, with a handful of later milestones (M21, M26, M29) retro-inserted where they earned a full spec. Milestones **M8–M30** are tracked in GH issues (the source of truth per `CLAUDE.md`) and the strategy docs; they are not backfilled here. This file resumes at **M31 — Trajectory Spine**, which formalizes the approved [[Blind Bench - Agent Trace Strategy]], and **M34 — Runs → Reviews → Results**, tracked by epic #333 and issues #345–#348.
 
 See also:
 - [[Blind Bench - Architecture#Next Steps]] — the short form of this doc
@@ -655,6 +655,21 @@ These carry forward from [[Blind Bench - Architecture#v1 Scope & Deferred]] so t
 - **CLI / CI-CD integrations**. Possible later because everything is a Convex function.
 - **Branching versions**. Linear only in v1; schema leaves room.
 - **External HTTP API**. Deferred — would be a thin `convex/http.ts` layer with `httpAction` wrappers.
+
+---
+
+## M34 — Runs → Reviews → Results (2026-07)
+
+**Goal:** make ingestion-first blind human review the obvious repeatable product loop while preserving the prompt playground as a secondary tool.
+
+**Critical path:**
+
+1. **P0 / #345:** reduce the project shell to Runs, Reviews, Results; move imports/sources and prompt execution beneath secondary Tools/settings surfaces; remove prompt-first onboarding and co-pilot pillars.
+2. **P1 / #346:** lead every successful import into one review builder with Score runs or Compare attempts, blind preview, opaque share link, and anonymous reviewer flow.
+3. **P2 / #347:** aggregate collecting/closed evidence in Results; show provenance only to owners; unlock evidence, regression, SFT, or DPO reuse only from eligible closed results with explicit exclusions.
+4. **P3 / #348:** preserve legacy URLs without presenting cycles/campaigns/sessions/matchups as primary concepts; align docs and canonical browser verification.
+
+**Release gate:** synthetic import → opaque anonymous review → judgment/comment → owner result → eligible reuse must pass without reviewer metadata leakage. Unit/component coverage does not replace the deployed two-principal check tracked in #339.
 
 ---
 

--- a/project-docs/Blind Bench - Glossary.md
+++ b/project-docs/Blind Bench - Glossary.md
@@ -153,9 +153,13 @@ A [[#Collaborator]] who can do everything an [[#Editor (role)]] can plus: invite
 
 The predecessor of a [[#Version]] in the linear version sequence. Stored on `promptVersions.parentVersionId`. Every non-initial version has a parent. Distinct from [[#Source version]] which tracks rollback origin.
 
+### Judgment
+
+One human decision made inside a blind [[#Review]]: a Strong / Acceptable / Weak run verdict, a directional paired preference, an annotation, or a comment. Judgment is the normalized product noun; decisions, preferences, verdict rows, and matchup choices are implementation-specific representations.
+
 ### Project
 
-A unit of prompt iteration owned by an [[#Organization]]. Contains versions, variables, test cases, meta context, collaborators, runs, feedback, and optimization requests. One prompt per project (conceptually) — multiple versions of the same prompt, not multiple independent prompts.
+An organization-owned workspace for related [[#Run|runs]], [[#Review|reviews]], and [[#Result|results]]. A project may also contain prompt versions, variables, test cases, meta context, collaborators, and optimization requests, but prompt iteration is a secondary tool rather than the universal project definition.
 
 ### Project variable
 
@@ -172,9 +176,17 @@ Type is set at creation and immutable. See [[Blind Bench - Architecture#Template
 
 An [[#Annotation]] on a specific range of a [[#Version]]'s system message or user template. Distinct from [[#Output feedback]]. Feeds the [[#Optimizer meta-prompt]] alongside output feedback. Evaluators cannot leave prompt feedback (they don't see the prompt).
 
+### Result
+
+The owner/editor aggregate produced by a [[#Review]]. A result reports judgment coverage, verdict or preference distribution, disagreement, comments, and provenance. Once closed and eligible, it is the context for copying evidence, promoting regression cases, or exporting SFT/DPO data. It is not a synonym for an individual model output.
+
+### Review
+
+A bounded request for blind human [[#Judgment|judgment]] over selected [[#Run|runs]]. The two user-facing modes are **Score runs** and **Compare attempts**. Campaigns, cycles, reviewer sessions, items, and matchups are implementation or legacy compatibility terms, not primary navigation nouns.
+
 ### Reviewer
 
-User-facing label for a [[#Collaborator]] with `role === "evaluator"`. Two flavors, distinguished by [[#Blind Mode]]:
+User-facing label for a [[#Collaborator]] with `role === "evaluator"`, or for an anonymous participant entering through an opaque review link. Authenticated legacy review has two flavors, distinguished by [[#Blind Mode]]:
 
 - **Reviewer (open)** — `blindMode === false`. Sees the prompt, model, and peer comments. Primary persona: non-technical stakeholder (PM, legal, domain expert). Lands on `/review/:projectId`. Can leave [[#Prompt feedback]] and [[#Output feedback]] but cannot edit, run, or trigger optimization.
 - **Reviewer (blind)** — `blindMode === true` or absent. Today's `Evaluator (role)` behavior. Sees only A/B/C-labeled outputs in a session. Lands on `/eval`.
@@ -191,7 +203,7 @@ The product boundary in which Blind Bench does not execute arbitrary customer ha
 
 ### Run
 
-One execution of a specific [[#Version]] against a specific [[#Test case]] at a specific model configuration (model, temperature, max tokens). Produces `runCount` [[#Output]]s via [[#Fan-out]]. Runs are the unit of comparison: running the same test case against v1/v2/v3 is the primitive for "is v2 actually better than v1?".
+The universal product noun for one completed AI execution. A run may be a single prompt/response or a multi-step agent execution containing conversation turns, tool calls, and outcomes. It may be imported from an external runtime or produced by the secondary prompt playground. `agentTraces`, prompt `runs`, and paired candidates are storage/execution representations of this product concept.
 
 ### Source version
 

--- a/project-docs/Blind Bench - Positioning One-Pager.md
+++ b/project-docs/Blind Bench - Positioning One-Pager.md
@@ -37,10 +37,11 @@ randomized, blinded human tests) is the one no platform ships.
   CX lead for a support agent, the senior engineer for a coding-agent trace.
   No-account, link-based review; plain-language surfaces; minutes, not an
   engineer-mediated CSV export.
-- **The unit of review is the change, not the run.** Review Cycles compare
-  candidate against control on the same cases, blind, and roll preferences up
-  to standings. The question answered is the one that matters: *did it get
-  better?*
+- **One loop for outputs and agents.** A Run is either one response or a
+  multi-step agent execution. Owners create a blind Review to **Score runs** or
+  **Compare attempts**; human Judgment rolls up into a Result with coverage,
+  disagreement, and explicit reuse eligibility. The question stays practical:
+  *is this good enough, and did it get better?*
 - **Judgment flows somewhere.** Ratings and comments re-attach to trace IDs,
   promote to regression sets and training data (SFT/DPO), and feed prompt
   revisions that cite the specific reviewer comments they address — never a

--- a/project-docs/Blind Bench - UX Spec.md
+++ b/project-docs/Blind Bench - UX Spec.md
@@ -21,6 +21,17 @@ Vocabulary is locked in [[Blind Bench - Glossary]]. If a term here doesn't match
 
 ---
 
+## M34 canonical experience
+
+The owner journey is **Run → Review → Judgment → Result** and the primary project navigation is exactly **Runs · Reviews · Results**.
+
+1. **Runs:** import completed flat outputs or multi-step agent traces. Import success leads with **Create blind review**.
+2. **Reviews:** one builder exposes only **Score runs** and **Compare attempts**, then selected runs, reviewer guidance, blind preview, and share controls. Review cycles, campaigns, sessions, and matchups may remain in URLs or data models for compatibility but are not primary user vocabulary.
+3. **Judgment:** an opaque link lets a reviewer judge blind content without source/model/harness provenance. Run context, outcome, and steps appear before verdict controls.
+4. **Results:** collecting and closed reviews share one owner surface. It reports coverage, verdict/preference distribution, disagreement, and comments. Provenance and evidence/regression/training reuse appear only to authorized owners/editors; unavailable reuse actions state their prerequisites.
+
+Imports, live sources, and Gateway setup are secondary support surfaces. Versions, variables, test cases, prompt execution, and history live under **Tools / Prompt playground**. The standalone Export destination redirects to Results. This section supersedes older prompt-first sitemap and cycle/phase terminology below.
+
 ## Table of contents
 
 1. [Design principles](#1-design-principles)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -51,9 +51,11 @@ const CycleCreator = lazy(() => import("./routes/orgs/projects/cycles/CycleCreat
 const CycleDetail = lazy(() => import("./routes/orgs/projects/cycles/CycleDetail").then(m => ({ default: m.CycleDetail })));
 const VersionDashboard = lazy(() => import("./routes/orgs/projects/cycles/VersionDashboard").then(m => ({ default: m.VersionDashboard })));
 const EvaluatePage = lazy(() => import("./routes/orgs/projects/EvaluatePage").then(m => ({ default: m.EvaluatePage })));
-const ExportTraining = lazy(() => import("./routes/orgs/projects/ExportTraining").then(m => ({ default: m.ExportTraining })));
 const ComparisonCampaignNew = lazy(() => import("./routes/orgs/projects/ComparisonCampaignNew").then(m => ({ default: m.ComparisonCampaignNew })));
 const ComparisonCampaignDetail = lazy(() => import("./routes/orgs/projects/ComparisonCampaignDetail").then(m => ({ default: m.ComparisonCampaignDetail })));
+const ReviewBuilder = lazy(() => import("./routes/orgs/projects/ReviewBuilder").then(m => ({ default: m.ReviewBuilder })));
+const VerdictReviewDetail = lazy(() => import("./routes/orgs/projects/VerdictReviewDetail").then(m => ({ default: m.VerdictReviewDetail })));
+const VerdictReview = lazy(() => import("./routes/review/VerdictReview").then(m => ({ default: m.VerdictReview })));
 const ReviewResults = lazy(() => import("./routes/orgs/projects/ReviewResults").then(m => ({ default: m.ReviewResults })));
 const IngestEndpoint = lazy(() => import("./routes/orgs/projects/IngestEndpoint").then(m => ({ default: m.IngestEndpoint })));
 const ImportRuns = lazy(() => import("./routes/orgs/projects/ImportRuns").then(m => ({ default: m.ImportRuns })));
@@ -79,6 +81,7 @@ export function App() {
         <Route path="/compare" element={<QuickCompare />} />
         <Route path="/review/demo" element={<ReviewDemo />} />
         <Route path="/review/campaign/:shareToken" element={<ComparisonReview />} />
+        <Route path="/review/verdict/:shareToken" element={<VerdictReview />} />
         <Route path="/invite/:token" element={<InviteLanding />} />
         <Route path="/legal/terms" element={<Terms />} />
         <Route path="/legal/privacy" element={<Privacy />} />
@@ -132,10 +135,12 @@ export function App() {
                 element={<CycleDetail />}
               />
               <Route path="evaluate" element={<EvaluatePage />} />
+              <Route path="reviews/new" element={<ReviewBuilder />} />
+              <Route path="reviews/verdict/:campaignId" element={<VerdictReviewDetail />} />
               <Route path="results" element={<ReviewResults />} />
               <Route path="comparisons/new" element={<ComparisonCampaignNew />} />
               <Route path="comparisons/:campaignId" element={<ComparisonCampaignDetail />} />
-              <Route path="export" element={<ExportTraining />} />
+              <Route path="export" element={<Navigate to="../results" replace />} />
               <Route path="ingest" element={<IngestEndpoint />} />
               <Route path="traces" element={<TraceList />} />
               <Route

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -54,8 +54,10 @@ const EvaluatePage = lazy(() => import("./routes/orgs/projects/EvaluatePage").th
 const ExportTraining = lazy(() => import("./routes/orgs/projects/ExportTraining").then(m => ({ default: m.ExportTraining })));
 const ComparisonCampaignNew = lazy(() => import("./routes/orgs/projects/ComparisonCampaignNew").then(m => ({ default: m.ComparisonCampaignNew })));
 const ComparisonCampaignDetail = lazy(() => import("./routes/orgs/projects/ComparisonCampaignDetail").then(m => ({ default: m.ComparisonCampaignDetail })));
+const ReviewResults = lazy(() => import("./routes/orgs/projects/ReviewResults").then(m => ({ default: m.ReviewResults })));
 const IngestEndpoint = lazy(() => import("./routes/orgs/projects/IngestEndpoint").then(m => ({ default: m.IngestEndpoint })));
 const ImportRuns = lazy(() => import("./routes/orgs/projects/ImportRuns").then(m => ({ default: m.ImportRuns })));
+const ProjectSources = lazy(() => import("./routes/orgs/projects/settings/ProjectSources").then(m => ({ default: m.ProjectSources })));
 const TraceList = lazy(() => import("./routes/traces/TraceList").then(m => ({ default: m.TraceList })));
 const TraceViewer = lazy(() => import("./routes/traces/TraceViewer").then(m => ({ default: m.TraceViewer })));
 const TraceMatchup = lazy(() => import("./routes/traces/TraceMatchup").then(m => ({ default: m.TraceMatchup })));
@@ -99,7 +101,7 @@ export function App() {
             <Route path="settings/openrouter-key" element={<OpenRouterKey />} />
             <Route path="settings/billing" element={<Billing />} />
             <Route path="projects/:projectId" element={<ProjectLayout />}>
-              <Route index element={<Navigate to="import" replace />} />
+              <Route index element={<Navigate to="traces" replace />} />
               <Route path="import" element={<ImportRuns />} />
               <Route path="variables" element={<Variables />} />
               <Route path="test-cases" element={<TestCases />} />
@@ -130,6 +132,7 @@ export function App() {
                 element={<CycleDetail />}
               />
               <Route path="evaluate" element={<EvaluatePage />} />
+              <Route path="results" element={<ReviewResults />} />
               <Route path="comparisons/new" element={<ComparisonCampaignNew />} />
               <Route path="comparisons/:campaignId" element={<ComparisonCampaignDetail />} />
               <Route path="export" element={<ExportTraining />} />
@@ -145,6 +148,7 @@ export function App() {
               />
               <Route path="history" element={<HistoryPage />} />
               <Route path="settings" element={<ProjectSettings />} />
+              <Route path="settings/sources" element={<ProjectSources />} />
               <Route
                 path="settings/collaborators"
                 element={<ProjectCollaborators />}

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -1,7 +1,8 @@
-import { useState, useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useQuery } from "convex/react";
 import { useNavigate, useParams } from "react-router-dom";
 import { api } from "../../convex/_generated/api";
+import type { Id } from "../../convex/_generated/dataModel";
 import { useOrg } from "@/contexts/OrgContext";
 import { onToggleCommandPalette } from "@/lib/commandPaletteState";
 import {
@@ -14,14 +15,17 @@ import {
   CommandShortcut,
 } from "@/components/ui/command";
 import {
+  BarChart3,
+  ClipboardCheck,
+  DatabaseZap,
+  FileInput,
   FolderOpen,
-  GitBranch,
-  FlaskConical,
-  Play,
-  Plus,
+  Route,
   Settings,
+  Wrench,
 } from "lucide-react";
 
+/** Keyboard navigation centered on the Runs → Reviews → Results workflow. */
 export function CommandPalette() {
   const [open, setOpen] = useState(false);
   const navigate = useNavigate();
@@ -30,40 +34,24 @@ export function CommandPalette() {
     projectId: string;
   }>();
   const { orgId } = useOrg();
-
-  // Always query projects for the current org
   const projects = useQuery(api.projects.list, { orgId });
-
-  // Check project role to avoid querying data the user can't access (e.g. evaluators)
   const projectInfo = useQuery(
     api.projects.get,
-    projectId ? { projectId: projectId as any } : "skip",
+    projectId ? { projectId: projectId as Id<"projects"> } : "skip",
   );
   const canBrowseProject =
     projectInfo?.role === "owner" || projectInfo?.role === "editor";
 
-  // Only query project-scoped data when inside a project and user has sufficient role
-  const versions = useQuery(
-    api.versions.list,
-    projectId && canBrowseProject ? { projectId: projectId as any } : "skip",
-  );
-  const testCases = useQuery(
-    api.testCases.list,
-    projectId && canBrowseProject ? { projectId: projectId as any } : "skip",
-  );
-
-  // Subscribe to external toggle events (e.g. TopBar button)
   useEffect(
-    () => onToggleCommandPalette(() => setOpen((prev) => !prev)),
+    () => onToggleCommandPalette(() => setOpen((current) => !current)),
     [],
   );
 
-  // Register Cmd+K globally
   useEffect(() => {
-    function handler(e: KeyboardEvent) {
-      if ((e.metaKey || e.ctrlKey) && e.key === "k") {
-        e.preventDefault();
-        setOpen((prev) => !prev);
+    function handler(event: KeyboardEvent) {
+      if ((event.metaKey || event.ctrlKey) && event.key === "k") {
+        event.preventDefault();
+        setOpen((current) => !current);
       }
     }
     window.addEventListener("keydown", handler);
@@ -76,135 +64,82 @@ export function CommandPalette() {
   }
 
   const basePath = `/orgs/${orgSlug}`;
-  const projectPath = projectId
-    ? `${basePath}/projects/${projectId}`
-    : null;
+  const projectPath = projectId ? `${basePath}/projects/${projectId}` : null;
 
   return (
     <CommandDialog open={open} onOpenChange={setOpen}>
-      <CommandInput placeholder="Search projects, versions, actions..." />
+      <CommandInput placeholder="Search projects and review actions…" />
       <CommandList>
         <CommandEmpty>
           <div className="py-6 text-center text-sm">
-            <p className="text-muted-foreground">
-              No matches in this {projectPath ? "prompt" : "workspace"}.
-            </p>
+            <p className="text-muted-foreground">No matching project or action.</p>
             <p className="mt-1 text-xs text-muted-foreground/80">
-              Try a shorter query, or press{" "}
-              <kbd className="rounded border bg-muted px-1 py-0.5 font-mono text-[10px]">
-                Esc
-              </kbd>{" "}
-              to close.
+              Try a shorter query, or press <kbd className="rounded border bg-muted px-1 py-0.5 font-mono text-[10px]">Esc</kbd> to close.
             </p>
           </div>
         </CommandEmpty>
 
-        {/* Actions */}
-        <CommandGroup heading="Actions">
+        <CommandGroup heading="Review workflow">
           <CommandItem onSelect={() => go(basePath)}>
-            <FolderOpen className="mr-2 h-4 w-4" />
+            <FolderOpen aria-hidden="true" className="mr-2 h-4 w-4" />
             Go to projects
             <CommandShortcut>G P</CommandShortcut>
           </CommandItem>
+          <CommandItem onSelect={() => go("/eval")}>
+            <ClipboardCheck aria-hidden="true" className="mr-2 h-4 w-4" />
+            Reviews for me
+          </CommandItem>
           {projectPath && canBrowseProject && (
             <>
-              <CommandItem
-                onSelect={() => go(`${projectPath}/versions`)}
-              >
-                <GitBranch className="mr-2 h-4 w-4" />
-                Go to versions
-                <CommandShortcut>G V</CommandShortcut>
-              </CommandItem>
-              <CommandItem
-                onSelect={() => go(`${projectPath}/test-cases`)}
-              >
-                <FlaskConical className="mr-2 h-4 w-4" />
-                Go to test cases
-                <CommandShortcut>G T</CommandShortcut>
-              </CommandItem>
-              <CommandItem
-                onSelect={() => go(`${projectPath}/run`)}
-              >
-                <Play className="mr-2 h-4 w-4" />
-                New run
-                <CommandShortcut>G N</CommandShortcut>
-              </CommandItem>
-              <CommandItem
-                onSelect={() => go(`${projectPath}/runs`)}
-              >
-                <Play className="mr-2 h-4 w-4" />
-                Go to runs
+              <CommandItem onSelect={() => go(`${projectPath}/traces`)}>
+                <Route aria-hidden="true" className="mr-2 h-4 w-4" />
+                Runs
                 <CommandShortcut>G R</CommandShortcut>
               </CommandItem>
-              <CommandItem
-                onSelect={() => go(`${projectPath}/variables`)}
-              >
-                <Plus className="mr-2 h-4 w-4" />
-                Variables
+              <CommandItem onSelect={() => go(`${projectPath}/import`)}>
+                <FileInput aria-hidden="true" className="mr-2 h-4 w-4" />
+                Add runs
+              </CommandItem>
+              <CommandItem onSelect={() => go(`${projectPath}/evaluate`)}>
+                <ClipboardCheck aria-hidden="true" className="mr-2 h-4 w-4" />
+                Reviews
+              </CommandItem>
+              <CommandItem onSelect={() => go(`${projectPath}/results`)}>
+                <BarChart3 aria-hidden="true" className="mr-2 h-4 w-4" />
+                Results
               </CommandItem>
             </>
           )}
-          <CommandItem
-            onSelect={() => go(`${basePath}/settings`)}
-          >
-            <Settings className="mr-2 h-4 w-4" />
-            Org settings
-          </CommandItem>
         </CommandGroup>
 
-        {/* Projects */}
-        {projects && projects.length > 0 && (
-          <CommandGroup heading="Prompts">
-            {projects.map((p) => (
-              <CommandItem
-                key={p._id}
-                onSelect={() =>
-                  go(`${basePath}/projects/${p._id}`)
-                }
-              >
-                <FolderOpen className="mr-2 h-4 w-4" />
-                {p.name}
-              </CommandItem>
-            ))}
+        {projectPath && canBrowseProject && (
+          <CommandGroup heading="Tools">
+            <CommandItem onSelect={() => go(`${projectPath}/settings/sources`)}>
+              <DatabaseZap aria-hidden="true" className="mr-2 h-4 w-4" />
+              Data sources
+            </CommandItem>
+            <CommandItem onSelect={() => go(`${projectPath}/versions`)}>
+              <Wrench aria-hidden="true" className="mr-2 h-4 w-4" />
+              Prompt playground
+            </CommandItem>
           </CommandGroup>
         )}
 
-        {/* Versions (project-scoped) */}
-        {versions && versions.length > 0 && projectPath && (
-          <CommandGroup heading="Versions">
-            {versions.slice(0, 10).map((v) => (
-              <CommandItem
-                key={v._id}
-                onSelect={() =>
-                  go(`${projectPath}/versions/${v._id}`)
-                }
-              >
-                <GitBranch className="mr-2 h-4 w-4" />
-                v{v.versionNumber}{" "}
-                <span className="text-muted-foreground capitalize">
-                  {v.status}
-                </span>
-              </CommandItem>
-            ))}
-          </CommandGroup>
-        )}
-
-        {/* Test cases (project-scoped) */}
-        {testCases && testCases.length > 0 && projectPath && (
-          <CommandGroup heading="Test Cases">
-            {testCases.map((tc) => (
-              <CommandItem
-                key={tc._id}
-                onSelect={() =>
-                  go(`${projectPath}/test-cases/${tc._id}`)
-                }
-              >
-                <FlaskConical className="mr-2 h-4 w-4" />
-                {tc.name}
-              </CommandItem>
-            ))}
-          </CommandGroup>
-        )}
+        <CommandGroup heading="Projects">
+          {projects?.map((project) => (
+            <CommandItem
+              key={project._id}
+              onSelect={() => go(`${basePath}/projects/${project._id}`)}
+            >
+              <FolderOpen aria-hidden="true" className="mr-2 h-4 w-4" />
+              {project.name}
+            </CommandItem>
+          ))}
+          <CommandItem onSelect={() => go(`${basePath}/settings`)}>
+            <Settings aria-hidden="true" className="mr-2 h-4 w-4" />
+            Workspace settings
+          </CommandItem>
+        </CommandGroup>
       </CommandList>
     </CommandDialog>
   );

--- a/src/components/CopilotPanel.tsx
+++ b/src/components/CopilotPanel.tsx
@@ -568,7 +568,7 @@ function SuggestionsView({
     },
     {
       id: "start_review_cycle",
-      title: "Start a review cycle",
+      title: "Create a blind review",
       body:
         "Pool runs from different versions and route them blind to evaluators.",
       cta: "New cycle",

--- a/src/components/HelpMenu.tsx
+++ b/src/components/HelpMenu.tsx
@@ -25,17 +25,10 @@ import {
   Info,
   FileText,
   Shield,
-  Compass,
 } from "lucide-react";
 
 export function HelpMenu() {
   const resetCallouts = useMutation(api.userPreferences.resetCallouts);
-  const setCopilotDismissed = useMutation(
-    api.userPreferences.setCopilotDismissed,
-  );
-  const setCopilotCollapsed = useMutation(
-    api.userPreferences.setCopilotCollapsed,
-  );
   const navigate = useNavigate();
   const [aboutOpen, setAboutOpen] = useState(false);
 
@@ -47,17 +40,6 @@ export function HelpMenu() {
           <span className="sr-only">Help</span>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end" className="w-56">
-          <DropdownMenuItem
-            onClick={async () => {
-              await Promise.all([
-                setCopilotDismissed({ dismissed: false }),
-                setCopilotCollapsed({ collapsed: false }),
-              ]);
-            }}
-          >
-            <Compass className="mr-2 h-4 w-4" />
-            Show setup co-pilot
-          </DropdownMenuItem>
           <DropdownMenuItem onClick={() => toggleCheatSheet()}>
             <Keyboard className="mr-2 h-4 w-4" />
             Keyboard shortcuts
@@ -106,8 +88,8 @@ export function HelpMenu() {
             <DialogTitle>Blind Bench</DialogTitle>
           </DialogHeader>
           <p className="text-sm text-muted-foreground">
-            Blind-evaluate LLM outputs so the best writing wins — not the
-            loudest opinion.
+            Import completed AI runs, collect blind expert judgment, and turn
+            the result into evidence your team can reuse.
           </p>
           <p className="text-xs text-muted-foreground mt-2">Version 0.9-pre</p>
         </DialogContent>

--- a/src/components/NewProjectDialog.tsx
+++ b/src/components/NewProjectDialog.tsx
@@ -101,7 +101,7 @@ export function NewProjectDialog({
         `/orgs/${org.slug}/projects/${result.projectId}/versions/${result.versionId}`,
       );
     } catch (err) {
-      setError(friendlyError(err, "Failed to create prompt."));
+      setError(friendlyError(err, "Failed to create project."));
     } finally {
       setSaving(false);
     }

--- a/src/components/ProjectTabs.ct.spec.tsx
+++ b/src/components/ProjectTabs.ct.spec.tsx
@@ -1,0 +1,39 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+import { MemoryRouter } from "react-router-dom";
+import { ProjectProvider } from "@/contexts/ProjectContext";
+import type { Id } from "../../convex/_generated/dataModel";
+import { ProjectTabs } from "./ProjectTabs";
+
+const projectId = "project-1" as Id<"projects">;
+
+/** The primary project shell exposes only the ingestion-first workflow. */
+test("project navigation leads with Runs, Reviews, and Results", async ({ mount }) => {
+  const component = await mount(
+    <MemoryRouter initialEntries={[`/orgs/demo/projects/${projectId}/traces`]}>
+      <ProjectProvider
+        value={{
+          project: {
+            _id: projectId,
+            _creationTime: 1,
+            organizationId: "org-1" as Id<"organizations">,
+            name: "Agent quality",
+            createdById: "user-1" as Id<"users">,
+          },
+          projectId,
+          role: "owner",
+          blindMode: undefined,
+        }}
+      >
+        <ProjectTabs />
+      </ProjectProvider>
+    </MemoryRouter>,
+  );
+
+  await expect(component.getByRole("link", { name: "Runs", exact: true })).toBeVisible();
+  await expect(component.getByRole("link", { name: "Reviews", exact: true })).toBeVisible();
+  await expect(component.getByRole("link", { name: "Results", exact: true })).toBeVisible();
+  await expect(component.getByRole("link", { name: "Run prompt", exact: true })).toHaveCount(0);
+  await expect(component.getByRole("link", { name: "Export", exact: true })).toHaveCount(0);
+
+  await expect(component.getByRole("button", { name: /tools/i })).toBeVisible();
+});

--- a/src/components/ProjectTabs.tsx
+++ b/src/components/ProjectTabs.tsx
@@ -1,56 +1,57 @@
-import { NavLink, useParams, useLocation } from "react-router-dom";
+import { NavLink, useLocation, useParams } from "react-router-dom";
 import { useProject } from "@/contexts/ProjectContext";
 import { cn } from "@/lib/utils";
-import { Settings } from "lucide-react";
+import {
+  Activity,
+  DatabaseZap,
+  FileInput,
+  FlaskConical,
+  MoreHorizontal,
+  Play,
+  Settings,
+  Wrench,
+} from "lucide-react";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 
-const tabs = [
-  { label: "Import", path: "import" },
-  { label: "Trajectories", path: "traces" },
-  { label: "Review", path: "evaluate" },
-  { label: "Export", path: "export" },
-  { label: "Live ingest", path: "ingest" },
-  // The original prompt playground remains available, but imported behavior is
-  // the primary product flow.
-  { label: "Playground", path: "versions" },
-  { label: "Run prompt", path: "run" },
-  { label: "Test Cases", path: "test-cases" },
-  { label: "History", path: "history" },
-];
+const primaryTabs = [
+  { label: "Runs", path: "traces" },
+  { label: "Reviews", path: "evaluate" },
+  { label: "Results", path: "results" },
+] as const;
 
+const secondaryItems = [
+  { label: "Add runs", path: "import", icon: FileInput },
+  { label: "Data sources", path: "settings/sources", icon: DatabaseZap },
+  { label: "Prompt playground", path: "versions", icon: Wrench },
+  { label: "Generate outputs", path: "run", icon: Play },
+  { label: "Playground test cases", path: "test-cases", icon: FlaskConical },
+  { label: "Activity", path: "history", icon: Activity },
+] as const;
+
+/** Primary project navigation for the ingestion-first Runs → Reviews → Results loop. */
 export function ProjectTabs() {
   const { orgSlug } = useParams<{ orgSlug: string }>();
   const { projectId, role } = useProject();
   const location = useLocation();
   const basePath = `/orgs/${orgSlug}/projects/${projectId}`;
+  const secondaryActive = secondaryItems.some((item) =>
+    location.pathname.startsWith(`${basePath}/${item.path}`),
+  );
 
   return (
-    <nav
-      aria-label="Project sections"
-      className="flex items-center border-b px-4"
-    >
-      <div className="flex items-center gap-1 flex-1 overflow-x-auto">
-        {tabs.map((tab) => {
-          // Evaluators: hide authoring/setup tabs
-          if (
-            role === "evaluator" &&
-            (tab.label === "Import" ||
-              tab.label === "Playground" ||
-              tab.label === "Run prompt" ||
-              tab.label === "Test Cases" ||
-              tab.label === "Review" ||
-              tab.label === "Export" ||
-              tab.label === "Live ingest")
-          )
-            return null;
-
+    <nav aria-label="Project sections" className="flex items-center border-b px-4">
+      <div className="flex flex-1 items-center gap-1 overflow-x-auto">
+        {primaryTabs.map((tab) => {
+          if (role === "evaluator") return null;
           const to = `${basePath}/${tab.path}`;
-
-          // Editor tab: match both /versions and /versions/:versionId
-          const isActive =
-            tab.path === "versions"
-              ? location.pathname.startsWith(`${basePath}/versions`)
-              : location.pathname.startsWith(to);
-
+          const isActive = location.pathname.startsWith(to);
           return (
             <NavLink
               key={tab.label}
@@ -58,9 +59,9 @@ export function ProjectTabs() {
               aria-current={isActive ? "page" : undefined}
               className={() =>
                 cn(
-                  "inline-flex min-h-11 items-center px-3 py-2.5 text-sm transition-colors border-b-2 sm:min-h-0",
+                  "inline-flex min-h-11 items-center border-b-2 px-3 py-2.5 text-sm transition-colors sm:min-h-0",
                   isActive
-                    ? "border-primary text-foreground font-medium"
+                    ? "border-primary font-medium text-foreground"
                     : "border-transparent text-muted-foreground hover:text-foreground",
                 )
               }
@@ -69,7 +70,46 @@ export function ProjectTabs() {
             </NavLink>
           );
         })}
+
+        {role !== "evaluator" && (
+          <DropdownMenu>
+            <DropdownMenuTrigger
+              className={cn(
+                "inline-flex min-h-11 items-center gap-1 border-b-2 px-3 py-2.5 text-sm transition-colors sm:min-h-0",
+                secondaryActive
+                  ? "border-primary font-medium text-foreground"
+                  : "border-transparent text-muted-foreground hover:text-foreground",
+              )}
+            >
+              Tools
+              <MoreHorizontal aria-hidden="true" className="h-4 w-4" />
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="start" className="w-56">
+              <DropdownMenuLabel>Import and sources</DropdownMenuLabel>
+              {secondaryItems.slice(0, 2).map((item) => (
+                <DropdownMenuItem key={item.path} render={<NavLink to={`${basePath}/${item.path}`} />}>
+                  <item.icon aria-hidden="true" className="mr-2 h-4 w-4" />
+                  {item.label}
+                </DropdownMenuItem>
+              ))}
+              <DropdownMenuSeparator />
+              <DropdownMenuLabel>Prompt playground</DropdownMenuLabel>
+              {secondaryItems.slice(2, 5).map((item) => (
+                <DropdownMenuItem key={item.path} render={<NavLink to={`${basePath}/${item.path}`} />}>
+                  <item.icon aria-hidden="true" className="mr-2 h-4 w-4" />
+                  {item.label}
+                </DropdownMenuItem>
+              ))}
+              <DropdownMenuSeparator />
+              <DropdownMenuItem render={<NavLink to={`${basePath}/${secondaryItems[5].path}`} />}>
+                <Activity aria-hidden="true" className="mr-2 h-4 w-4" />
+                Activity
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
       </div>
+
       {role === "owner" && (
         <NavLink
           to={`${basePath}/settings`}
@@ -77,14 +117,14 @@ export function ProjectTabs() {
             cn(
               "ml-2 inline-flex h-11 w-11 items-center justify-center rounded-md transition-colors sm:h-auto sm:w-auto sm:p-1.5",
               isActive
-                ? "text-foreground bg-accent"
-                : "text-muted-foreground hover:text-foreground hover:bg-accent",
+                ? "bg-accent text-foreground"
+                : "text-muted-foreground hover:bg-accent hover:text-foreground",
             )
           }
-          title="Settings"
+          title="Project settings"
           aria-label="Project settings"
         >
-          <Settings className="h-5 w-5 sm:h-4 sm:w-4" />
+          <Settings aria-hidden="true" className="h-5 w-5 sm:h-4 sm:w-4" />
         </NavLink>
       )}
     </nav>

--- a/src/components/SideNavContent.tsx
+++ b/src/components/SideNavContent.tsx
@@ -5,11 +5,9 @@ import { useOrg } from "@/contexts/OrgContext";
 import { cn } from "@/lib/utils";
 import {
   ClipboardCheck,
-  CloudDownload,
   CreditCard,
   FolderOpen,
   Key,
-  Plug,
   Plus,
   Settings,
   Users,
@@ -90,32 +88,12 @@ export function SideNavContent({
 
       <div className="mt-4 px-2 pb-1">
         <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
-          Workspace
+          Review
         </span>
       </div>
-      <NavLink
-        to={`/orgs/${org.slug}/gateway-onboarding`}
-        className={linkClass}
-        onClick={onNavigate}
-      >
-        <Plug aria-hidden="true" className="h-4 w-4 shrink-0" />
-        Ingest &amp; onboarding
-      </NavLink>
-      <NavLink
-        to={`/orgs/${org.slug}/gateway-import`}
-        className={linkClass}
-        onClick={onNavigate}
-      >
-        <CloudDownload aria-hidden="true" className="h-4 w-4 shrink-0" />
-        Import Gateway logs
-      </NavLink>
-      <NavLink
-        to={`/orgs/${org.slug}/scorecard`}
-        className={linkClass}
-        onClick={onNavigate}
-      >
+      <NavLink to="/eval" className={linkClass} onClick={onNavigate}>
         <ClipboardCheck aria-hidden="true" className="h-4 w-4 shrink-0" />
-        Quality scorecard
+        Reviews for me
       </NavLink>
 
       {role === "owner" && (

--- a/src/components/layouts/OrgLayout.tsx
+++ b/src/components/layouts/OrgLayout.tsx
@@ -21,7 +21,6 @@ import { NewProjectDialog } from "@/components/NewProjectDialog";
 import { CommandPalette } from "@/components/CommandPalette";
 import { ShortcutCheatSheet } from "@/components/ShortcutCheatSheet";
 import { PostHogOrgGroupBridge } from "@/components/PostHogOrgGroupBridge";
-import { CopilotPanel } from "@/components/CopilotPanel";
 import { Skeleton } from "@/components/ui/skeleton";
 
 export function OrgLayout() {
@@ -80,7 +79,6 @@ export function OrgLayout() {
             <main className="flex-1 overflow-auto">
               <Outlet />
             </main>
-            <CopilotPanel />
           </div>
         </div>
         <NewProjectDialog

--- a/src/routes/invite/InvitesInbox.tsx
+++ b/src/routes/invite/InvitesInbox.tsx
@@ -39,7 +39,7 @@ function TraceReviewCard({ count }: { count: number }) {
         <div className="flex items-center gap-3 min-w-0">
           <Route className="h-4 w-4 shrink-0 text-primary" />
           <p className="text-sm font-medium">
-            {count} {count === 1 ? "trajectory" : "trajectories"} to review
+            {count} {count === 1 ? "run" : "runs"} to review
           </p>
         </div>
         <span aria-hidden="true" className="text-primary">

--- a/src/routes/orgs/OrgHome.tsx
+++ b/src/routes/orgs/OrgHome.tsx
@@ -37,7 +37,7 @@ export function OrgHome() {
                     {s.projectName ? ` — ${s.projectName}` : ""}
                   </div>
                   <div className="text-xs text-muted-foreground">
-                    {s.phase === "phase1" ? "Phase 1 · Review" : "Phase 2 · Battle"}
+                    {s.phase === "phase1" ? "Scoring runs" : "Comparing attempts"}
                     {" · "}
                     {s.outputCount} outputs
                   </div>

--- a/src/routes/orgs/OrgHome.tsx
+++ b/src/routes/orgs/OrgHome.tsx
@@ -5,7 +5,7 @@ import { useOrg } from "@/contexts/OrgContext";
 import { useOrgLayout } from "@/components/layouts/OrgLayout";
 import { EmptyState } from "@/components/EmptyState";
 import { Skeleton } from "@/components/ui/skeleton";
-import { ClipboardCheck, FolderOpen, ChevronRight, Plug } from "lucide-react";
+import { ClipboardCheck, FolderOpen, ChevronRight } from "lucide-react";
 
 export function OrgHome() {
   const { org, orgId } = useOrg();
@@ -18,7 +18,7 @@ export function OrgHome() {
     <div className="p-6">
       <h1 className="text-2xl font-bold">{org.name}</h1>
       <p className="mt-1 text-sm text-muted-foreground">
-        Agent-review projects and prompt workspaces
+        Import completed AI runs, collect blind human review, and reuse the evidence.
       </p>
 
       {inFlight && inFlight.length > 0 && (
@@ -49,40 +49,6 @@ export function OrgHome() {
         </div>
       )}
 
-      <div className="mt-4 grid gap-3 sm:grid-cols-2">
-        <Link
-          to={`/orgs/${org.slug}/gateway-onboarding`}
-          className="flex items-center justify-between rounded-lg border px-4 py-3 hover:bg-accent transition-colors"
-        >
-          <div className="flex items-center gap-3">
-            <Plug aria-hidden="true" className="h-4 w-4 text-primary shrink-0" />
-            <div>
-              <div className="text-sm font-medium">Gateway onboarding</div>
-              <div className="text-xs text-muted-foreground">
-                Feed Cloudflare AI Gateway logs into Blind Bench.
-              </div>
-            </div>
-          </div>
-          <ChevronRight aria-hidden="true" className="h-4 w-4 text-muted-foreground" />
-        </Link>
-
-        <Link
-          to={`/orgs/${org.slug}/scorecard`}
-          className="flex items-center justify-between rounded-lg border px-4 py-3 hover:bg-accent transition-colors"
-        >
-          <div className="flex items-center gap-3">
-            <ClipboardCheck aria-hidden="true" className="h-4 w-4 text-primary shrink-0" />
-            <div>
-              <div className="text-sm font-medium">Quality scorecard</div>
-              <div className="text-xs text-muted-foreground">
-                Run deterministic quality checks over your imported traffic.
-              </div>
-            </div>
-          </div>
-          <ChevronRight aria-hidden="true" className="h-4 w-4 text-muted-foreground" />
-        </Link>
-      </div>
-
       <div className="mt-6">
         {projects === undefined ? (
           <div
@@ -99,10 +65,10 @@ export function OrgHome() {
         ) : projects.length === 0 ? (
           <EmptyState
             icon={FolderOpen}
-            heading="No agent-review projects yet"
-            description="Create a workspace for an agent prompt, test cases, runs, blind reviews, and the verdicts you route back."
+            heading="Bring in your first completed runs"
+            description="Create a project, upload runs from the systems you already use, and send one blind review link."
             action={{
-              label: "Create project",
+              label: "Create review project",
               onClick: openNewProjectDialog,
             }}
           />

--- a/src/routes/orgs/projects/CanonicalReviewJourney.ct.spec.tsx
+++ b/src/routes/orgs/projects/CanonicalReviewJourney.ct.spec.tsx
@@ -1,0 +1,70 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+import { MemoryRouter } from "react-router-dom";
+import type { Id } from "../../../../convex/_generated/dataModel";
+import { ProjectProvider } from "@/contexts/ProjectContext";
+import { ReviewBuilder } from "./ReviewBuilder";
+import { ReviewResults } from "./ReviewResults";
+import { VerdictReviewDetail } from "./VerdictReviewDetail";
+import { VerdictReview } from "@/routes/review/VerdictReview";
+
+const projectId = "test-project" as Id<"projects">;
+const projectValue = {
+  project: {
+    _id: projectId,
+    _creationTime: 1,
+    organizationId: "org-1" as Id<"organizations">,
+    name: "Synthetic support quality",
+    createdById: "owner-1" as Id<"users">,
+  },
+  projectId,
+  role: "owner" as const,
+  blindMode: undefined,
+};
+
+/** Synthetic browser journey across actual owner and anonymous-review components. */
+test("create review, judge blind, inspect result, and reuse evidence", async ({ mount }) => {
+  const component = await mount(
+    <MemoryRouter initialEntries={[`/orgs/demo/projects/${projectId}/reviews/new`]}>
+      <ProjectProvider value={projectValue}><ReviewBuilder /></ProjectProvider>
+    </MemoryRouter>,
+  );
+
+  await expect(component.getByRole("heading", { name: "Create blind review" })).toBeVisible();
+  await expect(component).toContainText("2 selected");
+  await component.getByLabel("Review name").fill("Synthetic support review");
+  await component.getByRole("button", { name: "Create review" }).click();
+
+  await component.update(
+    <MemoryRouter initialEntries={["/review/verdict/opaque-share-token"]}>
+      <VerdictReview />
+    </MemoryRouter>,
+  );
+  await component.getByLabel("Your display name").fill("Synthetic reviewer");
+  await component.getByRole("button", { name: "Start review" }).click();
+  await expect(component.getByRole("heading", { name: "Run", exact: true })).toBeVisible();
+  await expect(component).toContainText("Blind review");
+  await expect(component).not.toContainText("claude-sonnet");
+  await expect(component).not.toContainText("pi ·");
+  await component.getByRole("button", { name: "Strong" }).click();
+  await expect(component).toContainText("Saved.");
+
+  await component.update(
+    <MemoryRouter initialEntries={[`/orgs/demo/projects/${projectId}/reviews/verdict/verdict-review-test`]}>
+      <ProjectProvider value={projectValue}><VerdictReviewDetail /></ProjectProvider>
+    </MemoryRouter>,
+  );
+  await expect(component.getByRole("heading", { name: "Synthetic support review" })).toBeVisible();
+  await expect(component).toContainText("1 judgments");
+  await expect(component).toContainText("support · pi · claude-sonnet");
+  await component.getByRole("button", { name: "Add approved runs to regression set" }).click();
+  await expect(component).toContainText("1 added to the regression set");
+
+  await component.update(
+    <MemoryRouter initialEntries={[`/orgs/demo/projects/${projectId}/results`]}>
+      <ProjectProvider value={projectValue}><ReviewResults /></ProjectProvider>
+    </MemoryRouter>,
+  );
+  await expect(component.getByRole("heading", { name: "Results" })).toBeVisible();
+  await expect(component).toContainText("Closed and reusable");
+  await expect(component).toContainText("3/3 runs reviewed");
+});

--- a/src/routes/orgs/projects/ComparisonCampaignDetail.tsx
+++ b/src/routes/orgs/projects/ComparisonCampaignDetail.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { useAction, useMutation, useQuery } from "convex/react";
 import { Link, useParams } from "react-router-dom";
-import { ArrowLeft, Download, EyeOff, Lock } from "lucide-react";
+import { ArrowLeft, ClipboardCopy, Download, EyeOff, Lock } from "lucide-react";
 import { api } from "../../../../convex/_generated/api";
 import type { Id } from "../../../../convex/_generated/dataModel";
 import { useProject } from "@/contexts/ProjectContext";
@@ -11,13 +11,21 @@ import { CopyButton } from "@/components/ui/copy-button";
 import { friendlyError } from "@/lib/errors";
 
 const labels = [
-  ["leftWins", "Candidate A"], ["rightWins", "Candidate B"], ["same", "Same"],
-  ["neither", "Neither acceptable"], ["cannotJudge", "Cannot judge"],
+  ["leftWins", "Candidate A"],
+  ["rightWins", "Candidate B"],
+  ["same", "Same"],
+  ["neither", "Neither acceptable"],
+  ["cannotJudge", "Cannot judge"],
 ] as const;
 
+/** Owner results and contextual reuse for one paired blind review. */
 export function ComparisonCampaignDetail() {
   const { projectId } = useProject();
-  const { orgSlug, campaignId } = useParams<{ orgSlug: string; campaignId: string }>();
+  const { orgSlug, campaignId = "" } = useParams<{
+    orgSlug: string;
+    campaignId: string;
+  }>();
+  // SAFETY: Convex validates the route value as a table ID at the RPC boundary.
   const id = campaignId as Id<"comparisonCampaigns">;
   const campaign = useQuery(api.comparisonCampaigns.getOwnerCampaign, { campaignId: id });
   const openCampaign = useMutation(api.comparisonCampaigns.openCampaign);
@@ -26,58 +34,150 @@ export function ComparisonCampaignDetail() {
   const downloadExport = useAction(api.exports.downloadExport);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState("");
+  const [reuseMessage, setReuseMessage] = useState("");
   const base = `/orgs/${orgSlug}/projects/${projectId}`;
 
-  if (campaign === undefined) return <div className="p-6 text-sm text-muted-foreground">Loading comparison…</div>;
-  const reviewUrl = `${window.location.origin}/review/campaign/${campaign.shareToken}`;
-  const campaignName = campaign.name;
+  if (campaign === undefined) {
+    return <div className="p-6 text-sm text-muted-foreground">Loading comparison…</div>;
+  }
+  const currentCampaign = campaign;
+  const reviewUrl = `${window.location.origin}/review/campaign/${currentCampaign.shareToken}`;
 
   async function open() {
-    setBusy(true); setError("");
-    try { await openCampaign({ campaignId: id }); }
-    catch (cause: unknown) { setError(friendlyError(cause, "Could not open this comparison.")); }
-    finally { setBusy(false); }
+    setBusy(true);
+    setError("");
+    try {
+      await openCampaign({ campaignId: id });
+    } catch (cause: unknown) {
+      setError(friendlyError(cause, "Could not open this comparison."));
+    } finally {
+      setBusy(false);
+    }
   }
 
   async function close() {
-    if (!window.confirm("Close this campaign? Reviewers will no longer be able to submit choices.")) return;
-    setBusy(true); setError("");
-    try { await closeCampaign({ campaignId: id }); }
-    catch (cause: unknown) { setError(friendlyError(cause, "Could not close this comparison.")); }
-    finally { setBusy(false); }
+    if (!window.confirm("Close this review? Reviewers will no longer be able to submit choices.")) return;
+    setBusy(true);
+    setError("");
+    try {
+      await closeCampaign({ campaignId: id });
+    } catch (cause: unknown) {
+      setError(friendlyError(cause, "Could not close this comparison."));
+    } finally {
+      setBusy(false);
+    }
   }
 
   async function download() {
-    setBusy(true); setError("");
+    setBusy(true);
+    setError("");
+    setReuseMessage("");
     try {
-      const data = await generateExport({ projectId, campaignId: id, source: "trajectory", format: "dpo" });
-      if (data.rowCount === 0) throw new Error("This campaign has no directional preferences to export yet.");
+      const data = await generateExport({
+        projectId,
+        campaignId: id,
+        source: "trajectory",
+        format: "dpo",
+      });
+      if (data.rowCount === 0) {
+        setReuseMessage(`No DPO rows were eligible. ${data.excludedCount} pairs were explicitly excluded for ties, disagreement, or comparability.`);
+        return;
+      }
       const { url } = await downloadExport({ exportId: data.exportId });
-      const anchor = document.createElement("a"); anchor.href = url; anchor.download = `${campaignName.replace(/[^a-z0-9]+/gi, "-").toLowerCase()}-dpo.jsonl`; anchor.click();
-    } catch (cause: unknown) { setError(friendlyError(cause, "Could not export this comparison.")); }
-    finally { setBusy(false); }
+      const anchor = document.createElement("a");
+      anchor.href = url;
+      anchor.download = `${currentCampaign.name.replace(/[^a-z0-9]+/gi, "-").toLowerCase()}-dpo.jsonl`;
+      anchor.click();
+      setReuseMessage(`${data.rowCount} DPO rows ready; ${data.excludedCount} excluded.`);
+    } catch (cause: unknown) {
+      setError(friendlyError(cause, "Could not export this comparison."));
+    } finally {
+      setBusy(false);
+    }
   }
 
-  return <div className="mx-auto max-w-5xl p-6">
-    <Link to={`${base}/evaluate`} className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"><ArrowLeft className="h-3.5 w-3.5" /> Reviews</Link>
-    <div className="mt-3 flex flex-wrap items-start justify-between gap-4">
-      <div><h1 className="text-2xl font-bold">{campaign.name}</h1><p className="mt-1 text-sm text-muted-foreground">{campaign.caseCount} paired cases · {campaign.status}</p></div>
-      <div className="flex gap-2">{campaign.status === "draft" && <Button onClick={open} disabled={busy}>Open for review</Button>}{campaign.status === "open" && <Button variant="outline" onClick={close} disabled={busy}><Lock className="h-4 w-4" /> Close</Button>}<Button variant="outline" onClick={download} disabled={busy}><Download className="h-4 w-4" /> Export JSONL</Button></div>
+  async function copyEvidence() {
+    const summary = [
+      currentCampaign.name,
+      `${currentCampaign.results.judgments} judgments across ${currentCampaign.results.reviewedCases}/${currentCampaign.caseCount} pairs`,
+      `Candidate A ${currentCampaign.results.leftWins} · Candidate B ${currentCampaign.results.rightWins} · Same ${currentCampaign.results.same}`,
+      `Neither acceptable ${currentCampaign.results.neither} · Cannot judge ${currentCampaign.results.cannotJudge}`,
+      `Agreement ${currentCampaign.results.agreementRate === null ? "not enough reviewers" : `${Math.round(currentCampaign.results.agreementRate * 100)}%`}`,
+    ].join("\n");
+    await navigator.clipboard.writeText(summary);
+    setReuseMessage("Evidence summary copied.");
+  }
+
+  return (
+    <div className="mx-auto max-w-5xl p-6">
+      <Link to={`${base}/evaluate`} className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground">
+        <ArrowLeft className="h-3.5 w-3.5" /> Reviews
+      </Link>
+      <div className="mt-3 flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-bold">{currentCampaign.name}</h1>
+          <p className="mt-1 text-sm text-muted-foreground">Compare attempts · {currentCampaign.caseCount} pairs · {currentCampaign.status}</p>
+        </div>
+        <div className="flex gap-2">
+          {currentCampaign.status === "draft" && <Button onClick={open} disabled={busy}>Open for review</Button>}
+          {currentCampaign.status === "open" && <Button variant="outline" onClick={close} disabled={busy}><Lock className="h-4 w-4" /> Close</Button>}
+        </div>
+      </div>
+      {error && <p className="mt-3 text-sm text-destructive" role="alert">{error}</p>}
+
+      <div className="mt-6 grid gap-4 lg:grid-cols-4">
+        <Card className="lg:col-span-2">
+          <CardHeader><CardTitle className="text-base">Review link</CardTitle></CardHeader>
+          <CardContent>
+            <div className="flex items-center gap-2 rounded-lg border bg-muted/30 p-3"><EyeOff className="h-4 w-4 shrink-0 text-primary" /><code className="min-w-0 flex-1 truncate text-xs">{reviewUrl}</code><CopyButton text={reviewUrl} label="Copy review link" /></div>
+            <p className="mt-2 text-xs text-muted-foreground">{currentCampaign.status === "draft" ? "Open the review before sharing this link." : "Reviewers enter a display name and receive five randomized comparisons at a time."}</p>
+          </CardContent>
+        </Card>
+        <Metric title="Coverage" value={`${currentCampaign.results.reviewedCases}/${currentCampaign.caseCount}`} detail={`${currentCampaign.results.judgments} judgments`} />
+        <Metric title="Agreement" value={currentCampaign.results.agreementRate === null ? "—" : `${Math.round(currentCampaign.results.agreementRate * 100)}%`} detail={currentCampaign.results.agreementRate === null ? "Needs 2+ reviewers per pair" : `${currentCampaign.results.agreementCases} pairs measured`} />
+      </div>
+
+      <Card className="mt-4">
+        <CardHeader><CardTitle className="text-base">Results</CardTitle></CardHeader>
+        <CardContent>
+          <div className="mb-4 flex flex-wrap gap-x-6 gap-y-1 text-xs text-muted-foreground"><span><strong className="text-foreground">Candidate A:</strong> {currentCampaign.candidateA.join(", ")}</span><span><strong className="text-foreground">Candidate B:</strong> {currentCampaign.candidateB.join(", ")}</span></div>
+          <div className="grid gap-3 sm:grid-cols-5">{labels.map(([key, label]) => <ResultCount key={key} label={label} value={currentCampaign.results[key]} />)}</div>
+          <p className="mt-4 text-xs text-muted-foreground">Source mapping is visible only here, after reviewers judge randomized Attempt 1 / Attempt 2 cards.</p>
+        </CardContent>
+      </Card>
+
+      {currentCampaign.status === "closed" ? (
+        <Card className="mt-4">
+          <CardHeader><CardTitle className="text-base">Use this result</CardTitle></CardHeader>
+          <CardContent className="space-y-3">
+            <div className="flex flex-wrap gap-2">
+              <Button variant="outline" onClick={() => void copyEvidence()}><ClipboardCopy className="h-4 w-4" /> Copy evidence summary</Button>
+              <Button variant="outline" onClick={() => void download()} disabled={busy || currentCampaign.results.judgments === 0}><Download className="h-4 w-4" /> Export eligible DPO</Button>
+            </div>
+            <p className="text-xs text-muted-foreground">DPO includes only directional choices with a verified shared prefix. Ties, neither, cannot-judge, disagreement, and prefix mismatch are reported as exclusions.</p>
+            {reuseMessage && <p className="text-sm text-muted-foreground" role="status">{reuseMessage}</p>}
+          </CardContent>
+        </Card>
+      ) : (
+        <Card className="mt-4 border-dashed"><CardContent className="pt-6 text-sm text-muted-foreground">Close the review to unlock evidence and eligible preference export.</CardContent></Card>
+      )}
+
+      {currentCampaign.feedback.length > 0 && (
+        <Card className="mt-4">
+          <CardHeader><CardTitle className="text-base">Reviewer comments</CardTitle></CardHeader>
+          <CardContent className="space-y-3">
+            {currentCampaign.feedback.map((item, index) => <div key={`${item.caseKey}-${item.reviewerName}-${index}`} className="rounded-lg border p-3"><div className="flex flex-wrap items-center justify-between gap-2 text-xs text-muted-foreground"><span>{item.caseKey} · {item.reviewerName}</span><span>{item.outcome}</span></div><p className="mt-2 whitespace-pre-wrap text-sm">{item.note}</p></div>)}
+          </CardContent>
+        </Card>
+      )}
     </div>
-    {error && <p className="mt-3 text-sm text-destructive" role="alert">{error}</p>}
-    <div className="mt-6 grid gap-4 lg:grid-cols-4">
-      <Card className="lg:col-span-2"><CardHeader><CardTitle className="text-base">Review link</CardTitle></CardHeader><CardContent>
-        <div className="flex items-center gap-2 rounded-lg border bg-muted/30 p-3"><EyeOff className="h-4 w-4 shrink-0 text-primary" /><code className="min-w-0 flex-1 truncate text-xs">{reviewUrl}</code><CopyButton text={reviewUrl} label="Copy review link" /></div>
-        <p className="mt-2 text-xs text-muted-foreground">Share in Slack. Reviewers enter a display name and get five randomized blind comparisons at a time.</p>
-      </CardContent></Card>
-      <Card><CardHeader><CardTitle className="text-base">Coverage</CardTitle></CardHeader><CardContent><div className="text-3xl font-semibold">{campaign.results.reviewedCases}/{campaign.caseCount}</div><p className="text-sm text-muted-foreground">cases · {campaign.results.judgments} judgments</p><p className="mt-2 truncate text-xs text-muted-foreground">{campaign.reviewerNames.join(", ") || "Awaiting reviewers"}</p></CardContent></Card>
-      <Card><CardHeader><CardTitle className="text-base">Agreement</CardTitle></CardHeader><CardContent><div className="text-3xl font-semibold">{campaign.results.agreementRate === null ? "—" : `${Math.round(campaign.results.agreementRate * 100)}%`}</div><p className="text-sm text-muted-foreground">{campaign.results.agreementRate === null ? "Needs 2+ reviewers per case" : `majority agreement across ${campaign.results.agreementCases} cases`}</p></CardContent></Card>
-    </div>
-    <Card className="mt-4"><CardHeader><CardTitle className="text-base">Results</CardTitle></CardHeader><CardContent>
-      <div className="mb-4 flex flex-wrap gap-x-6 gap-y-1 text-xs text-muted-foreground"><span><strong className="text-foreground">Candidate A:</strong> {campaign.candidateA.join(", ")}</span><span><strong className="text-foreground">Candidate B:</strong> {campaign.candidateB.join(", ")}</span></div>
-      <div className="grid gap-3 sm:grid-cols-5">{labels.map(([key, label]) => <div key={key} className="rounded-lg border p-3"><div className="text-2xl font-semibold">{campaign.results[key]}</div><div className="text-xs text-muted-foreground">{label}</div></div>)}</div>
-      <p className="mt-4 text-xs text-muted-foreground">A/B is the canonical import order, independent of each reviewer’s randomized first/second presentation. JSONL includes only directional preferences; same, neither, and cannot judge remain in results but are excluded from training rows.</p>
-    </CardContent></Card>
-    {campaign.feedback.length > 0 && <Card className="mt-4"><CardHeader><CardTitle className="text-base">Reviewer notes</CardTitle></CardHeader><CardContent className="space-y-3">{campaign.feedback.map((item, index) => <div key={`${item.caseKey}-${item.reviewerName}-${index}`} className="rounded-lg border p-3"><div className="flex flex-wrap items-center justify-between gap-2 text-xs text-muted-foreground"><span>{item.caseKey} · {item.reviewerName}</span><span>{item.outcome}</span></div><p className="mt-2 whitespace-pre-wrap text-sm">{item.note}</p></div>)}</CardContent></Card>}
-  </div>;
+  );
+}
+
+function Metric({ title, value, detail }: { readonly title: string; readonly value: string; readonly detail: string }) {
+  return <Card><CardHeader><CardTitle className="text-base">{title}</CardTitle></CardHeader><CardContent><div className="text-3xl font-semibold">{value}</div><p className="mt-1 text-xs text-muted-foreground">{detail}</p></CardContent></Card>;
+}
+
+function ResultCount({ label, value }: { readonly label: string; readonly value: number }) {
+  return <div className="rounded-lg border p-3"><div className="text-2xl font-semibold">{value}</div><div className="text-xs text-muted-foreground">{label}</div></div>;
 }

--- a/src/routes/orgs/projects/EvaluatePage.tsx
+++ b/src/routes/orgs/projects/EvaluatePage.tsx
@@ -2,218 +2,93 @@ import { useQuery } from "convex/react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import { api } from "../../../../convex/_generated/api";
 import { useProject } from "@/contexts/ProjectContext";
-import { CycleStatusPill } from "@/components/CycleStatusPill";
 import { EmptyState } from "@/components/EmptyState";
 import { buttonVariants } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
-import { ArrowRight, ClipboardCheck, EyeOff, Layers, Plus } from "lucide-react";
+import { ArrowRight, ClipboardCheck, EyeOff, ListChecks, Plus } from "lucide-react";
 
+/** Unified owner list for independent run reviews and paired comparisons. */
 export function EvaluatePage() {
   const { projectId, role } = useProject();
   const { orgSlug } = useParams<{ orgSlug: string }>();
   const navigate = useNavigate();
-
-  const cycles = useQuery(
-    api.reviewCycles.list,
+  const verdictReviews = useQuery(
+    api.verdictReviewCampaigns.listCampaigns,
     role !== "evaluator" ? { projectId } : "skip",
   );
   const comparisons = useQuery(
     api.comparisonCampaigns.listCampaigns,
     role !== "evaluator" ? { projectId } : "skip",
   );
-
-  const isLoading = cycles === undefined || comparisons === undefined;
-
   const basePath = `/orgs/${orgSlug}/projects/${projectId}`;
 
-  const openCycles = cycles?.filter((c) => c.status === "open") ?? [];
-  const draftCycles = cycles?.filter((c) => c.status === "draft") ?? [];
-  const closedCycles = cycles?.filter((c) => c.status === "closed") ?? [];
-
-  const pastItems: Array<{
-    type: "cycle";
-    id: string;
-    name: string;
-    date: number;
-    closedAction: string | null;
-  }> = closedCycles
-    .map((c) => ({
-      type: "cycle" as const,
-      id: c._id,
-      name: c.name,
-      date: c.closedAt ?? c.createdAt,
-      closedAction: c.closedAction,
-    }))
-    .sort((a, b) => b.date - a.date);
-
-  if (isLoading) {
+  if (verdictReviews === undefined || comparisons === undefined) {
     return (
-      <div className="p-6 space-y-4">
-        <div className="flex items-center justify-between">
-          <Skeleton className="h-8 w-32" />
-          <Skeleton className="h-9 w-32" />
-        </div>
-        <div className="space-y-3">
-          {[...Array(3)].map((_, i) => (
-            <Skeleton key={i} className="h-20 w-full max-w-2xl" />
-          ))}
-        </div>
+      <div className="space-y-4 p-6">
+        <div className="flex items-center justify-between"><Skeleton className="h-8 w-32" /><Skeleton className="h-9 w-32" /></div>
+        {[1, 2, 3].map((key) => <Skeleton key={key} className="h-20 w-full max-w-2xl" />)}
       </div>
     );
   }
 
-  const hasAnything =
-    (comparisons?.length ?? 0) > 0 ||
-    openCycles.length > 0 ||
-    draftCycles.length > 0 ||
-    pastItems.length > 0;
-
+  const hasReviews = verdictReviews.length > 0 || comparisons.length > 0;
   return (
-    <div className="p-6 space-y-6">
-      <div className="flex items-center justify-between">
-        <h1 className="text-xl font-semibold">Evaluate</h1>
-        <div className="flex items-center gap-2">
-          <Link to={`${basePath}/import?source=paired`} className={buttonVariants({ size: "sm" })}>
-            <Plus className="mr-1.5 h-4 w-4" /> New comparison
-          </Link>
-          <Link to={`${basePath}/cycles/new`} className={buttonVariants({ size: "sm", variant: "outline" })}>
-            New cycle
-          </Link>
+    <div className="space-y-6 p-6">
+      <div className="flex items-center justify-between gap-4">
+        <div>
+          <h1 className="text-xl font-semibold">Reviews</h1>
+          <p className="mt-1 text-sm text-muted-foreground">Send completed runs to domain experts without exposing model or harness provenance.</p>
         </div>
+        <Link to={`${basePath}/reviews/new`} className={buttonVariants({ size: "sm" })}>
+          <Plus className="mr-1.5 h-4 w-4" /> New review
+        </Link>
       </div>
 
-      {!hasAnything ? (
+      {!hasReviews ? (
         <EmptyState
           icon={ClipboardCheck}
-          heading="Compare completed attempts without exposing their source"
-          description="Import paired responses for a fast blind comparison, or pool existing runs into a review cycle."
-          action={{
-            label: "New blind comparison",
-            onClick: () => navigate(`${basePath}/import?source=paired`),
-          }}
+          heading="Create a blind review from completed runs"
+          description="Score runs independently or compare two attempts with the same context."
+          action={{ label: "Create blind review", onClick: () => navigate(`${basePath}/reviews/new`) }}
         />
       ) : (
         <div className="max-w-2xl space-y-6">
-          {(comparisons?.length ?? 0) > 0 && <section className="space-y-3">
-            <h2 className="text-sm font-semibold text-muted-foreground uppercase tracking-wide">Blind comparisons</h2>
-            {comparisons?.map((comparison) => <Link key={comparison.id} to={`${basePath}/comparisons/${comparison.id}`} className="flex items-center justify-between rounded-lg border px-4 py-3 transition-colors hover:bg-muted/50">
-              <div className="flex min-w-0 flex-1 items-center gap-3"><EyeOff className="h-4 w-4 shrink-0 text-primary" /><div className="min-w-0"><p className="truncate text-sm font-medium">{comparison.name}</p><p className="text-xs text-muted-foreground">{comparison.caseCount} cases · {comparison.judgments} judgments · {comparison.status}</p></div></div><ArrowRight className="h-4 w-4 text-muted-foreground" />
-            </Link>)}
-          </section>}
-          {/* Active items — need attention now */}
-          {(openCycles.length > 0 || draftCycles.length > 0) && (
-            <section className="space-y-3">
-              <h2 className="text-sm font-semibold text-muted-foreground uppercase tracking-wide">
-                Needs attention
-              </h2>
-
-              {/* Open cycles */}
-              {openCycles.map((cycle) => (
-                <Link
-                  key={cycle._id}
-                  to={`${basePath}/cycles/${cycle._id}`}
-                  className="flex items-center justify-between rounded-lg border border-primary/20 bg-primary/5 px-4 py-3 hover:bg-primary/10 transition-colors"
-                >
-                  <div className="flex-1 min-w-0">
-                    <div className="flex items-center gap-2">
-                      <Layers className="h-4 w-4 text-primary shrink-0" />
-                      <span className="text-sm font-medium truncate">
-                        {cycle.name}
-                      </span>
-                      <CycleStatusPill status={cycle.status} />
-                    </div>
-                    <p className="mt-0.5 text-xs text-muted-foreground">
-                      {cycle.evaluatorProgress.completed}/
-                      {cycle.evaluatorProgress.total} evaluators complete
-                      {cycle.outputCount > 0 &&
-                        ` · ${cycle.outputCount} outputs`}
-                    </p>
-                  </div>
-                  <ArrowRight className="h-4 w-4 text-muted-foreground shrink-0" />
-                </Link>
+          {verdictReviews.length > 0 && (
+            <ReviewSection title="Score runs">
+              {verdictReviews.map((review) => (
+                <ReviewRow
+                  key={review.id}
+                  href={`${basePath}/reviews/verdict/${review.id}`}
+                  icon={ListChecks}
+                  name={review.name}
+                  detail={`${review.itemCount} runs · ${review.judgments} judgments · ${review.status}`}
+                />
               ))}
-
-              {/* Draft cycles */}
-              {draftCycles.map((cycle) => (
-                <Link
-                  key={cycle._id}
-                  to={`${basePath}/cycles/${cycle._id}`}
-                  className="flex items-center justify-between rounded-lg border border-dashed px-4 py-3 hover:bg-muted/50 transition-colors"
-                >
-                  <div className="flex-1 min-w-0">
-                    <div className="flex items-center gap-2">
-                      <Layers className="h-4 w-4 text-muted-foreground shrink-0" />
-                      <span className="text-sm font-medium truncate">
-                        {cycle.name}
-                      </span>
-                      <CycleStatusPill status={cycle.status} />
-                    </div>
-                    <p className="mt-0.5 text-xs text-muted-foreground">
-                      Draft — configure and start when ready
-                    </p>
-                  </div>
-                  <ArrowRight className="h-4 w-4 text-muted-foreground shrink-0" />
-                </Link>
-              ))}
-
-            </section>
+            </ReviewSection>
           )}
-
-          {/* Past evaluations */}
-          {pastItems.length > 0 && (
-            <section className="space-y-3">
-              <h2 className="text-sm font-semibold text-muted-foreground uppercase tracking-wide">
-                Past evaluations
-              </h2>
-              {pastItems.map((item) => (
-                <Link
-                  key={`cycle-${item.id}`}
-                  to={`${basePath}/cycles/${item.id}`}
-                  className="flex items-center justify-between rounded-lg border px-4 py-3 hover:bg-muted/50 transition-colors"
-                >
-                  <div className="flex-1 min-w-0">
-                    <div className="flex items-center gap-2">
-                      <Layers className="h-4 w-4 text-muted-foreground shrink-0" />
-                      <span className="text-sm font-medium truncate">
-                        {item.name}
-                      </span>
-                      <CycleStatusPill status="closed" />
-                    </div>
-                    <p className="mt-0.5 text-xs text-muted-foreground">
-                      {formatDate(item.date)}
-                      {item.closedAction &&
-                        ` · ${formatAction(item.closedAction)}`}
-                    </p>
-                  </div>
-                  <ArrowRight className="h-4 w-4 text-muted-foreground shrink-0" />
-                </Link>
+          {comparisons.length > 0 && (
+            <ReviewSection title="Compare attempts">
+              {comparisons.map((review) => (
+                <ReviewRow
+                  key={review.id}
+                  href={`${basePath}/comparisons/${review.id}`}
+                  icon={EyeOff}
+                  name={review.name}
+                  detail={`${review.caseCount} pairs · ${review.judgments} judgments · ${review.status}`}
+                />
               ))}
-            </section>
+            </ReviewSection>
           )}
         </div>
       )}
-
     </div>
   );
 }
 
-function formatDate(ts: number): string {
-  return new Date(ts).toLocaleDateString(undefined, {
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-  });
+function ReviewSection({ title, children }: { readonly title: string; readonly children: React.ReactNode }) {
+  return <section className="space-y-3"><h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">{title}</h2>{children}</section>;
 }
 
-function formatAction(action: string): string {
-  switch (action) {
-    case "optimized":
-      return "Optimized";
-    case "new_version":
-      return "New version created";
-    case "no_action":
-      return "No action taken";
-    default:
-      return action;
-  }
+function ReviewRow({ href, icon: Icon, name, detail }: { readonly href: string; readonly icon: typeof EyeOff; readonly name: string; readonly detail: string }) {
+  return <Link to={href} className="flex items-center justify-between rounded-lg border px-4 py-3 transition-colors hover:bg-muted/50"><div className="flex min-w-0 flex-1 items-center gap-3"><Icon className="h-4 w-4 shrink-0 text-primary" /><div className="min-w-0"><p className="truncate text-sm font-medium">{name}</p><p className="text-xs text-muted-foreground">{detail}</p></div></div><ArrowRight className="h-4 w-4 text-muted-foreground" /></Link>;
 }

--- a/src/routes/orgs/projects/HistoryPage.tsx
+++ b/src/routes/orgs/projects/HistoryPage.tsx
@@ -64,7 +64,7 @@ export function HistoryPage() {
         <EmptyState
           icon={Clock}
           heading="No activity yet"
-          description="Runs, version changes, review cycles, and optimizations will appear here as they happen."
+          description="Runs, prompt-tool changes, reviews, and optimizations will appear here as they happen."
         />
       ) : (
         <div className="max-w-2xl space-y-6">

--- a/src/routes/orgs/projects/ImportRuns.tsx
+++ b/src/routes/orgs/projects/ImportRuns.tsx
@@ -385,7 +385,13 @@ export function ImportRuns() {
         </CardContent>
       </Card>
 
-      {result && <ImportSummary result={result} tracesHref="../traces" />}
+      {result && (
+        <ImportSummary
+          result={result}
+          createReviewHref="../reviews/new"
+          runsHref="../traces"
+        />
+      )}
 
       <Card className="mt-6 border-amber-500/40 bg-amber-500/5">
         <CardContent className="flex gap-3 pt-6 text-sm text-muted-foreground">
@@ -470,7 +476,15 @@ function CsvMappingEditor({
   );
 }
 
-function ImportSummary({ result, tracesHref }: { readonly result: ImportResult; readonly tracesHref: string }) {
+function ImportSummary({
+  result,
+  createReviewHref,
+  runsHref,
+}: {
+  readonly result: ImportResult;
+  readonly createReviewHref: string;
+  readonly runsHref: string;
+}) {
   const imported = "imported" in result ? result.imported : result.deduped ? 0 : 1;
   const deduped = typeof result.deduped === "number" ? result.deduped : result.deduped ? 1 : 0;
   const summary = result.summary as unknown as Record<string, unknown>;
@@ -518,9 +532,14 @@ function ImportSummary({ result, tracesHref }: { readonly result: ImportResult; 
             </p>
           )}
         </div>
-        <Link to={tracesHref} className={buttonVariants({ size: "sm" })}>
-          Review trajectories
-        </Link>
+        <div className="flex flex-wrap gap-2">
+          <Link to={createReviewHref} className={buttonVariants({ size: "sm" })}>
+            Create blind review
+          </Link>
+          <Link to={runsHref} className={buttonVariants({ size: "sm", variant: "outline" })}>
+            Inspect imported runs
+          </Link>
+        </div>
       </CardContent>
     </Card>
   );

--- a/src/routes/orgs/projects/ReviewBuilder.ct.spec.tsx
+++ b/src/routes/orgs/projects/ReviewBuilder.ct.spec.tsx
@@ -1,0 +1,42 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+import { MemoryRouter } from "react-router-dom";
+import type { Id } from "../../../../convex/_generated/dataModel";
+import { ProjectProvider } from "@/contexts/ProjectContext";
+import { ReviewBuilder } from "./ReviewBuilder";
+
+const projectId = "project-review-builder" as Id<"projects">;
+
+/** Owners can configure either review mode without learning backend concepts. */
+test("review builder selects imported runs and previews the blind reviewer view", async ({ mount }) => {
+  const component = await mount(
+    <MemoryRouter initialEntries={[`/orgs/demo/projects/${projectId}/reviews/new`]}>
+      <ProjectProvider
+        value={{
+          project: {
+            _id: projectId,
+            _creationTime: 1,
+            organizationId: "org-1" as Id<"organizations">,
+            name: "Support quality",
+            createdById: "user-1" as Id<"users">,
+          },
+          projectId,
+          role: "owner",
+          blindMode: undefined,
+        }}
+      >
+        <ReviewBuilder />
+      </ProjectProvider>
+    </MemoryRouter>,
+  );
+
+  await expect(component.getByRole("heading", { name: "Create blind review" })).toBeVisible();
+  await expect(component).toContainText("Score runs");
+  await expect(component).toContainText("Compare attempts");
+  await expect(component).toContainText("2 selected");
+  await expect(component.getByText("Reviewer view preview", { exact: true })).toBeVisible();
+  await expect(component).toContainText("Model, provider, harness, source IDs");
+  await expect(component.getByRole("button", { name: "Create review" })).toBeDisabled();
+
+  await component.getByLabel("Review name").fill("Support review");
+  await expect(component.getByRole("button", { name: "Create review" })).toBeEnabled();
+});

--- a/src/routes/orgs/projects/ReviewBuilder.tsx
+++ b/src/routes/orgs/projects/ReviewBuilder.tsx
@@ -1,0 +1,178 @@
+import { useEffect, useState } from "react";
+import { useMutation, useQuery } from "convex/react";
+import { Link, useNavigate, useParams } from "react-router-dom";
+import { api } from "../../../../convex/_generated/api";
+import type { Id } from "../../../../convex/_generated/dataModel";
+import { useProject } from "@/contexts/ProjectContext";
+import { Button, buttonVariants } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Skeleton } from "@/components/ui/skeleton";
+import { friendlyError } from "@/lib/errors";
+import { cn } from "@/lib/utils";
+import { ArrowLeft, CheckCircle2, EyeOff, GitCompareArrows, ListChecks } from "lucide-react";
+
+/** One owner-facing setup surface for scoring runs or comparing attempts. */
+export function ReviewBuilder() {
+  const { projectId } = useProject();
+  const { orgSlug } = useParams<{ orgSlug: string }>();
+  const navigate = useNavigate();
+  const traces = useQuery(api.agentTraces.listTraces, { projectId });
+  const createReview = useMutation(api.verdictReviewCampaigns.create);
+  const base = `/orgs/${orgSlug}/projects/${projectId}`;
+  const [name, setName] = useState("");
+  const [instructions, setInstructions] = useState(
+    "Check whether the run completed the task correctly. Note the step where quality broke down.",
+  );
+  const [selected, setSelected] = useState<ReadonlySet<Id<"agentTraces">>>(new Set());
+  const [initialized, setInitialized] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    if (initialized || !traces || traces.length === 0) return;
+    setSelected(new Set(traces.slice(0, 10).map((trace) => trace._id)));
+    setInitialized(true);
+  }, [initialized, traces]);
+
+  function toggle(traceId: Id<"agentTraces">) {
+    setSelected((current) => {
+      const next = new Set(current);
+      if (next.has(traceId)) next.delete(traceId);
+      else next.add(traceId);
+      return next;
+    });
+  }
+
+  async function handleCreate(event: React.FormEvent) {
+    event.preventDefault();
+    if (!name.trim() || selected.size === 0 || busy) return;
+    setBusy(true);
+    setError("");
+    try {
+      const campaignId = await createReview({
+        projectId,
+        name: name.trim(),
+        instructions: instructions.trim() || undefined,
+        traceIds: [...selected],
+      });
+      navigate(`${base}/reviews/verdict/${campaignId}`);
+    } catch (cause: unknown) {
+      setError(friendlyError(cause, "Could not create this review."));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="mx-auto max-w-5xl p-6">
+      <Link to={`${base}/evaluate`} className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground">
+        <ArrowLeft aria-hidden="true" className="h-3.5 w-3.5" /> Reviews
+      </Link>
+      <header className="mt-3">
+        <h1 className="text-2xl font-bold">Create blind review</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Select completed runs, set the review question, and preview what reviewers can see.
+        </p>
+      </header>
+
+      <div className="mt-6 grid gap-4 sm:grid-cols-2">
+        <Card className="border-primary bg-primary/5">
+          <CardHeader><CardTitle className="flex items-center gap-2 text-base"><ListChecks className="h-4 w-4 text-primary" /> Score runs</CardTitle></CardHeader>
+          <CardContent className="text-sm text-muted-foreground">
+            Review one or more runs independently with an overall verdict and step-level comments.
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader><CardTitle className="flex items-center gap-2 text-base"><GitCompareArrows className="h-4 w-4" /> Compare attempts</CardTitle></CardHeader>
+          <CardContent className="space-y-3 text-sm text-muted-foreground">
+            <p>Choose between two attempts that share the same task or conversation prefix.</p>
+            <Link to={`${base}/import?source=paired`} className={cn(buttonVariants({ size: "sm", variant: "outline" }))}>
+              Import paired attempts
+            </Link>
+          </CardContent>
+        </Card>
+      </div>
+
+      <form onSubmit={handleCreate} className="mt-6 grid gap-6 lg:grid-cols-[1fr_320px]">
+        <div className="space-y-5">
+          <Card>
+            <CardHeader><CardTitle className="text-base">Review details</CardTitle></CardHeader>
+            <CardContent className="space-y-4">
+              <div className="space-y-1.5">
+                <Label htmlFor="review-name">Review name</Label>
+                <Input id="review-name" value={name} onChange={(event) => setName(event.target.value)} placeholder="July support-agent quality check" maxLength={120} autoFocus />
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="review-instructions">Question for reviewers</Label>
+                <Textarea id="review-instructions" value={instructions} onChange={(event) => setInstructions(event.target.value)} rows={4} maxLength={2_000} />
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center justify-between gap-3 text-base">
+                <span>Select runs</span>
+                <span className="text-xs font-normal text-muted-foreground">{selected.size} selected · 50 maximum</span>
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              {traces === undefined ? (
+                <div className="space-y-2">{[1, 2, 3].map((key) => <Skeleton key={key} className="h-14 w-full" />)}</div>
+              ) : traces.length === 0 ? (
+                <div className="space-y-3 text-sm text-muted-foreground">
+                  <p>Add completed runs before creating a review.</p>
+                  <Link to={`${base}/import`} className={buttonVariants({ size: "sm" })}>Add runs</Link>
+                </div>
+              ) : (
+                <div className="max-h-[440px] divide-y overflow-y-auto rounded-md border">
+                  {traces.map((trace) => {
+                    const traceId = trace._id;
+                    const checked = selected.has(traceId);
+                    const source = [trace.product, trace.harnessName, trace.model].filter(Boolean).join(" · ") || "Imported run";
+                    return (
+                      <label key={trace._id} className="flex cursor-pointer items-start gap-3 px-3 py-3 hover:bg-muted/40">
+                        <input type="checkbox" checked={checked} onChange={() => toggle(traceId)} className="mt-0.5 h-4 w-4 accent-primary" />
+                        <span className="min-w-0 flex-1">
+                          <span className="block truncate text-sm font-medium">{source}</span>
+                          <span className="text-xs text-muted-foreground">{trace.stepCount} {trace.stepCount === 1 ? "step" : "steps"} · {new Date(trace.createdAt).toLocaleString()}</span>
+                        </span>
+                      </label>
+                    );
+                  })}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+          {error && <p className="text-sm text-destructive" role="alert">{error}</p>}
+          <Button type="submit" disabled={busy || !name.trim() || selected.size === 0}>
+            {busy ? "Creating…" : "Create review"}
+          </Button>
+        </div>
+
+        <ReviewerPreview instructions={instructions} selectedCount={selected.size} />
+      </form>
+    </div>
+  );
+}
+
+function ReviewerPreview({ instructions, selectedCount }: { readonly instructions: string; readonly selectedCount: number }) {
+  return (
+    <Card className="h-fit lg:sticky lg:top-4">
+      <CardHeader><CardTitle className="flex items-center gap-2 text-base"><EyeOff className="h-4 w-4 text-primary" /> Reviewer view preview</CardTitle></CardHeader>
+      <CardContent className="space-y-4 text-sm">
+        <p className="rounded-md bg-muted/40 p-3 text-muted-foreground">{instructions.trim() || "Your review question appears here."}</p>
+        {["Task and context", "Final outcome", "Ordered steps and tool calls", "Verdict and optional note"].map((label) => (
+          <div key={label} className="flex items-center gap-2"><CheckCircle2 className="h-4 w-4 text-primary" /><span>{label}</span></div>
+        ))}
+        <div className="rounded-md border border-primary/30 bg-primary/5 p-3 text-xs text-muted-foreground">
+          Model, provider, harness, source IDs, token counts, cost, and timing stay hidden. For multi-step runs, blinding reduces bias but is not anonymity.
+        </div>
+        <p className="text-xs text-muted-foreground">Reviewers receive {selectedCount || "the selected"} run{selectedCount === 1 ? "" : "s"} in a stable randomized order.</p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/routes/orgs/projects/ReviewResults.ct.spec.tsx
+++ b/src/routes/orgs/projects/ReviewResults.ct.spec.tsx
@@ -1,0 +1,38 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+import { MemoryRouter } from "react-router-dom";
+import type { Id } from "../../../../convex/_generated/dataModel";
+import { ProjectProvider } from "@/contexts/ProjectContext";
+import { ReviewResults } from "./ReviewResults";
+
+const projectId = "project-results" as Id<"projects">;
+
+/** Collecting and reusable evidence share one Results model across review modes. */
+test("results groups collecting and closed verdict/comparison reviews", async ({ mount }) => {
+  const component = await mount(
+    <MemoryRouter initialEntries={[`/orgs/demo/projects/${projectId}/results`]}>
+      <ProjectProvider
+        value={{
+          project: {
+            _id: projectId,
+            _creationTime: 1,
+            organizationId: "org-1" as Id<"organizations">,
+            name: "Support quality",
+            createdById: "user-1" as Id<"users">,
+          },
+          projectId,
+          role: "owner",
+          blindMode: undefined,
+        }}
+      >
+        <ReviewResults />
+      </ProjectProvider>
+    </MemoryRouter>,
+  );
+
+  await expect(component.getByRole("heading", { name: "Results" })).toBeVisible();
+  await expect(component).toContainText("Collecting");
+  await expect(component).toContainText("Closed and reusable");
+  await expect(component).toContainText("2/5 runs reviewed");
+  await expect(component).toContainText("3/3 runs reviewed");
+  await expect(component).toContainText("10 judgments across 5 pairs");
+});

--- a/src/routes/orgs/projects/ReviewResults.tsx
+++ b/src/routes/orgs/projects/ReviewResults.tsx
@@ -1,0 +1,29 @@
+import { Link, useNavigate, useParams } from "react-router-dom";
+import { useProject } from "@/contexts/ProjectContext";
+import { EmptyState } from "@/components/EmptyState";
+import { BarChart3 } from "lucide-react";
+
+/** Owner-facing entry point for completed and collecting human-review results. */
+export function ReviewResults() {
+  const { projectId } = useProject();
+  const { orgSlug } = useParams<{ orgSlug: string }>();
+  const navigate = useNavigate();
+  const reviewsHref = `/orgs/${orgSlug}/projects/${projectId}/evaluate`;
+
+  return (
+    <div className="p-6">
+      <h1 className="text-xl font-semibold">Results</h1>
+      <div className="mt-6">
+        <EmptyState
+          icon={BarChart3}
+          heading="Results appear after people review your runs"
+          description="Create a blind review, share the link, and come back here to see verdicts, agreement, and comments."
+          action={{ label: "Open reviews", onClick: () => navigate(reviewsHref) }}
+        />
+        <p className="mt-4 text-center text-xs text-muted-foreground">
+          Or <Link className="text-primary hover:underline" to={reviewsHref}>view reviews in progress</Link>.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/routes/orgs/projects/ReviewResults.tsx
+++ b/src/routes/orgs/projects/ReviewResults.tsx
@@ -1,29 +1,107 @@
+import { useQuery } from "convex/react";
 import { Link, useNavigate, useParams } from "react-router-dom";
+import { api } from "../../../../convex/_generated/api";
 import { useProject } from "@/contexts/ProjectContext";
 import { EmptyState } from "@/components/EmptyState";
-import { BarChart3 } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { ArrowRight, BarChart3, GitCompareArrows, ListChecks } from "lucide-react";
 
-/** Owner-facing entry point for completed and collecting human-review results. */
+/** Aggregated owner entry point for collecting and completed human-review evidence. */
 export function ReviewResults() {
   const { projectId } = useProject();
   const { orgSlug } = useParams<{ orgSlug: string }>();
   const navigate = useNavigate();
-  const reviewsHref = `/orgs/${orgSlug}/projects/${projectId}/evaluate`;
+  const verdictReviews = useQuery(api.verdictReviewCampaigns.listCampaigns, { projectId });
+  const comparisons = useQuery(api.comparisonCampaigns.listCampaigns, { projectId });
+  const base = `/orgs/${orgSlug}/projects/${projectId}`;
+
+  if (verdictReviews === undefined || comparisons === undefined) {
+    return <div className="space-y-3 p-6">{[1, 2, 3].map((key) => <Skeleton key={key} className="h-20 w-full max-w-3xl" />)}</div>;
+  }
+
+  const rows: ReadonlyArray<ResultRow> = [
+    ...verdictReviews.map((review) => ({
+      id: String(review.id),
+      mode: "verdict" as const,
+      name: review.name,
+      status: review.status,
+      href: `${base}/reviews/verdict/${review.id}`,
+      coverage: `${review.reviewedRuns}/${review.itemCount} runs reviewed`,
+      judgments: review.judgments,
+      reviewers: review.reviewers,
+      createdAt: review.createdAt,
+    })),
+    ...comparisons.map((review) => ({
+      id: String(review.id),
+      mode: "comparison" as const,
+      name: review.name,
+      status: review.status === "importing" ? "draft" as const : review.status,
+      href: `${base}/comparisons/${review.id}`,
+      coverage: `${review.judgments} judgments across ${review.caseCount} pairs`,
+      judgments: review.judgments,
+      reviewers: 0,
+      createdAt: review.createdAt,
+    })),
+  ].sort((left, right) => right.createdAt - left.createdAt);
+  const collecting = rows.filter((row) => row.status !== "closed");
+  const completed = rows.filter((row) => row.status === "closed");
 
   return (
-    <div className="p-6">
-      <h1 className="text-xl font-semibold">Results</h1>
-      <div className="mt-6">
+    <div className="space-y-6 p-6">
+      <header>
+        <h1 className="text-xl font-semibold">Results</h1>
+        <p className="mt-1 text-sm text-muted-foreground">Coverage, verdicts, disagreement, comments, and reuse actions from blind human review.</p>
+      </header>
+
+      {rows.length === 0 ? (
         <EmptyState
           icon={BarChart3}
           heading="Results appear after people review your runs"
-          description="Create a blind review, share the link, and come back here to see verdicts, agreement, and comments."
-          action={{ label: "Open reviews", onClick: () => navigate(reviewsHref) }}
+          description="Create a blind review, share the link, and return here to reuse the evidence."
+          action={{ label: "Create review", onClick: () => navigate(`${base}/reviews/new`) }}
         />
-        <p className="mt-4 text-center text-xs text-muted-foreground">
-          Or <Link className="text-primary hover:underline" to={reviewsHref}>view reviews in progress</Link>.
-        </p>
-      </div>
+      ) : (
+        <div className="max-w-3xl space-y-7">
+          {collecting.length > 0 && <ResultSection title="Collecting" rows={collecting} />}
+          {completed.length > 0 && <ResultSection title="Closed and reusable" rows={completed} />}
+        </div>
+      )}
     </div>
+  );
+}
+
+type ResultRow = {
+  readonly id: string;
+  readonly mode: "verdict" | "comparison";
+  readonly name: string;
+  readonly status: "draft" | "open" | "closed";
+  readonly href: string;
+  readonly coverage: string;
+  readonly judgments: number;
+  readonly reviewers: number;
+  readonly createdAt: number;
+};
+
+function ResultSection({ title, rows }: { readonly title: string; readonly rows: ReadonlyArray<ResultRow> }) {
+  return (
+    <section className="space-y-3">
+      <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">{title}</h2>
+      {rows.map((row) => {
+        const Icon = row.mode === "verdict" ? ListChecks : GitCompareArrows;
+        return (
+          <Link key={`${row.mode}-${row.id}`} to={row.href} className="flex items-center justify-between gap-4 rounded-lg border px-4 py-3 transition-colors hover:bg-muted/50">
+            <div className="flex min-w-0 items-center gap-3">
+              <Icon aria-hidden="true" className="h-4 w-4 shrink-0 text-primary" />
+              <div className="min-w-0">
+                <div className="flex items-center gap-2"><p className="truncate text-sm font-medium">{row.name}</p><Badge variant="outline" className="text-[10px] capitalize">{row.status}</Badge></div>
+                <p className="mt-0.5 text-xs text-muted-foreground">{row.coverage}{row.reviewers > 0 ? ` · ${row.reviewers} reviewers` : ""}</p>
+              </div>
+            </div>
+            <ArrowRight aria-hidden="true" className="h-4 w-4 shrink-0 text-muted-foreground" />
+          </Link>
+        );
+      })}
+    </section>
   );
 }

--- a/src/routes/orgs/projects/RunView.tsx
+++ b/src/routes/orgs/projects/RunView.tsx
@@ -185,7 +185,7 @@ export function RunView() {
               to={`/orgs/${orgSlug}/projects/${projectId}/cycles/new?primaryVersionId=${run.promptVersionId}`}
               className="text-primary hover:underline font-medium"
             >
-              Start a review cycle
+              Create blind review
             </Link>{" "}
             to track evaluator progress and compare versions.
           </p>

--- a/src/routes/orgs/projects/RunsList.tsx
+++ b/src/routes/orgs/projects/RunsList.tsx
@@ -67,7 +67,7 @@ export function RunsList() {
                 Comparing {compareVersionLabels.join(" vs ")}
               </p>
               <p className="text-xs text-muted-foreground">
-                Once runs complete, create a review cycle to get blind
+                Once runs complete, create a blind review to get
                 evaluations.
               </p>
             </div>
@@ -76,7 +76,7 @@ export function RunsList() {
             to={`/orgs/${orgSlug}/projects/${projectId}/cycles/new?primaryVersionId=${compareVersionIds[0]}&controlVersionId=${compareVersionIds[1]}`}
             className={buttonVariants({ size: "sm" })}
           >
-            Create Review Cycle
+            Create blind review
           </Link>
         </div>
       )}

--- a/src/routes/orgs/projects/VerdictReviewDetail.tsx
+++ b/src/routes/orgs/projects/VerdictReviewDetail.tsx
@@ -1,0 +1,225 @@
+import { useState } from "react";
+import { useAction, useMutation, useQuery } from "convex/react";
+import { Link, useParams } from "react-router-dom";
+import { api } from "../../../../convex/_generated/api";
+import type { Id } from "../../../../convex/_generated/dataModel";
+import { useProject } from "@/contexts/ProjectContext";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { CopyButton } from "@/components/ui/copy-button";
+import { friendlyError } from "@/lib/errors";
+import { ArrowLeft, ClipboardCopy, Database, Download, EyeOff, Lock, MessageSquareText } from "lucide-react";
+
+/** Owner/editor lifecycle and early results for one blind run review. */
+export function VerdictReviewDetail() {
+  const { projectId } = useProject();
+  const { orgSlug, campaignId = "" } = useParams<{
+    orgSlug: string;
+    campaignId: string;
+  }>();
+  // SAFETY: Convex validates the route value as a table ID at the RPC boundary.
+  const id = campaignId as Id<"verdictReviewCampaigns">;
+  const campaign = useQuery(api.verdictReviewCampaigns.getOwnerCampaign, {
+    campaignId: id,
+  });
+  const openCampaign = useMutation(api.verdictReviewCampaigns.openCampaign);
+  const closeCampaign = useMutation(api.verdictReviewCampaigns.closeCampaign);
+  const promoteRuns = useMutation(api.verdictReviewCampaigns.promoteAcceptedRuns);
+  const generateExport = useAction(api.exports.generateExport);
+  const downloadExport = useAction(api.exports.downloadExport);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState("");
+  const [reuseMessage, setReuseMessage] = useState("");
+  const base = `/orgs/${orgSlug}/projects/${projectId}`;
+
+  if (campaign === undefined) {
+    return <div className="p-6 text-sm text-muted-foreground">Loading review…</div>;
+  }
+  const currentCampaign = campaign;
+  const reviewUrl = `${window.location.origin}/review/verdict/${currentCampaign.shareToken}`;
+
+  async function open() {
+    setBusy(true);
+    setError("");
+    try {
+      await openCampaign({ campaignId: id });
+    } catch (cause: unknown) {
+      setError(friendlyError(cause, "Could not open this review."));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function close() {
+    if (!window.confirm("Close this review? Reviewers will no longer be able to submit verdicts.")) return;
+    setBusy(true);
+    setError("");
+    try {
+      await closeCampaign({ campaignId: id });
+    } catch (cause: unknown) {
+      setError(friendlyError(cause, "Could not close this review."));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function promote() {
+    setBusy(true);
+    setError("");
+    setReuseMessage("");
+    try {
+      const result = await promoteRuns({ campaignId: id });
+      setReuseMessage(
+        `${result.added} added to the regression set · ${result.alreadyPresent} already present · ${result.excluded} excluded`,
+      );
+    } catch (cause: unknown) {
+      setError(friendlyError(cause, "Could not add these runs to the regression set."));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function exportSft() {
+    setBusy(true);
+    setError("");
+    setReuseMessage("");
+    try {
+      const result = await generateExport({
+        projectId,
+        verdictCampaignId: id,
+        source: "trajectory",
+        format: "sft",
+      });
+      if (result.rowCount === 0) {
+        setReuseMessage(`No SFT rows were eligible. ${result.excludedCount} runs were explicitly excluded by review or data-boundary gates.`);
+        return;
+      }
+      const { url } = await downloadExport({ exportId: result.exportId });
+      window.open(url, "_blank", "noopener,noreferrer");
+      setReuseMessage(`${result.rowCount} approved SFT rows ready; ${result.excludedCount} excluded.`);
+    } catch (cause: unknown) {
+      setError(friendlyError(cause, "Could not export approved runs."));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function copyEvidence() {
+    const summary = [
+      currentCampaign.name,
+      `${currentCampaign.results.judgments} judgments from ${currentCampaign.results.reviewers} reviewers`,
+      `${currentCampaign.results.best} strong · ${currentCampaign.results.acceptable} acceptable · ${currentCampaign.results.weak} weak`,
+      `${currentCampaign.results.disagreementRuns} runs with disagreement`,
+    ].join("\n");
+    await navigator.clipboard.writeText(summary);
+    setReuseMessage("Evidence summary copied.");
+  }
+
+  return (
+    <div className="mx-auto max-w-5xl p-6">
+      <Link to={`${base}/evaluate`} className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground">
+        <ArrowLeft aria-hidden="true" className="h-3.5 w-3.5" /> Reviews
+      </Link>
+      <div className="mt-3 flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-bold">{currentCampaign.name}</h1>
+          <p className="mt-1 text-sm text-muted-foreground">Score runs · {currentCampaign.itemCount} runs · {currentCampaign.status}</p>
+        </div>
+        <div className="flex gap-2">
+          {currentCampaign.status === "draft" && <Button onClick={open} disabled={busy}>Open for review</Button>}
+          {currentCampaign.status === "open" && <Button variant="outline" onClick={close} disabled={busy}><Lock className="h-4 w-4" /> Close</Button>}
+        </div>
+      </div>
+      {currentCampaign.instructions && <p className="mt-3 max-w-2xl text-sm text-muted-foreground">{currentCampaign.instructions}</p>}
+      {error && <p className="mt-3 text-sm text-destructive" role="alert">{error}</p>}
+
+      <div className="mt-6 grid gap-4 lg:grid-cols-4">
+        <Card className="lg:col-span-2">
+          <CardHeader><CardTitle className="text-base">Review link</CardTitle></CardHeader>
+          <CardContent>
+            <div className="flex items-center gap-2 rounded-lg border bg-muted/30 p-3">
+              <EyeOff aria-hidden="true" className="h-4 w-4 shrink-0 text-primary" />
+              <code className="min-w-0 flex-1 truncate text-xs">{reviewUrl}</code>
+              <CopyButton text={reviewUrl} label="Copy review link" />
+            </div>
+            <p className="mt-2 text-xs text-muted-foreground">
+              {currentCampaign.status === "draft"
+                ? "Open the review before sharing this link."
+                : "Share this link in Slack or email. No Blind Bench account is required."}
+            </p>
+          </CardContent>
+        </Card>
+        <Metric title="Coverage" value={`${currentCampaign.results.reviewedRuns}/${currentCampaign.itemCount}`} detail={`${currentCampaign.results.judgments} judgments`} />
+        <Metric title="Reviewers" value={String(currentCampaign.results.reviewers)} detail={currentCampaign.reviewerNames.join(", ") || "Awaiting reviewers"} />
+      </div>
+
+      <Card className="mt-4">
+        <CardHeader><CardTitle className="text-base">Verdicts</CardTitle></CardHeader>
+        <CardContent>
+          <div className="grid gap-3 sm:grid-cols-4">
+            <ResultCount label="Best" value={currentCampaign.results.best} />
+            <ResultCount label="Acceptable" value={currentCampaign.results.acceptable} />
+            <ResultCount label="Weak" value={currentCampaign.results.weak} />
+            <ResultCount label="Runs with disagreement" value={currentCampaign.results.disagreementRuns} />
+          </div>
+        </CardContent>
+      </Card>
+
+      {currentCampaign.status === "closed" ? (
+        <Card className="mt-4">
+          <CardHeader><CardTitle className="text-base">Use this result</CardTitle></CardHeader>
+          <CardContent className="space-y-3">
+            <div className="flex flex-wrap gap-2">
+              <Button variant="outline" onClick={() => void copyEvidence()} disabled={busy}><ClipboardCopy className="h-4 w-4" /> Copy evidence summary</Button>
+              <Button variant="outline" onClick={() => void promote()} disabled={busy || currentCampaign.results.judgments === 0}><Database className="h-4 w-4" /> Add approved runs to regression set</Button>
+              <Button variant="outline" onClick={() => void exportSft()} disabled={busy || currentCampaign.results.judgments === 0}><Download className="h-4 w-4" /> Export approved SFT</Button>
+            </div>
+            <p className="text-xs text-muted-foreground">
+              Regression promotion uses majority non-weak verdicts. SFT requires at least one Strong verdict and excludes any run with a Weak verdict; every exclusion is reported.
+            </p>
+            {reuseMessage && <p className="text-sm text-muted-foreground" role="status">{reuseMessage}</p>}
+          </CardContent>
+        </Card>
+      ) : (
+        <Card className="mt-4 border-dashed">
+          <CardContent className="pt-6 text-sm text-muted-foreground">Close the review to unlock evidence, regression, and eligible training-data actions.</CardContent>
+        </Card>
+      )}
+
+      <Card className="mt-4">
+        <CardHeader><CardTitle className="text-base">Source mapping</CardTitle></CardHeader>
+        <CardContent className="space-y-2">
+          <p className="text-xs text-muted-foreground">Visible only to project owners and editors after reviewers judge blind.</p>
+          {currentCampaign.runs.map((run) => (
+            <div key={run.traceId} className="flex flex-wrap items-center justify-between gap-2 rounded border px-3 py-2 text-sm">
+              <span>{[run.product, run.harness, run.model].filter(Boolean).join(" · ")}</span>
+              <span className="text-xs text-muted-foreground">{run.judgments} judgments</span>
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+
+      {currentCampaign.comments.length > 0 && (
+        <Card className="mt-4">
+          <CardHeader><CardTitle className="flex items-center gap-2 text-base"><MessageSquareText className="h-4 w-4" /> Reviewer comments</CardTitle></CardHeader>
+          <CardContent className="space-y-3">
+            {currentCampaign.comments.map((comment, index) => (
+              <div key={`${comment.traceId}-${index}`} className="rounded-lg border p-3">
+                <p className="text-xs text-muted-foreground">{comment.reviewerName} · {comment.target.kind === "trace" ? "whole run" : `${comment.target.kind.replace("_", " ")} ${comment.target.stepIndex + 1}`}</p>
+                <p className="mt-2 whitespace-pre-wrap text-sm">{comment.comment}</p>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}
+
+function Metric({ title, value, detail }: { readonly title: string; readonly value: string; readonly detail: string }) {
+  return <Card><CardHeader><CardTitle className="text-base">{title}</CardTitle></CardHeader><CardContent><div className="text-3xl font-semibold">{value}</div><p className="mt-1 truncate text-xs text-muted-foreground">{detail}</p></CardContent></Card>;
+}
+
+function ResultCount({ label, value }: { readonly label: string; readonly value: number }) {
+  return <div className="rounded-lg border p-3"><div className="text-2xl font-semibold">{value}</div><div className="text-xs text-muted-foreground">{label}</div></div>;
+}

--- a/src/routes/orgs/projects/cycles/CycleDetail.tsx
+++ b/src/routes/orgs/projects/cycles/CycleDetail.tsx
@@ -531,7 +531,7 @@ export function CycleDetail() {
         </div>
       </div>
 
-      {/* Phase 2 Battle Results */}
+      {/* Legacy comparison results */}
       <BattleResultsSection stats={matchupStats} />
 
       {/* Reviewer Comments */}
@@ -770,7 +770,7 @@ function BattleResultsSection({ stats }: { stats: MatchupStats | undefined }) {
     <div className="mt-8">
       <div className="flex items-center justify-between mb-3">
         <h3 className="text-sm font-semibold">
-          Battle Results{" "}
+          Comparison results{" "}
           <span className="font-normal text-muted-foreground">
             — {stats.decidedCount} decided across {stats.phase2Sessions}{" "}
             session{stats.phase2Sessions !== 1 ? "s" : ""}
@@ -781,7 +781,7 @@ function BattleResultsSection({ stats }: { stats: MatchupStats | undefined }) {
       {stats.outputs.length === 0 ? (
         <div className="rounded-lg border border-dashed p-6 text-center">
           <p className="text-sm text-muted-foreground">
-            Battle rounds haven't produced decided matchups yet.
+            Comparison rounds haven't produced decided matchups yet.
           </p>
         </div>
       ) : (
@@ -797,7 +797,7 @@ function BattleResultsSection({ stats }: { stats: MatchupStats | undefined }) {
                 <div className="flex items-center gap-3">
                   <BlindLabelBadge label={row.cycleBlindLabel} />
                   <span className="text-xs text-muted-foreground">
-                    {row.battles} battle{row.battles !== 1 ? "s" : ""}
+                    {row.battles} comparison{row.battles !== 1 ? "s" : ""}
                   </span>
                 </div>
                 <div className="flex items-center gap-4 text-xs">

--- a/src/routes/orgs/projects/settings/ProjectCollaborators.tsx
+++ b/src/routes/orgs/projects/settings/ProjectCollaborators.tsx
@@ -47,11 +47,11 @@ export function ProjectCollaborators() {
           <div>
             <h1 className="text-2xl font-bold">Collaborators</h1>
             <p className="mt-1 text-sm text-muted-foreground">
-              Manage who can access this prompt and their roles.
+              Manage who can access this review project and their roles.
             </p>
             <p className="mt-2 text-sm text-muted-foreground">
-              Evaluators can only see blinded outputs and leave feedback. They cannot
-              see versions or know which version produced which output.
+              Blind reviewers see only the task, outcome, and projected steps. Model,
+              harness, and source provenance remain hidden while they judge.
             </p>
           </div>
           <Button onClick={() => setInviteOpen(true)}>

--- a/src/routes/orgs/projects/settings/ProjectSettings.tsx
+++ b/src/routes/orgs/projects/settings/ProjectSettings.tsx
@@ -56,7 +56,7 @@ export function ProjectSettings() {
   }
 
   async function handleDelete() {
-    if (!confirm("Delete this prompt? This action cannot be undone.")) return;
+    if (!confirm("Delete this project? This action cannot be undone.")) return;
     setDeleting(true);
     setDeleteError("");
     try {
@@ -65,7 +65,7 @@ export function ProjectSettings() {
     } catch (err) {
       setDeleting(false);
       setDeleteError(
-        friendlyError(err, "Failed to delete prompt. Please try again."),
+        friendlyError(err, "Failed to delete project. Please try again."),
       );
     }
   }
@@ -74,9 +74,9 @@ export function ProjectSettings() {
     <div className="flex">
       <ProjectSettingsNav />
       <div className="p-6 max-w-2xl flex-1">
-      <h1 className="text-2xl font-bold">Prompt settings</h1>
+      <h1 className="text-2xl font-bold">Project settings</h1>
       <p className="mt-1 text-sm text-muted-foreground">
-        Manage prompt details.
+        Manage this review project's details.
       </p>
 
       <form onSubmit={handleSave} className="mt-6 space-y-4">
@@ -94,7 +94,7 @@ export function ProjectSettings() {
             id="project-desc"
             value={description}
             onChange={(e) => setDescription(e.target.value)}
-            placeholder="What this prompt is about"
+            placeholder="What runs and decisions this project covers"
           />
         </div>
         {error && <p className="text-sm text-destructive">{error}</p>}
@@ -116,13 +116,13 @@ export function ProjectSettings() {
             onClick={handleDelete}
             disabled={deleting}
           >
-            {deleting ? "Deleting..." : "Delete prompt"}
+            {deleting ? "Deleting..." : "Delete project"}
           </Button>
           {deleteError && (
             <p className="mt-2 text-sm text-destructive">{deleteError}</p>
           )}
           <p className="mt-2 text-xs text-muted-foreground">
-            This will permanently delete the prompt and all its data.
+            This will permanently delete the project and all its data.
           </p>
         </CardContent>
       </Card>

--- a/src/routes/orgs/projects/settings/ProjectSettingsNav.tsx
+++ b/src/routes/orgs/projects/settings/ProjectSettingsNav.tsx
@@ -1,10 +1,11 @@
 import { NavLink, useParams } from "react-router-dom";
 import { useProject } from "@/contexts/ProjectContext";
 import { cn } from "@/lib/utils";
-import { Settings, Users } from "lucide-react";
+import { DatabaseZap, Settings, Users } from "lucide-react";
 
 const links = [
   { label: "General", path: "", icon: Settings, end: true },
+  { label: "Data sources", path: "sources", icon: DatabaseZap, end: false },
   { label: "Collaborators", path: "collaborators", icon: Users, end: false },
 ];
 

--- a/src/routes/orgs/projects/settings/ProjectSources.tsx
+++ b/src/routes/orgs/projects/settings/ProjectSources.tsx
@@ -1,0 +1,88 @@
+import { Link, useParams } from "react-router-dom";
+import { useProject } from "@/contexts/ProjectContext";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { buttonVariants } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { CloudDownload, FileInput, RadioTower } from "lucide-react";
+import { ProjectSettingsNav } from "./ProjectSettingsNav";
+
+/** Project-level entry points for file, API, and advanced Gateway ingestion. */
+export function ProjectSources() {
+  const { projectId } = useProject();
+  const { orgSlug } = useParams<{ orgSlug: string }>();
+  const projectBase = `/orgs/${orgSlug}/projects/${projectId}`;
+  const orgBase = `/orgs/${orgSlug}`;
+
+  return (
+    <div className="flex">
+      <ProjectSettingsNav />
+      <div className="max-w-3xl flex-1 p-6">
+        <header>
+          <h1 className="text-2xl font-bold">Data sources</h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Add completed AI behavior by file or endpoint. Blind Bench stores and
+            reviews runs; it does not execute your harness.
+          </p>
+        </header>
+
+        <div className="mt-6 grid gap-4 sm:grid-cols-2">
+          <SourceCard
+            icon={FileInput}
+            title="Upload completed runs"
+            description="CSV, OpenTelemetry JSON, Pi sessions, and Claude Code transcripts."
+            href={`${projectBase}/import`}
+            action="Open file import"
+          />
+          <SourceCard
+            icon={RadioTower}
+            title="Continuous ingest"
+            description="Send native eval-record v1 or OTLP events with a project-scoped token."
+            href={`${projectBase}/ingest`}
+            action="Configure endpoint"
+          />
+          <SourceCard
+            icon={CloudDownload}
+            title="Cloudflare AI Gateway"
+            description="Advanced adapter for exported Gateway JSONL and scorecard materialization."
+            href={`${orgBase}/gateway-import`}
+            action="Open Gateway adapter"
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SourceCard({
+  icon: Icon,
+  title,
+  description,
+  href,
+  action,
+}: {
+  readonly icon: typeof FileInput;
+  readonly title: string;
+  readonly description: string;
+  readonly href: string;
+  readonly action: string;
+}) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-base">
+          <Icon aria-hidden="true" className="h-4 w-4 text-primary" />
+          {title}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <p className="text-sm text-muted-foreground">{description}</p>
+        <Link
+          to={href}
+          className={cn(buttonVariants({ size: "sm", variant: "outline" }))}
+        >
+          {action}
+        </Link>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/routes/review/CheatSheetDialog.tsx
+++ b/src/routes/review/CheatSheetDialog.tsx
@@ -46,8 +46,8 @@ export function CheatSheetDialog({
           <DialogTitle>Keyboard shortcuts</DialogTitle>
           <DialogDescription>
             {phase === "phase1" &&
-              "Phase 1 — review each output. Navigation is separate from rating."}
-            {phase === "phase2" && "Phase 2 — pick one of two."}
+              "Score each attempt. Navigation is separate from rating."}
+            {phase === "phase2" && "Compare two attempts and pick one."}
             {phase === "complete" && "Nothing to do here."}
           </DialogDescription>
         </DialogHeader>

--- a/src/routes/review/DemoDeck.tsx
+++ b/src/routes/review/DemoDeck.tsx
@@ -102,7 +102,7 @@ export function DemoDeck() {
     );
     const pairs = generateRoundRobinMatchups(MOCK_OUTPUTS, dropped);
     if (pairs.length < 1) {
-      toast.error("Need at least 2 non-weak outputs to battle.");
+      toast.error("Need at least 2 non-weak attempts to compare.");
       return;
     }
     setMatchups(
@@ -269,7 +269,7 @@ function DemoHeader({
               onClick={onSubmitPhase1}
               disabled={reviewedCount === 0}
             >
-              Submit Phase 1
+              Finish scoring
               <ArrowRight className="size-3.5" />
             </Button>
           )}
@@ -294,8 +294,8 @@ function DemoHeader({
 
 function PhaseChip({ phase }: { phase: Phase }) {
   const label = {
-    phase1: "Phase 1 · Review",
-    phase2: "Phase 2 · Battle",
+    phase1: "Score attempts",
+    phase2: "Compare attempts",
     complete: "Complete",
   }[phase];
 
@@ -357,7 +357,7 @@ function CompletePhase({
       </div>
 
       <section className="rounded-lg border p-4">
-        <h2 className="text-sm font-medium">Phase 1 · ratings</h2>
+        <h2 className="text-sm font-medium">Scores</h2>
         <div className="mt-2 flex gap-4 text-sm">
           <span className="text-sky-700 dark:text-sky-300">{best} best</span>
           <span className="text-slate-600 dark:text-slate-400">{acc} acceptable</span>
@@ -367,7 +367,7 @@ function CompletePhase({
       </section>
 
       <section className="rounded-lg border p-4">
-        <h2 className="text-sm font-medium">Phase 2 · leaderboard</h2>
+        <h2 className="text-sm font-medium">Comparison leaderboard</h2>
         {leaderboard.length === 0 ? (
           <p className="mt-2 text-sm text-muted-foreground">
             No matchups recorded.

--- a/src/routes/review/SessionDeck.tsx
+++ b/src/routes/review/SessionDeck.tsx
@@ -287,11 +287,11 @@ export function SessionDeck() {
         if (res.phase === "complete") {
           toast.success("Review complete");
         } else {
-          toast.success(`Phase 2: ${res.matchups} matchups`);
+          toast.success(`${res.matchups} comparisons ready`);
         }
       })
       .catch((err) =>
-        toast.error(friendlyError(err, "Couldn't submit Phase 1.")),
+        toast.error(friendlyError(err, "Couldn't submit scores.")),
       );
   }, [data, submitPhase1, scope]);
 
@@ -485,7 +485,7 @@ function SessionHeader({
               onClick={onSubmitPhase1}
               disabled={reviewedCount === 0}
             >
-              Submit Phase 1
+              Finish scoring
               <ArrowRight className="size-3.5" />
             </Button>
           )}
@@ -522,8 +522,8 @@ function SessionHeader({
 
 function PhaseChip({ phase }: { phase: Phase }) {
   const label = {
-    phase1: "Phase 1 · Review",
-    phase2: "Phase 2 · Battle",
+    phase1: "Score attempts",
+    phase2: "Compare attempts",
     complete: "Complete",
   }[phase];
 
@@ -589,7 +589,7 @@ function CompleteView({
       </div>
 
       <section className="rounded-lg border p-4">
-        <h2 className="text-sm font-medium">Phase 1 · ratings</h2>
+        <h2 className="text-sm font-medium">Scores</h2>
         <div className="mt-2 flex gap-4 text-sm">
           <span className="text-sky-700 dark:text-sky-300">{best} best</span>
           <span className="text-slate-600 dark:text-slate-400">
@@ -602,7 +602,7 @@ function CompleteView({
 
       <section className="rounded-lg border p-4">
         <div className="flex items-baseline justify-between">
-          <h2 className="text-sm font-medium">Phase 2 · standings</h2>
+          <h2 className="text-sm font-medium">Comparison standings</h2>
           <span className="text-[11px] text-muted-foreground">
             Bradley-Terry
           </span>

--- a/src/routes/review/VerdictReview.tsx
+++ b/src/routes/review/VerdictReview.tsx
@@ -1,0 +1,119 @@
+import { useEffect, useState } from "react";
+import { useAuthActions } from "@convex-dev/auth/react";
+import { useConvexAuth, useMutation, useQuery } from "convex/react";
+import { useParams } from "react-router-dom";
+import { Check, EyeOff, Lock } from "lucide-react";
+import { api } from "../../../convex/_generated/api";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { TraceTokenReviewBody } from "@/routes/traces/TraceTokenReviewBody";
+import { friendlyError } from "@/lib/errors";
+
+/** Public no-account entry for a blind single-run or batch verdict review. */
+export function VerdictReview() {
+  const { shareToken = "" } = useParams<{ shareToken: string }>();
+  const { isAuthenticated, isLoading } = useConvexAuth();
+  const { signIn } = useAuthActions();
+  const [name, setName] = useState("");
+  const [started, setStarted] = useState(false);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    document.title = "Blind run review — Blind Bench";
+  }, []);
+
+  async function begin(event: React.FormEvent) {
+    event.preventDefault();
+    if (!name.trim()) return;
+    setError("");
+    try {
+      if (!isAuthenticated) await signIn("anonymous");
+      setStarted(true);
+    } catch (cause: unknown) {
+      setError(friendlyError(cause, "Could not start this review."));
+    }
+  }
+
+  if (isLoading) return <ReviewShell><p className="text-sm text-muted-foreground">Preparing blind review…</p></ReviewShell>;
+  if (started && isAuthenticated) {
+    return <JoinedReview shareToken={shareToken} reviewerName={name.trim()} />;
+  }
+
+  return (
+    <ReviewShell>
+      <div className="mx-auto max-w-md text-center">
+        <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-2xl bg-primary/10 text-primary"><EyeOff className="h-6 w-6" /></div>
+        <h1 className="mt-5 text-2xl font-semibold tracking-tight">Blind run review</h1>
+        <p className="mt-2 text-sm leading-6 text-muted-foreground">
+          Judge completed AI runs without seeing which model, harness, or source produced them. You can comment on the exact step where quality changed.
+        </p>
+        <form onSubmit={begin} className="mt-6 space-y-3 text-left">
+          <label htmlFor="verdict-reviewer-name" className="text-sm font-medium">Your display name</label>
+          <Input id="verdict-reviewer-name" autoFocus value={name} onChange={(event) => setName(event.target.value)} placeholder="Alex" maxLength={80} />
+          {error && <p className="text-sm text-destructive" role="alert">{error}</p>}
+          <Button className="w-full" type="submit" disabled={!name.trim()}>Start review</Button>
+        </form>
+        <p className="mt-4 text-xs text-muted-foreground">No Blind Bench account required. This link does not grant project access.</p>
+      </div>
+    </ReviewShell>
+  );
+}
+
+function JoinedReview({ shareToken, reviewerName }: { readonly shareToken: string; readonly reviewerName: string }) {
+  const join = useMutation(api.verdictReviewCampaigns.joinCampaign);
+  const [token, setToken] = useState<string | null>(null);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    let cancelled = false;
+    void join({ shareToken, displayName: reviewerName })
+      .then((result) => {
+        if (!cancelled) setToken(result.sessionToken);
+      })
+      .catch((cause: unknown) => {
+        if (!cancelled) setError(friendlyError(cause, "This review link could not be opened."));
+      });
+    return () => { cancelled = true; };
+  }, [join, reviewerName, shareToken]);
+
+  if (error) return <ReviewShell><p className="text-sm text-destructive" role="alert">{error}</p></ReviewShell>;
+  if (!token) return <ReviewShell><p className="text-sm text-muted-foreground">Opening review…</p></ReviewShell>;
+  return <ReviewDeck token={token} />;
+}
+
+function ReviewDeck({ token }: { readonly token: string }) {
+  const review = useQuery(api.verdictReviewCampaigns.getReview, { sessionToken: token });
+  if (review === undefined) return <ReviewShell><p className="text-sm text-muted-foreground">Loading next run…</p></ReviewShell>;
+  if (review.status === "closed") {
+    return <ReviewShell><Completion icon={Lock} title="Review closed" detail="The workspace owner closed this review. Your saved judgments are preserved." /></ReviewShell>;
+  }
+  if (review.complete) {
+    return <ReviewShell><Completion icon={Check} title="Review complete" detail={`You reviewed ${review.progress.judged} of ${review.progress.total} runs. Your judgments are saved.`} /></ReviewShell>;
+  }
+
+  return (
+    <ReviewShell wide>
+      <header className="mx-auto mb-2 max-w-3xl">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <p className="text-xs font-medium uppercase tracking-wider text-muted-foreground">Blind run review</p>
+            <h1 className="mt-1 text-lg font-semibold">{review.instructions || "Check whether this run handled the task correctly."}</h1>
+          </div>
+          <div className="text-right text-xs text-muted-foreground">
+            <div>{review.progress.judged + 1} / {review.progress.total}</div>
+            <div className="mt-1 h-1.5 w-24 overflow-hidden rounded-full bg-muted"><div className="h-full bg-primary" style={{ width: `${(review.progress.judged / review.progress.total) * 100}%` }} /></div>
+          </div>
+        </div>
+      </header>
+      <TraceTokenReviewBody key={review.progress.judged} token={token} showBackLink={false} />
+    </ReviewShell>
+  );
+}
+
+function Completion({ icon: Icon, title, detail }: { readonly icon: typeof Check; readonly title: string; readonly detail: string }) {
+  return <div className="mx-auto max-w-md text-center"><div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-primary/10 text-primary"><Icon className="h-6 w-6" /></div><h1 className="mt-4 text-2xl font-semibold">{title}</h1><p className="mt-2 text-sm text-muted-foreground">{detail}</p></div>;
+}
+
+function ReviewShell({ children, wide = false }: { readonly children: React.ReactNode; readonly wide?: boolean }) {
+  return <main className="min-h-screen bg-muted/20 p-4 sm:p-8"><div className={`mx-auto ${wide ? "max-w-5xl" : "max-w-xl"}`}><div className="mb-8 flex items-center gap-2 text-sm font-semibold"><EyeOff className="h-4 w-4 text-primary" /> Blind Bench</div>{children}</div></main>;
+}

--- a/src/routes/traces/TraceList.tsx
+++ b/src/routes/traces/TraceList.tsx
@@ -38,11 +38,11 @@ export function TraceList() {
         <div>
           <div className="flex items-center gap-2">
             <Route aria-hidden="true" className="h-5 w-5 text-primary" />
-            <h1 className="text-2xl font-bold">Trajectories</h1>
+            <h1 className="text-2xl font-bold">Runs</h1>
           </div>
           <p className="mt-1 text-sm text-muted-foreground">
-            Review imported agent runs step by step — every message, tool call,
-            and result in order.
+            Completed AI behavior from your existing systems. A run may be one
+            response or a multi-step agent trace with tool calls.
           </p>
         </div>
         <Link
@@ -64,8 +64,8 @@ export function TraceList() {
         ) : traces.length === 0 ? (
           <div className="max-w-lg space-y-3 rounded-lg border border-dashed p-6">
             <p className="text-sm">
-              No trajectories here yet. Import an agent session to review the
-              agent’s steps, tool calls, and decisions.
+              Add completed runs from the systems you already use, then create a
+              blind review for the people whose judgment matters.
             </p>
             <Link
               to={`${projectBase}/import`}
@@ -91,7 +91,7 @@ export function TraceList() {
                       <p className="truncate text-sm font-medium">
                         {provenance.length > 0
                           ? provenance.join(" · ")
-                          : "Trajectory"}
+                          : "Imported run"}
                       </p>
                       <p className="mt-0.5 text-xs text-muted-foreground">
                         {t.stepCount} {t.stepCount === 1 ? "step" : "steps"} ·{" "}

--- a/src/routes/traces/TraceTokenReviewBody.tsx
+++ b/src/routes/traces/TraceTokenReviewBody.tsx
@@ -12,14 +12,24 @@ import { StepBody, StepList } from "./traceSteps";
 import { ArrowLeft, EyeOff, Route } from "lucide-react";
 
 const RATINGS = [
-  { value: "best", label: "Best" },
+  { value: "best", label: "Strong" },
   { value: "acceptable", label: "Acceptable" },
   { value: "weak", label: "Weak" },
 ] as const;
 type Rating = (typeof RATINGS)[number]["value"];
 
-/** Blind trajectory review body that speaks only in opaque session tokens. */
-export function TraceTokenReviewBody({ token }: { readonly token: string }) {
+/** Blind run-review body that speaks only in opaque session tokens. */
+export function TraceTokenReviewBody({
+  token,
+  backTo = "/eval/traces",
+  backLabel = "Runs to review",
+  showBackLink = true,
+}: {
+  readonly token: string;
+  readonly backTo?: string;
+  readonly backLabel?: string;
+  readonly showBackLink?: boolean;
+}) {
   const trace = useQuery(api.agentTraceReviewSessions.getTrace, { token });
   const comments = useQuery(api.agentTraceReviewSessions.listComments, { token });
 
@@ -44,14 +54,16 @@ export function TraceTokenReviewBody({ token }: { readonly token: string }) {
 
   return (
     <div className="mx-auto max-w-3xl p-6">
-      <Link to="/eval/traces" className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground">
-        <ArrowLeft aria-hidden="true" className="h-3 w-3" />
-        Trajectories to review
-      </Link>
-      <header className="mt-3">
+      {showBackLink && (
+        <Link to={backTo} className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground">
+          <ArrowLeft aria-hidden="true" className="h-3 w-3" />
+          {backLabel}
+        </Link>
+      )}
+      <header className={showBackLink ? "mt-3" : undefined}>
         <div className="flex items-center gap-2">
           <Route aria-hidden="true" className="h-5 w-5 text-primary" />
-          <h1 className="text-2xl font-bold">Trajectory</h1>
+          <h1 className="text-2xl font-bold">Run</h1>
         </div>
         <p className="mt-1 text-sm text-muted-foreground">
           {trace.stepCount} {trace.stepCount === 1 ? "step" : "steps"}
@@ -66,8 +78,6 @@ export function TraceTokenReviewBody({ token }: { readonly token: string }) {
         </CardContent>
       </Card>
 
-      <TokenVerdict token={token} />
-
       {trace.hasFinalAnswer && (
         <Card className="mt-6">
           <CardHeader><CardTitle className="text-base">Final answer</CardTitle></CardHeader>
@@ -79,6 +89,8 @@ export function TraceTokenReviewBody({ token }: { readonly token: string }) {
         <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-muted-foreground">Steps</h2>
         <StepList reviewToken={token} comments={comments} />
       </section>
+
+      <TokenVerdict token={token} />
     </div>
   );
 }

--- a/src/routes/traces/__smoke__/convexAuthMock.ts
+++ b/src/routes/traces/__smoke__/convexAuthMock.ts
@@ -1,0 +1,7 @@
+const signIn = async () => undefined;
+const signOut = async () => undefined;
+
+/** Component-test auth boundary: an anonymous principal is available after entry. */
+export function useAuthActions() {
+  return { signIn, signOut };
+}

--- a/src/routes/traces/__smoke__/convexReactMock.tsx
+++ b/src/routes/traces/__smoke__/convexReactMock.tsx
@@ -35,6 +35,7 @@ const noop = () => {};
 const getBodyFn = async () => FIXTURE_BODY;
 const importPairedComparison = async () => ({ campaignId: "campaign-import-test" });
 const noopMutation = async () => undefined;
+const createVerdictReview = async () => "verdict-review-test";
 const createImportProject = async () => ({ orgSlug: "test-org", projectId: "test-project" });
 const PAGINATED = {
   results: FIXTURE_STEPS,
@@ -60,9 +61,9 @@ export function useAction(action?: unknown) {
 
 export function useMutation(mutation?: unknown) {
   try {
-    if (getFunctionName(mutation as never) === "projects:createForImport") {
-      return createImportProject;
-    }
+    const name = getFunctionName(mutation as never);
+    if (name === "projects:createForImport") return createImportProject;
+    if (name === "verdictReviewCampaigns:create") return createVerdictReview;
   } catch {
     // Keep unrelated component-test mutations as stable no-ops.
   }
@@ -102,6 +103,63 @@ export const FIXTURE_BLIND_MATCHUP = {
   reasonTags: [],
 };
 
+export const FIXTURE_OWNER_TRACES = [
+  {
+    _id: "trace-owner-1",
+    product: "support",
+    harnessName: "pi",
+    model: "claude-sonnet",
+    status: "ready",
+    stepCount: 4,
+    createdAt: 2,
+  },
+  {
+    _id: "trace-owner-2",
+    product: "support",
+    harnessName: "native",
+    model: "gpt-4o",
+    status: "ready",
+    stepCount: 1,
+    createdAt: 1,
+  },
+];
+
+export const FIXTURE_VERDICT_REVIEWS = [
+  {
+    id: "verdict-open",
+    mode: "verdict",
+    name: "Open run review",
+    status: "open",
+    itemCount: 5,
+    reviewedRuns: 2,
+    reviewers: 1,
+    judgments: 2,
+    createdAt: 3,
+  },
+  {
+    id: "verdict-closed",
+    mode: "verdict",
+    name: "Closed run review",
+    status: "closed",
+    itemCount: 3,
+    reviewedRuns: 3,
+    reviewers: 2,
+    judgments: 6,
+    createdAt: 2,
+  },
+];
+
+export const FIXTURE_COMPARISON_REVIEWS = [
+  {
+    id: "comparison-closed",
+    name: "Candidate comparison",
+    status: "closed",
+    caseCount: 5,
+    judgments: 10,
+    createdAt: 1,
+  },
+];
+
 export const FIXTURE_BLIND_TRACE = {
   _id: "trace_review_1",
   projectName: "Support Router",
@@ -126,6 +184,12 @@ export function useQuery(query: unknown) {
     switch (getFunctionName(query as never)) {
       case "agentTraceReviewSessions:listMine":
         return FIXTURE_REVIEWABLE;
+      case "agentTraces:listTraces":
+        return FIXTURE_OWNER_TRACES;
+      case "verdictReviewCampaigns:listCampaigns":
+        return FIXTURE_VERDICT_REVIEWS;
+      case "comparisonCampaigns:listCampaigns":
+        return FIXTURE_COMPARISON_REVIEWS;
       case "agentTraces:getTrace":
       case "agentTraceReviewSessions:getTrace":
         return FIXTURE_BLIND_TRACE;

--- a/src/routes/traces/__smoke__/convexReactMock.tsx
+++ b/src/routes/traces/__smoke__/convexReactMock.tsx
@@ -36,6 +36,8 @@ const getBodyFn = async () => FIXTURE_BODY;
 const importPairedComparison = async () => ({ campaignId: "campaign-import-test" });
 const noopMutation = async () => undefined;
 const createVerdictReview = async () => "verdict-review-test";
+const joinVerdictReview = async () => ({ sessionToken: "opaque-verdict-session" });
+const promoteAcceptedRuns = async () => ({ added: 1, alreadyPresent: 0, excluded: 0 });
 const createImportProject = async () => ({ orgSlug: "test-org", projectId: "test-project" });
 const PAGINATED = {
   results: FIXTURE_STEPS,
@@ -50,9 +52,10 @@ export function usePaginatedQuery() {
 
 export function useAction(action?: unknown) {
   try {
-    if (getFunctionName(action as never) === "comparisonCampaigns:importPairedCsv") {
-      return importPairedComparison;
-    }
+    const name = getFunctionName(action as never);
+    if (name === "comparisonCampaigns:importPairedCsv") return importPairedComparison;
+    if (name === "exports:generateExport") return async () => ({ exportId: "export-1", rowCount: 1, excludedCount: 0, manifest: {} });
+    if (name === "exports:downloadExport") return async () => ({ url: "data:application/json,fixture" });
   } catch {
     // Keep unrelated component-test actions on the stable body fixture.
   }
@@ -64,6 +67,8 @@ export function useMutation(mutation?: unknown) {
     const name = getFunctionName(mutation as never);
     if (name === "projects:createForImport") return createImportProject;
     if (name === "verdictReviewCampaigns:create") return createVerdictReview;
+    if (name === "verdictReviewCampaigns:joinCampaign") return joinVerdictReview;
+    if (name === "verdictReviewCampaigns:promoteAcceptedRuns") return promoteAcceptedRuns;
   } catch {
     // Keep unrelated component-test mutations as stable no-ops.
   }
@@ -149,6 +154,40 @@ export const FIXTURE_VERDICT_REVIEWS = [
   },
 ];
 
+export const FIXTURE_OWNER_VERDICT_REVIEW = {
+  _id: "verdict-review-test",
+  projectId: "test-project",
+  name: "Synthetic support review",
+  instructions: "Check whether the run resolved the request.",
+  status: "closed",
+  shareToken: "opaque-share-token",
+  itemCount: 1,
+  judgmentCount: 1,
+  createdAt: 1,
+  openedAt: 2,
+  closedAt: 3,
+  results: {
+    judgments: 1,
+    reviewers: 1,
+    reviewedRuns: 1,
+    best: 1,
+    acceptable: 0,
+    weak: 0,
+    disagreementRuns: 0,
+  },
+  reviewerNames: ["Synthetic reviewer"],
+  regressionCount: 0,
+  runs: [{ traceId: "trace-owner-1", product: "support", harness: "pi", model: "claude-sonnet", judgments: 1 }],
+  comments: [],
+};
+
+export const FIXTURE_REVIEW_DECK = {
+  status: "open",
+  complete: false,
+  instructions: "Check whether the run resolved the request.",
+  progress: { judged: 0, total: 1 },
+};
+
 export const FIXTURE_COMPARISON_REVIEWS = [
   {
     id: "comparison-closed",
@@ -179,6 +218,10 @@ export const FIXTURE_BLIND_TRACE = {
 
 // Branch by function name so each query gets the right fixture; anything
 // unmapped stays undefined (loading), keeping specs independent.
+export function useConvexAuth() {
+  return { isAuthenticated: true, isLoading: false };
+}
+
 export function useQuery(query: unknown) {
   try {
     switch (getFunctionName(query as never)) {
@@ -188,6 +231,10 @@ export function useQuery(query: unknown) {
         return FIXTURE_OWNER_TRACES;
       case "verdictReviewCampaigns:listCampaigns":
         return FIXTURE_VERDICT_REVIEWS;
+      case "verdictReviewCampaigns:getOwnerCampaign":
+        return FIXTURE_OWNER_VERDICT_REVIEW;
+      case "verdictReviewCampaigns:getReview":
+        return FIXTURE_REVIEW_DECK;
       case "comparisonCampaigns:listCampaigns":
         return FIXTURE_COMPARISON_REVIEWS;
       case "agentTraces:getTrace":

--- a/src/routes/traces/traceReviewBody.ct.spec.tsx
+++ b/src/routes/traces/traceReviewBody.ct.spec.tsx
@@ -12,11 +12,14 @@ test("blind token review: no provenance, bias framing, verdict, and steps render
       <TraceTokenReviewBody token="opaque-review-token" />
     </MemoryRouter>,
   );
-  await expect(component).toContainText("Trajectory");
+  await expect(component.getByRole("heading", { name: "Run", exact: true })).toBeVisible();
   await expect(component).toContainText("Blinding reduces bias; it is not anonymity");
   await expect(component).toContainText("Your verdict");
   await expect(component).toContainText("Acceptable");
   await expect(component).toContainText("run_command");
+  const finalAnswer = component.getByText("Final answer", { exact: true });
+  const verdict = component.getByText("Your verdict", { exact: true });
+  expect((await finalAnswer.boundingBox())?.y).toBeLessThan((await verdict.boundingBox())?.y ?? 0);
   await expect(component.locator("[data-trace-id], [data-step-id]")).toHaveCount(0);
 });
 


### PR DESCRIPTION
## Summary

Implements the approved P0–P3 ingestion-first UX program under #333.

- makes **Runs · Reviews · Results** the primary project information architecture
- moves imports/sources/Gateway and the prompt playground to secondary Tools/settings surfaces
- adds one review builder with **Score runs** and **Compare attempts**
- adds opaque, anonymous blind verdict-review sessions for single-turn and multi-step runs
- prioritizes **Create blind review** after import
- aggregates collecting and closed verdict/comparison evidence in Results
- reveals source provenance only on authenticated owner/editor result surfaces
- gates evidence, regression, SFT, and DPO reuse behind eligible closed results with explicit exclusions
- redirects the standalone Export route to Results
- consolidates stale Phase/Battle/core prompt-first copy and aligns canonical docs

Tracks/completes #345, #346, #347, and #348.

## Security and data boundaries

- reviewer payload tests assert no model, harness, product, source IDs, campaign IDs, item IDs, or trace IDs leak
- review links and progression use opaque session tokens
- owner provenance is joined only by authenticated owner/editor queries
- SFT excludes any Weak verdict and reports no-approved/disagreement/privacy exclusions
- DPO remains comparability-gated and now requires a closed review when exported contextually
- all browser fixtures are synthetic

## Verification

Fresh from commit `4b7411f`:

```text
npm run test:all
✓ production TypeScript/Vite build
✓ 23 eval files / 189 tests
✓ 36 Convex files / 287 tests
✓ 14 Chromium component/browser tests
```

The Chromium suite includes a synthetic canonical journey across owner setup → anonymous blind judgment → owner-only result/provenance → regression reuse.

## Review notes

- Existing legacy URLs continue to resolve for compatibility, but cycles/campaigns/sessions/matchups are no longer primary navigation concepts.
- Prompt versions/execution remain functional under Tools → Prompt playground.
- The deployed authenticated two-principal import → external review → reveal → reuse release gate remains tracked by #339. This PR does not claim mocked browser coverage replaces that production validation.
- No merge or deployment is requested by this PR.
