### PR TITLE
Fix project Tools menu crash

### DIFF
--- a/src/components/ProjectTabs.ct.spec.tsx
+++ b/src/components/ProjectTabs.ct.spec.tsx
@@ -7,7 +7,7 @@ import { ProjectTabs } from "./ProjectTabs";
 const projectId = "project-1" as Id<"projects">;
 
 /** The primary project shell exposes only the ingestion-first workflow. */
-test("project navigation leads with Runs, Reviews, and Results", async ({ mount }) => {
+test("project navigation leads with Runs, Reviews, and Results", async ({ mount, page }) => {
   const component = await mount(
     <MemoryRouter initialEntries={[`/orgs/demo/projects/${projectId}/traces`]}>
       <ProjectProvider
@@ -35,5 +35,9 @@ test("project navigation leads with Runs, Reviews, and Results", async ({ mount 
   await expect(component.getByRole("link", { name: "Run prompt", exact: true })).toHaveCount(0);
   await expect(component.getByRole("link", { name: "Export", exact: true })).toHaveCount(0);
 
-  await expect(component.getByRole("button", { name: /tools/i })).toBeVisible();
+  const tools = component.getByRole("button", { name: /tools/i });
+  await expect(tools).toBeVisible();
+  await tools.click();
+  await expect(page.getByRole("menuitem", { name: "Add runs" })).toBeVisible();
+  await expect(page.getByRole("menuitem", { name: "Prompt playground" })).toBeVisible();
 });

--- a/src/components/ProjectTabs.tsx
+++ b/src/components/ProjectTabs.tsx
@@ -14,6 +14,7 @@ import {
 import {
   DropdownMenu,
   DropdownMenuContent,
+  DropdownMenuGroup,
   DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuSeparator,
@@ -85,21 +86,25 @@ export function ProjectTabs() {
               <MoreHorizontal aria-hidden="true" className="h-4 w-4" />
             </DropdownMenuTrigger>
             <DropdownMenuContent align="start" className="w-56">
-              <DropdownMenuLabel>Import and sources</DropdownMenuLabel>
-              {secondaryItems.slice(0, 2).map((item) => (
-                <DropdownMenuItem key={item.path} render={<NavLink to={`${basePath}/${item.path}`} />}>
-                  <item.icon aria-hidden="true" className="mr-2 h-4 w-4" />
-                  {item.label}
-                </DropdownMenuItem>
-              ))}
+              <DropdownMenuGroup>
+                <DropdownMenuLabel>Import and sources</DropdownMenuLabel>
+                {secondaryItems.slice(0, 2).map((item) => (
+                  <DropdownMenuItem key={item.path} render={<NavLink to={`${basePath}/${item.path}`} />}>
+                    <item.icon aria-hidden="true" className="mr-2 h-4 w-4" />
+                    {item.label}
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuGroup>
               <DropdownMenuSeparator />
-              <DropdownMenuLabel>Prompt playground</DropdownMenuLabel>
-              {secondaryItems.slice(2, 5).map((item) => (
-                <DropdownMenuItem key={item.path} render={<NavLink to={`${basePath}/${item.path}`} />}>
-                  <item.icon aria-hidden="true" className="mr-2 h-4 w-4" />
-                  {item.label}
-                </DropdownMenuItem>
-              ))}
+              <DropdownMenuGroup>
+                <DropdownMenuLabel>Prompt playground</DropdownMenuLabel>
+                {secondaryItems.slice(2, 5).map((item) => (
+                  <DropdownMenuItem key={item.path} render={<NavLink to={`${basePath}/${item.path}`} />}>
+                    <item.icon aria-hidden="true" className="mr-2 h-4 w-4" />
+                    {item.label}
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuGroup>
               <DropdownMenuSeparator />
               <DropdownMenuItem render={<NavLink to={`${basePath}/${secondaryItems[5].path}`} />}>
                 <Activity aria-hidden="true" className="mr-2 h-4 w-4" />


### PR DESCRIPTION
## Summary

Fixes #350.

Base UI `DropdownMenuLabel` renders a `Menu.GroupLabel` and throws production error #31 when it is not nested in a menu group. The project Tools dropdown now wraps both labeled sections in `DropdownMenuGroup`.

The project navigation component test now opens Tools and verifies the portal-rendered menu items, preventing the click path from regressing.

## Verification

- `npx playwright test -c playwright-ct.config.ts src/components/ProjectTabs.ct.spec.tsx --reporter=line` — 1 passed
- `npm run build` — passed
- `git diff --check origin/main...HEAD` — passed

No merge requested.