### PR TITLE
feat: add customer review automation API

### DIFF
--- a/convex/http.ts
+++ b/convex/http.ts
@@ -5,6 +5,11 @@ import { auth } from "./auth";
 import { verifyWebhook } from "./lib/polarSignature";
 import { otlpIngestHandler } from "./otlpIngest";
 import { nativeIngestHandler } from "./nativeIngest";
+import {
+  closeReviewHandler,
+  createReviewHandler,
+  getReviewHandler,
+} from "./reviewsHttp";
 
 const http = httpRouter();
 
@@ -206,5 +211,10 @@ http.route({
     });
   }),
 });
+
+// --- Customer review automation (scoped project token auth; no browser CORS) ---
+http.route({ path: "/api/v1/reviews", method: "POST", handler: createReviewHandler });
+http.route({ path: "/api/v1/reviews", method: "GET", handler: getReviewHandler });
+http.route({ path: "/api/v1/reviews/close", method: "POST", handler: closeReviewHandler });
 
 export default http;

--- a/convex/ingestTokens.ts
+++ b/convex/ingestTokens.ts
@@ -12,8 +12,20 @@ import type { Id } from "./_generated/dataModel";
 import { requireProjectRole } from "./lib/auth";
 import { generateToken } from "./lib/crypto";
 
+export const tokenScopeValidator = v.union(
+  v.literal("traces:write"),
+  v.literal("reviews:write"),
+  v.literal("reviews:read"),
+);
+
+export type TokenScope = "traces:write" | "reviews:write" | "reviews:read";
+
 export const issueIngestToken = mutation({
-  args: { projectId: v.id("projects"), label: v.string() },
+  args: {
+    projectId: v.id("projects"),
+    label: v.string(),
+    scopes: v.optional(v.array(tokenScopeValidator)),
+  },
   handler: async (
     ctx,
     args,
@@ -21,10 +33,14 @@ export const issueIngestToken = mutation({
     const { userId } = await requireProjectRole(ctx, args.projectId, ["owner", "editor"]);
     const label = args.label.trim() || "Ingest token";
     const token = generateToken();
+    const scopes = args.scopes === undefined
+      ? undefined
+      : [...new Set<TokenScope>(args.scopes)];
     const tokenId = await ctx.db.insert("ingestTokens", {
       projectId: args.projectId,
       token,
       label,
+      scopes,
       createdById: userId,
     });
     // Full token returned ONCE — never surfaced again.
@@ -57,6 +73,7 @@ export const listIngestTokens = query({
       // Masked — the full token is only ever shown at creation.
       preview: `${r.token.slice(0, 6)}…${r.token.slice(-4)}`,
       createdAt: r._creationTime,
+      scopes: r.scopes ?? ["traces:write" as const],
       lastUsedAt: r.lastUsedAt,
       revoked: r.revokedAt !== undefined,
     }));

--- a/convex/nativeIngest.ts
+++ b/convex/nativeIngest.ts
@@ -28,6 +28,9 @@ export const nativeIngestHandler = httpAction(async (ctx, req) => {
   if (!token) return json({ error: "Missing ingest token" }, 401);
   const resolved = await ctx.runQuery(internal.otlpIngest.resolveIngestToken, { token });
   if (!resolved) return json({ error: "Invalid or revoked ingest token" }, 401);
+  if (!resolved.scopes.includes("traces:write")) {
+    return json({ error: "Token lacks traces:write scope" }, 403);
+  }
 
   const body = await req.text();
   // UTF-8 byte length, not JS string length (which undercounts multibyte content).

--- a/convex/otlpIngest.ts
+++ b/convex/otlpIngest.ts
@@ -14,6 +14,7 @@ import type { Id } from "./_generated/dataModel";
 import { mapOtlpToTraces } from "./lib/otelGenAI";
 import { storeTraceSteps } from "./agentTraces";
 import type { AgentRunTrace } from "./lib/agentTrace";
+import type { TokenScope } from "./ingestTokens";
 
 export const MAX_BYTES = 8 * 1024 * 1024;
 
@@ -26,7 +27,11 @@ export const json = (body: unknown, status: number): Response =>
 export const readToken = (req: Request): string | undefined => {
   const auth = req.headers.get("authorization");
   if (auth?.toLowerCase().startsWith("bearer ")) return auth.slice(7).trim();
-  return req.headers.get("x-blindbench-ingest-token")?.trim() || undefined;
+  return (
+    req.headers.get("x-blindbench-api-token")?.trim() ||
+    req.headers.get("x-blindbench-ingest-token")?.trim() ||
+    undefined
+  );
 };
 
 export const resolveIngestToken = internalQuery({
@@ -34,13 +39,22 @@ export const resolveIngestToken = internalQuery({
   handler: async (
     ctx,
     args,
-  ): Promise<{ projectId: Id<"projects">; createdById: Id<"users"> } | null> => {
+  ): Promise<{
+    projectId: Id<"projects">;
+    createdById: Id<"users">;
+    scopes: ReadonlyArray<TokenScope>;
+  } | null> => {
     const row = await ctx.db
       .query("ingestTokens")
       .withIndex("by_token", (q) => q.eq("token", args.token))
       .unique();
     if (!row || row.revokedAt !== undefined) return null;
-    return { projectId: row.projectId, createdById: row.createdById };
+    // Tokens issued before scopes existed remain ingest-only.
+    return {
+      projectId: row.projectId,
+      createdById: row.createdById,
+      scopes: row.scopes ?? ["traces:write"],
+    };
   },
 });
 
@@ -99,6 +113,9 @@ export const otlpIngestHandler = httpAction(async (ctx, req) => {
   if (!token) return json({ error: "Missing ingest token" }, 401);
   const resolved = await ctx.runQuery(internal.otlpIngest.resolveIngestToken, { token });
   if (!resolved) return json({ error: "Invalid or revoked ingest token" }, 401);
+  if (!resolved.scopes.includes("traces:write")) {
+    return json({ error: "Token lacks traces:write scope" }, 403);
+  }
 
   const body = await req.text();
   if (new TextEncoder().encode(body).byteLength > MAX_BYTES) return json({ error: "Payload too large" }, 413);

--- a/convex/reviewsApi.ts
+++ b/convex/reviewsApi.ts
@@ -1,0 +1,156 @@
+/** Token-authenticated, management-safe automation operations for verdict reviews. */
+import { v } from "convex/values";
+import { internalMutation } from "./_generated/server";
+import type { MutationCtx, QueryCtx } from "./_generated/server";
+import type { Doc } from "./_generated/dataModel";
+import { generateToken } from "./lib/crypto";
+
+const apiError = (status: 401 | 403 | 404 | 409, error: string) => ({ ok: false as const, status, error });
+
+/** Create and open one campaign transactionally, replaying an idempotent request. */
+export const createReview = internalMutation({
+  args: {
+    token: v.string(),
+    name: v.string(),
+    instructions: v.optional(v.string()),
+    traceIds: v.array(v.string()),
+    idempotencyKey: v.string(),
+    fingerprint: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const tokenRow = await ctx.db
+      .query("ingestTokens")
+      .withIndex("by_token", (q) => q.eq("token", args.token))
+      .unique();
+    if (!tokenRow || tokenRow.revokedAt !== undefined) return apiError(401, "Invalid or revoked API token");
+    if (!(tokenRow.scopes ?? []).includes("reviews:write")) return apiError(403, "Token lacks reviews:write scope");
+
+    const existing = await ctx.db
+      .query("verdictReviewCampaigns")
+      .withIndex("by_project_and_idempotency", (q) =>
+        q.eq("projectId", tokenRow.projectId).eq("idempotencyKey", args.idempotencyKey),
+      )
+      .unique();
+    if (existing) {
+      if (existing.idempotencyFingerprint !== args.fingerprint) {
+        return apiError(409, "Idempotency key is already used by a different request");
+      }
+      await ctx.db.patch(tokenRow._id, { lastUsedAt: Date.now() });
+      return {
+        ok: true as const,
+        reviewId: existing._id,
+        status: existing.status,
+        itemCount: existing.itemCount,
+        shareToken: existing.shareToken,
+      };
+    }
+
+    const traces: Array<Doc<"agentTraces">> = [];
+    for (const stableTraceId of args.traceIds) {
+      const trace = await ctx.db
+        .query("agentTraces")
+        .withIndex("by_trace_id", (q) => q.eq("traceId", stableTraceId))
+        .filter((q) => q.eq(q.field("projectId"), tokenRow.projectId))
+        .unique();
+      if (!trace) return apiError(404, "Run not found in this project");
+      if (trace.status !== "ready") return apiError(409, "Every selected run must be ready");
+      traces.push(trace);
+    }
+
+    const now = Date.now();
+    const shareToken = generateToken();
+    const campaignId = await ctx.db.insert("verdictReviewCampaigns", {
+      projectId: tokenRow.projectId,
+      name: args.name,
+      instructions: args.instructions,
+      status: "open",
+      shareToken,
+      idempotencyKey: args.idempotencyKey,
+      idempotencyFingerprint: args.fingerprint,
+      itemCount: traces.length,
+      judgmentCount: 0,
+      createdById: tokenRow.createdById,
+      createdAt: now,
+      openedAt: now,
+    });
+    for (let sortOrder = 0; sortOrder < traces.length; sortOrder++) {
+      const trace = traces[sortOrder];
+      if (trace === undefined) continue;
+      await ctx.db.insert("verdictReviewItems", {
+        campaignId,
+        projectId: tokenRow.projectId,
+        agentTraceId: trace._id,
+        sortOrder,
+      });
+    }
+    await ctx.db.patch(tokenRow._id, { lastUsedAt: now });
+    return { ok: true as const, reviewId: campaignId, status: "open" as const, itemCount: traces.length, shareToken };
+  },
+});
+
+async function safeSummary(
+  ctx: QueryCtx | MutationCtx,
+  campaign: Doc<"verdictReviewCampaigns">,
+) {
+  const decisions = await ctx.db
+    .query("verdictReviewDecisions")
+    .withIndex("by_campaign", (q) => q.eq("campaignId", campaign._id))
+    .collect();
+  const ratingsByItem = new Map<string, Set<string>>();
+  for (const decision of decisions) {
+    const key = String(decision.itemId);
+    const ratings = ratingsByItem.get(key) ?? new Set<string>();
+    ratings.add(decision.rating);
+    ratingsByItem.set(key, ratings);
+  }
+  return {
+    review_id: campaign._id,
+    status: campaign.status,
+    item_count: campaign.itemCount,
+    judgment_count: decisions.length,
+    reviewed_item_count: ratingsByItem.size,
+    aggregate: {
+      best: decisions.filter((decision) => decision.rating === "best").length,
+      acceptable: decisions.filter((decision) => decision.rating === "acceptable").length,
+      weak: decisions.filter((decision) => decision.rating === "weak").length,
+      disagreement: [...ratingsByItem.values()].filter((ratings) => ratings.size > 1).length,
+    },
+  };
+}
+
+/** Read a project-tenanted status projection with no reviewer or run provenance. */
+export const getReview = internalMutation({
+  args: { token: v.string(), reviewId: v.string() },
+  handler: async (ctx, args) => {
+    const tokenRow = await ctx.db.query("ingestTokens").withIndex("by_token", (q) => q.eq("token", args.token)).unique();
+    if (!tokenRow || tokenRow.revokedAt !== undefined) return apiError(401, "Invalid or revoked API token");
+    if (!(tokenRow.scopes ?? []).includes("reviews:read")) return apiError(403, "Token lacks reviews:read scope");
+    const campaignId = ctx.db.normalizeId("verdictReviewCampaigns", args.reviewId);
+    if (!campaignId) return apiError(404, "Review not found");
+    const campaign = await ctx.db.get(campaignId);
+    if (!campaign || campaign.projectId !== tokenRow.projectId) return apiError(404, "Review not found");
+    await ctx.db.patch(tokenRow._id, { lastUsedAt: Date.now() });
+    return { ok: true as const, summary: await safeSummary(ctx, campaign) };
+  },
+});
+
+/** Idempotently close an open project-tenanted review and return its safe summary. */
+export const closeReview = internalMutation({
+  args: { token: v.string(), reviewId: v.string() },
+  handler: async (ctx, args) => {
+    const tokenRow = await ctx.db.query("ingestTokens").withIndex("by_token", (q) => q.eq("token", args.token)).unique();
+    if (!tokenRow || tokenRow.revokedAt !== undefined) return apiError(401, "Invalid or revoked API token");
+    if (!(tokenRow.scopes ?? []).includes("reviews:write")) return apiError(403, "Token lacks reviews:write scope");
+    const campaignId = ctx.db.normalizeId("verdictReviewCampaigns", args.reviewId);
+    if (!campaignId) return apiError(404, "Review not found");
+    const campaign = await ctx.db.get(campaignId);
+    if (!campaign || campaign.projectId !== tokenRow.projectId) return apiError(404, "Review not found");
+    if (campaign.status === "draft") return apiError(409, "Review is not open");
+    if (campaign.status === "open") {
+      await ctx.db.patch(campaign._id, { status: "closed", closedAt: Date.now() });
+    }
+    await ctx.db.patch(tokenRow._id, { lastUsedAt: Date.now() });
+    const current = campaign.status === "closed" ? campaign : { ...campaign, status: "closed" as const };
+    return { ok: true as const, summary: await safeSummary(ctx, current) };
+  },
+});

--- a/convex/reviewsHttp.ts
+++ b/convex/reviewsHttp.ts
@@ -1,0 +1,147 @@
+/** Public HTTP boundary for customer-managed verdict review automation. */
+import { httpAction } from "./_generated/server";
+import { internal } from "./_generated/api";
+import { json, readToken } from "./otlpIngest";
+
+const MAX_BODY_BYTES = 256 * 1024;
+const CREATE_KEYS = new Set(["name", "instructions", "trace_ids", "idempotency_key"]);
+const CLOSE_KEYS = new Set(["review_id"]);
+
+type CreateInput = {
+  readonly name: string;
+  readonly instructions?: string;
+  readonly traceIds: ReadonlyArray<string>;
+  readonly idempotencyKey: string;
+};
+
+type ParseResult<T> = { readonly ok: true; readonly value: T } | { readonly ok: false; readonly status: 400 | 413; readonly error: string };
+
+function objectRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+async function readJsonObject(req: Request): Promise<ParseResult<Record<string, unknown>>> {
+  const declaredLength = Number(req.headers.get("content-length"));
+  if (Number.isFinite(declaredLength) && declaredLength > MAX_BODY_BYTES) {
+    return { ok: false, status: 413, error: "Payload too large" };
+  }
+  const text = await req.text();
+  if (new TextEncoder().encode(text).byteLength > MAX_BODY_BYTES) {
+    return { ok: false, status: 413, error: "Payload too large" };
+  }
+  let decoded: unknown;
+  try {
+    decoded = JSON.parse(text);
+  } catch {
+    return { ok: false, status: 400, error: "Invalid JSON" };
+  }
+  const record = objectRecord(decoded);
+  if (!record) return { ok: false, status: 400, error: "JSON body must be an object" };
+  return { ok: true, value: record };
+}
+
+function parseCreate(record: Record<string, unknown>): ParseResult<CreateInput> {
+  if (Object.keys(record).some((key) => !CREATE_KEYS.has(key))) {
+    return { ok: false, status: 400, error: "Request contains an unknown field" };
+  }
+  const name = typeof record.name === "string" ? record.name.trim() : "";
+  if (!name || name.length > 120) return { ok: false, status: 400, error: "name must be 1 to 120 characters" };
+  const idempotencyKey = typeof record.idempotency_key === "string" ? record.idempotency_key.trim() : "";
+  if (!idempotencyKey || idempotencyKey.length > 200) return { ok: false, status: 400, error: "idempotency_key must be 1 to 200 characters" };
+  const instructions = record.instructions === undefined ? undefined : typeof record.instructions === "string" ? record.instructions.trim() : null;
+  if (instructions === null || (instructions !== undefined && instructions.length > 2_000)) {
+    return { ok: false, status: 400, error: "instructions must be at most 2000 characters" };
+  }
+  if (!Array.isArray(record.trace_ids)) return { ok: false, status: 400, error: "trace_ids must be an array" };
+  if (record.trace_ids.length > 50) return { ok: false, status: 413, error: "trace_ids supports at most 50 runs" };
+  if (record.trace_ids.length === 0 || record.trace_ids.some((value) => typeof value !== "string" || value.trim().length === 0)) {
+    return { ok: false, status: 400, error: "trace_ids must contain 1 to 50 non-empty strings" };
+  }
+  const traceIds = record.trace_ids.map((value) => String(value).trim());
+  if (new Set(traceIds).size !== traceIds.length) return { ok: false, status: 400, error: "trace_ids must not contain duplicates" };
+  return {
+    ok: true,
+    value: {
+      name,
+      ...(instructions ? { instructions } : {}),
+      traceIds,
+      idempotencyKey,
+    },
+  };
+}
+
+async function fingerprint(input: CreateInput): Promise<string> {
+  const canonical = JSON.stringify({
+    name: input.name,
+    instructions: input.instructions ?? null,
+    trace_ids: input.traceIds,
+  });
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(canonical),
+  );
+  return [...new Uint8Array(digest)]
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function siteUrl(): string {
+  const configured = process.env.SITE_URL?.trim();
+  return (configured || "https://blindbench.dev").replace(/\/+$/, "");
+}
+
+function authToken(req: Request): string | null {
+  return readToken(req) ?? null;
+}
+
+/** POST /api/v1/reviews. */
+export const createReviewHandler = httpAction(async (ctx, req) => {
+  const token = authToken(req);
+  if (!token) return json({ error: "Missing API token" }, 401);
+  const decoded = await readJsonObject(req);
+  if (!decoded.ok) return json({ error: decoded.error }, decoded.status);
+  const parsed = parseCreate(decoded.value);
+  if (!parsed.ok) return json({ error: parsed.error }, parsed.status);
+  const input = parsed.value;
+  const result = await ctx.runMutation(internal.reviewsApi.createReview, {
+    token,
+    name: input.name,
+    instructions: input.instructions,
+    traceIds: [...input.traceIds],
+    idempotencyKey: input.idempotencyKey,
+    fingerprint: await fingerprint(input),
+  });
+  if (!result.ok) return json({ error: result.error }, result.status);
+  return json({
+    review_id: result.reviewId,
+    status: result.status,
+    item_count: result.itemCount,
+    review_url: `${siteUrl()}/review/verdict/${result.shareToken}`,
+  }, 200);
+});
+
+/** GET /api/v1/reviews?id=<review_id>. */
+export const getReviewHandler = httpAction(async (ctx, req) => {
+  const token = authToken(req);
+  if (!token) return json({ error: "Missing API token" }, 401);
+  const reviewId = new URL(req.url).searchParams.get("id")?.trim();
+  if (!reviewId) return json({ error: "Missing review id" }, 400);
+  const result = await ctx.runMutation(internal.reviewsApi.getReview, { token, reviewId });
+  if (!result.ok) return json({ error: result.error }, result.status);
+  return json(result.summary, 200);
+});
+
+/** POST /api/v1/reviews/close. */
+export const closeReviewHandler = httpAction(async (ctx, req) => {
+  const token = authToken(req);
+  if (!token) return json({ error: "Missing API token" }, 401);
+  const decoded = await readJsonObject(req);
+  if (!decoded.ok) return json({ error: decoded.error }, decoded.status);
+  if (Object.keys(decoded.value).some((key) => !CLOSE_KEYS.has(key))) return json({ error: "Request contains an unknown field" }, 400);
+  const reviewId = typeof decoded.value.review_id === "string" ? decoded.value.review_id.trim() : "";
+  if (!reviewId) return json({ error: "review_id must be a non-empty string" }, 400);
+  const result = await ctx.runMutation(internal.reviewsApi.closeReview, { token, reviewId });
+  if (!result.ok) return json({ error: result.error }, result.status);
+  return json(result.summary, 200);
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -770,6 +770,10 @@ const schema = defineSchema({
       v.literal("closed"),
     ),
     shareToken: v.string(),
+    // Customer API retries are deduplicated within the token's project. Optional
+    // keeps reviews created before the automation API compatible.
+    idempotencyKey: v.optional(v.string()),
+    idempotencyFingerprint: v.optional(v.string()),
     itemCount: v.number(),
     judgmentCount: v.number(),
     createdById: v.id("users"),
@@ -778,7 +782,8 @@ const schema = defineSchema({
     closedAt: v.optional(v.number()),
   })
     .index("by_project", ["projectId"])
-    .index("by_share_token", ["shareToken"]),
+    .index("by_share_token", ["shareToken"])
+    .index("by_project_and_idempotency", ["projectId", "idempotencyKey"]),
 
   verdictReviewItems: defineTable({
     campaignId: v.id("verdictReviewCampaigns"),
@@ -1115,6 +1120,17 @@ const schema = defineSchema({
     projectId: v.id("projects"),
     token: v.string(),
     label: v.string(),
+    // Missing means the legacy ingest-only capability. Explicit arrays are a
+    // strict allowlist; no capability is inferred from another capability.
+    scopes: v.optional(
+      v.array(
+        v.union(
+          v.literal("traces:write"),
+          v.literal("reviews:write"),
+          v.literal("reviews:read"),
+        ),
+      ),
+    ),
     createdById: v.id("users"),
     lastUsedAt: v.optional(v.number()),
     revokedAt: v.optional(v.number()),

--- a/convex/tests/reviewsHttp.test.ts
+++ b/convex/tests/reviewsHttp.test.ts
@@ -1,0 +1,252 @@
+/// <reference types="vite/client" />
+import { convexTest } from "convex-test";
+import { describe, expect, test } from "vitest";
+import { api } from "../_generated/api";
+import type { Id } from "../_generated/dataModel";
+import schema from "../schema";
+
+async function seed() {
+  const t = convexTest(schema);
+  const ids = await t.run(async (ctx) => {
+    const owner = await ctx.db.insert("users", { name: "Owner", email: "owner@example.test" });
+    const org = await ctx.db.insert("organizations", { name: "Example", slug: "example", createdById: owner });
+    await ctx.db.insert("organizationMembers", { organizationId: org, userId: owner, role: "owner" });
+    const project = await ctx.db.insert("projects", { organizationId: org, name: "Evaluation", createdById: owner });
+    const otherProject = await ctx.db.insert("projects", { organizationId: org, name: "Other", createdById: owner });
+    await ctx.db.insert("projectCollaborators", { projectId: project, userId: owner, role: "owner", invitedById: owner, invitedAt: 1 });
+    await ctx.db.insert("projectCollaborators", { projectId: otherProject, userId: owner, role: "owner", invitedById: owner, invitedAt: 1 });
+    const ready = await insertTrace(ctx, project, owner, "trace-ready", "ready");
+    await insertTrace(ctx, project, owner, "trace-pending", "pending");
+    await insertTrace(ctx, otherProject, owner, "trace-other", "ready");
+    return { owner, project, ready };
+  });
+  const asOwner = t.withIdentity({ subject: `${ids.owner}|session`, tokenIdentifier: `test|${ids.owner}` });
+  return { t, ids, asOwner };
+}
+
+type SeedCtx = Parameters<Parameters<ReturnType<typeof convexTest>["run"]>[0]>[0];
+
+async function insertTrace(
+  ctx: SeedCtx,
+  projectId: Id<"projects">,
+  owner: Id<"users">,
+  traceId: string,
+  status: "pending" | "ready",
+) {
+  return await ctx.db.insert("agentTraces", {
+    projectId,
+    traceId,
+    source: "agent_harness",
+    harnessName: "synthetic",
+    product: "example",
+    stepCount: 1,
+    status,
+    privacyClass: "internal",
+    importedById: owner,
+  });
+}
+
+const auth = (token: string) => ({ Authorization: `Bearer ${token}`, "Content-Type": "application/json" });
+
+async function json(response: Response): Promise<Record<string, unknown>> {
+  const value: unknown = await response.json();
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("Expected object response");
+  return value as Record<string, unknown>;
+}
+
+function safeObject(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("Expected object");
+  }
+  return value as Record<string, unknown>;
+}
+
+describe("customer reviews HTTP API", () => {
+  test("requires valid auth and exact scopes while legacy tokens remain ingest-only", async () => {
+    const { t, ids, asOwner } = await seed();
+    const missing = await t.fetch("/api/v1/reviews", { method: "POST", body: "{}" });
+    expect(missing.status).toBe(401);
+    expect(await json(missing)).toHaveProperty("error");
+
+    const invalid = await t.fetch("/api/v1/reviews?id=x", { headers: { "x-blindbench-api-token": "invalid" } });
+    expect(invalid.status).toBe(401);
+
+    const legacy = await asOwner.mutation(api.ingestTokens.issueIngestToken, { projectId: ids.project, label: "legacy" });
+    const legacyIngest = await t.fetch("/ingest/v1/traces", {
+      method: "POST",
+      headers: auth(legacy.token),
+      body: JSON.stringify({
+        version: "1",
+        id: "legacy-ingest-smoke",
+        input: { messages: [{ role: "user", content: "Synthetic input" }] },
+        output: { content: "Synthetic output" },
+      }),
+    });
+    expect(legacyIngest.status).toBe(200);
+    expect(await json(legacyIngest)).toMatchObject({ imported: 1, invalid: 0 });
+    const denied = await t.fetch("/api/v1/reviews", {
+      method: "POST",
+      headers: auth(legacy.token),
+      body: JSON.stringify({ name: "Review", trace_ids: ["trace-ready"], idempotency_key: "key-1" }),
+    });
+    expect(denied.status).toBe(403);
+
+    const readOnly = await asOwner.mutation(api.ingestTokens.issueIngestToken, {
+      projectId: ids.project,
+      label: "read",
+      scopes: ["reviews:read"],
+    });
+    const readDenied = await t.fetch("/api/v1/reviews", {
+      method: "POST",
+      headers: auth(readOnly.token),
+      body: JSON.stringify({ name: "Review", trace_ids: ["trace-ready"], idempotency_key: "key-2" }),
+    });
+    expect(readDenied.status).toBe(403);
+    const ingestDenied = await t.fetch("/ingest/v1/traces", {
+      method: "POST",
+      headers: auth(readOnly.token),
+      body: "{}",
+    });
+    expect(ingestDenied.status).toBe(403);
+
+    const listed = await asOwner.query(api.ingestTokens.listIngestTokens, { projectId: ids.project });
+    expect(listed.find((row) => row.label === "legacy")?.scopes).toEqual(["traces:write"]);
+    expect(listed.find((row) => row.label === "read")?.scopes).toEqual(["reviews:read"]);
+    expect(JSON.stringify(listed)).not.toContain(legacy.token);
+    expect(JSON.stringify(listed)).not.toContain(readOnly.token);
+  });
+
+  test("creates and opens once by stable project trace IDs, then returns a leakage-safe status", async () => {
+    const { t, ids, asOwner } = await seed();
+    const issued = await asOwner.mutation(api.ingestTokens.issueIngestToken, {
+      projectId: ids.project,
+      label: "automation",
+      scopes: ["traces:write", "reviews:write", "reviews:read"],
+    });
+    const body = { name: "Synthetic review", instructions: "Assess correctness.", trace_ids: ["trace-ready"], idempotency_key: "job-42" };
+    const first = await t.fetch("/api/v1/reviews", { method: "POST", headers: auth(issued.token), body: JSON.stringify(body) });
+    expect(first.status).toBe(200);
+    const created = await json(first);
+    expect(created).toMatchObject({ status: "open", item_count: 1 });
+    expect(created.review_url).toMatch(/^https:\/\/blindbench\.dev\/review\/verdict\//);
+    expect(Object.keys(created).sort()).toEqual(["item_count", "review_id", "review_url", "status"]);
+
+    const replay = await t.fetch("/api/v1/reviews", { method: "POST", headers: auth(issued.token), body: JSON.stringify(body) });
+    expect(await json(replay)).toEqual(created);
+    const campaigns = await t.run(async (ctx) =>
+      await ctx.db.query("verdictReviewCampaigns").collect()
+    );
+    expect(campaigns).toHaveLength(1);
+    expect(campaigns[0]?.idempotencyFingerprint).toMatch(/^[0-9a-f]{64}$/);
+    expect(campaigns[0]?.idempotencyFingerprint).not.toContain("Assess correctness.");
+
+    await t.run(async (ctx) => {
+      const campaign = campaigns[0];
+      if (!campaign) throw new Error("Missing campaign");
+      const item = await ctx.db
+        .query("verdictReviewItems")
+        .withIndex("by_campaign", (q) => q.eq("campaignId", campaign._id))
+        .unique();
+      if (!item) throw new Error("Missing review item");
+      const firstReviewer = await ctx.db.insert("users", {
+        name: "PRIVATE-REVIEWER-ONE",
+        email: "reviewer-one@example.test",
+      });
+      const secondReviewer = await ctx.db.insert("users", {
+        name: "PRIVATE-REVIEWER-TWO",
+        email: "reviewer-two@example.test",
+      });
+      for (const [userId, rating, note] of [
+        [firstReviewer, "best", "PRIVATE-NOTE-ONE"],
+        [secondReviewer, "weak", "PRIVATE-NOTE-TWO"],
+      ] as const) {
+        await ctx.db.insert("verdictReviewDecisions", {
+          campaignId: campaign._id,
+          itemId: item._id,
+          projectId: ids.project,
+          agentTraceId: ids.ready,
+          userId,
+          rating,
+          note,
+          decidedAt: 1,
+        });
+      }
+    });
+
+    const readOnly = await asOwner.mutation(api.ingestTokens.issueIngestToken, {
+      projectId: ids.project,
+      label: "poller",
+      scopes: ["reviews:read"],
+    });
+    const status = await t.fetch(`/api/v1/reviews?id=${String(created.review_id)}`, { headers: { "x-blindbench-api-token": readOnly.token } });
+    expect(status.status).toBe(200);
+    const safe = await json(status);
+    expect(safe).toMatchObject({ status: "open", item_count: 1, judgment_count: 2, reviewed_item_count: 1, aggregate: { best: 1, acceptable: 0, weak: 1, disagreement: 1 } });
+    expect(Object.keys(safe).sort()).toEqual([
+      "aggregate",
+      "item_count",
+      "judgment_count",
+      "review_id",
+      "reviewed_item_count",
+      "status",
+    ]);
+    expect(Object.keys(safeObject(safe.aggregate)).sort()).toEqual([
+      "acceptable",
+      "best",
+      "disagreement",
+      "weak",
+    ]);
+    const serialized = JSON.stringify(safe);
+    for (const secret of ["trace-ready", "synthetic", "example", "Assess correctness.", "PRIVATE-REVIEWER-ONE", "PRIVATE-REVIEWER-TWO", "PRIVATE-NOTE-ONE", "PRIVATE-NOTE-TWO", "shareToken", "share_token", "model", "harness", "source", "reviewer", "comment", String(ids.ready)]) {
+      expect(serialized).not.toContain(secret);
+    }
+    const listedAfterRead = await asOwner.query(api.ingestTokens.listIngestTokens, {
+      projectId: ids.project,
+    });
+    expect(listedAfterRead.find((row) => row.label === "poller")?.lastUsedAt).toEqual(
+      expect.any(Number),
+    );
+  });
+
+  test("rejects unknown, not-ready, cross-project, oversized, and conflicting create requests", async () => {
+    const { t, ids, asOwner } = await seed();
+    const { token } = await asOwner.mutation(api.ingestTokens.issueIngestToken, { projectId: ids.project, label: "automation", scopes: ["reviews:write"] });
+    const create = (traceIds: string[], key: string) => t.fetch("/api/v1/reviews", { method: "POST", headers: auth(token), body: JSON.stringify({ name: "Review", trace_ids: traceIds, idempotency_key: key }) });
+    expect((await create(["missing"], "missing")).status).toBe(404);
+    expect((await create(["trace-pending"], "pending")).status).toBe(409);
+    expect((await create(["trace-other"], "other")).status).toBe(404);
+    expect((await create(Array.from({ length: 51 }, (_, i) => `trace-${i}`), "large")).status).toBe(413);
+    const declaredOversize = await t.fetch("/api/v1/reviews", {
+      method: "POST",
+      headers: { ...auth(token), "Content-Length": String(256 * 1024 + 1) },
+      body: "{}",
+    });
+    expect(declaredOversize.status).toBe(413);
+    expect((await create(["trace-ready"], "same-key")).status).toBe(200);
+    expect((await t.fetch("/api/v1/reviews", { method: "POST", headers: auth(token), body: JSON.stringify({ name: "Different", trace_ids: ["trace-ready"], idempotency_key: "same-key" }) })).status).toBe(409);
+  });
+
+  test("enforces tenancy, closes idempotently, and rejects a revoked token", async () => {
+    const { t, ids, asOwner } = await seed();
+    const first = await asOwner.mutation(api.ingestTokens.issueIngestToken, { projectId: ids.project, label: "automation", scopes: ["reviews:write", "reviews:read"] });
+    const created = await json(await t.fetch("/api/v1/reviews", { method: "POST", headers: auth(first.token), body: JSON.stringify({ name: "Review", trace_ids: ["trace-ready"], idempotency_key: "close-me" }) }));
+
+    const other = await t.run(async (ctx) => {
+      const project = await ctx.db.query("projects").filter((q) => q.eq(q.field("name"), "Other")).unique();
+      if (!project) throw new Error("Missing project");
+      return project._id;
+    });
+    const second = await asOwner.mutation(api.ingestTokens.issueIngestToken, { projectId: other, label: "other", scopes: ["reviews:write", "reviews:read"] });
+    expect((await t.fetch(`/api/v1/reviews?id=${String(created.review_id)}`, { headers: { Authorization: `Bearer ${second.token}` } })).status).toBe(404);
+
+    const close = () => t.fetch("/api/v1/reviews/close", { method: "POST", headers: auth(first.token), body: JSON.stringify({ review_id: created.review_id }) });
+    expect(await json(await close())).toMatchObject({ status: "closed" });
+    expect(await json(await close())).toMatchObject({ status: "closed" });
+
+    const listed = await asOwner.query(api.ingestTokens.listIngestTokens, { projectId: ids.project });
+    const tokenId = listed.find((row) => row.label === "automation")?._id;
+    if (!tokenId) throw new Error("Missing token");
+    await asOwner.mutation(api.ingestTokens.revokeIngestToken, { tokenId });
+    expect((await t.fetch(`/api/v1/reviews?id=${String(created.review_id)}`, { headers: { Authorization: `Bearer ${first.token}` } })).status).toBe(401);
+  });
+});

--- a/docs/customer-automation-api.md
+++ b/docs/customer-automation-api.md
@@ -1,0 +1,169 @@
+# Blind Bench customer automation API
+
+Use this API to upload completed `eval-record` v1 artifacts and automate blind verdict reviews without access to the Blind Bench backend repository.
+
+## Prerequisite and authentication
+
+A project owner or editor must currently issue the token in the Blind Bench app:
+
+1. Open the project.
+2. Go to **Settings → Data sources → Continuous ingest**.
+3. Choose **Automation (ingest + manage reviews)**, issue the token, and copy it immediately. The full token is shown once; later lists show only a masked preview.
+
+Send the token in either header:
+
+```http
+Authorization: Bearer $BLINDBENCH_API_TOKEN
+```
+
+or:
+
+```http
+x-blindbench-api-token: $BLINDBENCH_API_TOKEN
+```
+
+Tokens are project-scoped and use an exact capability allowlist:
+
+| Scope | Allows |
+|---|---|
+| `traces:write` | Upload native `eval-record` v1 or OTLP traces |
+| `reviews:write` | Create/open and close verdict reviews |
+| `reviews:read` | Read management-safe review status |
+
+The default **Ingest only** preset grants only `traces:write`. Tokens issued before scoped tokens existed are also ingest-only. Revocation immediately disables every endpoint.
+
+Set the API base URL to the project's Convex HTTP Actions site, for example `https://example.convex.site`. This is the `.convex.site` URL, not `.convex.cloud`.
+
+## Upload `eval-record` v1
+
+```bash
+curl -X POST "$BLINDBENCH_URL/ingest/v1/traces" \
+  -H "Authorization: Bearer $BLINDBENCH_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data-binary @eval-record.json
+```
+
+The endpoint accepts one record, a JSON array, or `{ "records": [...] }`. Its response is counts-only:
+
+```json
+{
+  "traces": 1,
+  "imported": 1,
+  "deduped": 0,
+  "steps": 2,
+  "requestMissing": 0,
+  "responseMissing": 0,
+  "invalid": 0,
+  "truncated": false
+}
+```
+
+Keep the stable record/trace IDs used by your artifacts. Review creation resolves the resulting `agentTraces.traceId` values, not Blind Bench database IDs. For native records with `id: "case-123"`, the stable trace ID is `native-case-123`.
+
+## Create and open a review
+
+`POST /api/v1/reviews` requires `reviews:write`.
+
+```bash
+curl -X POST "$BLINDBENCH_URL/api/v1/reviews" \
+  -H "Authorization: Bearer $BLINDBENCH_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Release candidate review",
+    "instructions": "Judge correctness and completeness.",
+    "trace_ids": ["native-case-123", "native-case-124"],
+    "idempotency_key": "release-2026-07-11"
+  }'
+```
+
+All trace IDs must resolve to ready runs in the token's project. A review contains 1–50 unique runs. Creation opens the review immediately.
+
+```json
+{
+  "review_id": "k57...",
+  "status": "open",
+  "item_count": 2,
+  "review_url": "https://blindbench.dev/review/verdict/opaque-token"
+}
+```
+
+Give `review_url` to reviewers. The share token is deliberately not returned as a separate field.
+
+`idempotency_key` is scoped to the project. Retrying an identical request with the same key returns the same review and URL. Reusing the key with a different name, instructions, or trace list returns HTTP `409`.
+
+## Read safe status
+
+`GET /api/v1/reviews?id=<review_id>` requires `reviews:read`.
+
+```bash
+curl "$BLINDBENCH_URL/api/v1/reviews?id=k57..." \
+  -H "Authorization: Bearer $BLINDBENCH_API_TOKEN"
+```
+
+```json
+{
+  "review_id": "k57...",
+  "status": "open",
+  "item_count": 2,
+  "judgment_count": 3,
+  "reviewed_item_count": 2,
+  "aggregate": {
+    "best": 1,
+    "acceptable": 1,
+    "weak": 1,
+    "disagreement": 1
+  }
+}
+```
+
+`aggregate.disagreement` counts reviewed runs that received more than one distinct verdict. This management projection never includes prompts, outputs, instructions, comments, reviewer names, model/harness/source provenance, source IDs, run IDs, or the share token.
+
+## Close a review
+
+`POST /api/v1/reviews/close` requires `reviews:write`.
+
+```bash
+curl -X POST "$BLINDBENCH_URL/api/v1/reviews/close" \
+  -H "Authorization: Bearer $BLINDBENCH_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"review_id":"k57..."}'
+```
+
+The response has the same safe shape as status with `"status": "closed"`. Closing an already closed review succeeds and returns the same state. A closed review preserves submitted judgments and accepts no new ones.
+
+## CLI
+
+The repository includes a standalone, dependency-light TypeScript CLI. It imports no Convex backend modules and can be copied into an independent package with a TypeScript runner.
+
+```bash
+export BLINDBENCH_URL="https://example.convex.site"
+export BLINDBENCH_API_TOKEN="..."
+
+npm run blindbench -- --help
+npm run blindbench -- upload ./eval-record.json
+npm run blindbench -- create \
+  --name "Release candidate review" \
+  --instructions "Judge correctness and completeness." \
+  --idempotency-key "release-2026-07-11" \
+  --trace-id native-case-123 \
+  --trace-id native-case-124
+npm run blindbench -- status --review-id 'k57...'
+npm run blindbench -- close --review-id 'k57...'
+```
+
+The CLI never prints the API token or raw artifact records. Upload output is counts-only; review output is restricted to IDs, status/counts, and the reviewer URL.
+
+## Errors and limits
+
+All endpoint errors are JSON: `{ "error": "..." }`.
+
+| HTTP status | Meaning |
+|---|---|
+| `400` | Invalid JSON, missing/unknown field, malformed ID, duplicate trace ID |
+| `401` | Missing, invalid, or revoked token |
+| `403` | Token lacks the exact required scope |
+| `404` | Review or trace is absent from the token's project (including cross-project IDs) |
+| `409` | Trace is not ready, idempotency conflict, or invalid lifecycle transition |
+| `413` | Request body is too large or more than 50 trace IDs were supplied |
+
+Review API endpoints do not expose wildcard CORS headers. Call them from server-side automation or the CLI, not untrusted browser code.

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
+    "blindbench": "tsx scripts/blindbench.ts",
+    "test:blindbench-cli": "vitest run scripts/blindbench.test.ts",
     "launch:customer-test-packet": "npx tsx scripts/customer-test-launch-packet.ts",
     "build:deploy": "node scripts/vercel-build.mjs",
     "readiness:customer-testing": "npx tsx scripts/customer-testing-readiness.ts",

--- a/scripts/blindbench.test.ts
+++ b/scripts/blindbench.test.ts
@@ -1,0 +1,114 @@
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, test } from "vitest";
+import { parseArgs, runCli } from "./blindbench";
+
+function harness(responses: ReadonlyArray<{ readonly status?: number; readonly body: unknown }>) {
+  const output: string[] = [];
+  const errors: string[] = [];
+  const requests: Array<{ readonly url: string; readonly init?: RequestInit }> = [];
+  let index = 0;
+  const fetcher = async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+    requests.push({ url: String(input), init });
+    const next = responses[index];
+    index++;
+    if (!next) throw new Error("Unexpected request");
+    return new Response(JSON.stringify(next.body), { status: next.status ?? 200, headers: { "Content-Type": "application/json" } });
+  };
+  return {
+    output,
+    errors,
+    requests,
+    fetcher,
+    io: { out: (text: string) => output.push(text), error: (text: string) => errors.push(text) },
+    env: { BLINDBENCH_URL: "http://127.0.0.1:9000/", BLINDBENCH_API_TOKEN: "secret-api-token" },
+  };
+}
+
+describe("Blind Bench customer CLI", () => {
+  test("prints help and rejects arguments deterministically", () => {
+    expect(parseArgs(["--help"])).toMatchObject({ ok: true, command: { kind: "help" } });
+    expect(parseArgs(["create", "--name", "Example"])).toEqual({ ok: false, error: "create requires --idempotency-key" });
+    expect(parseArgs(["status", "--review-id", "one", "--review-id", "two"])).toEqual({ ok: false, error: "Duplicate argument: --review-id" });
+    expect(parseArgs(["close", "--unknown", "x"])).toEqual({ ok: false, error: "Unknown argument: --unknown" });
+  });
+
+  test("uploads a synthetic eval-record without echoing the token or record content", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "blindbench-cli-"));
+    const path = join(dir, "record.json");
+    const sentinel = "PRIVATE-SYNTHETIC-CONTENT";
+    await writeFile(path, JSON.stringify({ version: "1", id: "synthetic-1", input: { messages: [{ role: "user", content: sentinel }] }, output: { content: "Synthetic answer" } }));
+    const h = harness([{ body: { imported: 1, deduped: 0, invalid: 0, truncated: false, malicious: sentinel } }]);
+    expect(await runCli(["upload", path], h.env, h.io, h.fetcher)).toBe(0);
+    expect(h.requests[0]?.url).toBe("http://127.0.0.1:9000/ingest/v1/traces");
+    expect(h.requests[0]?.init?.body).toContain(sentinel);
+    const rendered = [...h.output, ...h.errors].join("\n");
+    expect(rendered).toContain("imported=1");
+    expect(rendered).not.toContain(sentinel);
+    expect(rendered).not.toContain("secret-api-token");
+  });
+
+  test("wraps create, status, and close with safe projected output", async () => {
+    const h = harness([
+      { body: { review_id: "review-1", status: "open", item_count: 2, review_url: "https://blindbench.dev/review/verdict/opaque", raw: "DO-NOT-PRINT" } },
+      { body: { review_id: "review-1", status: "open", item_count: 2, judgment_count: 1, reviewed_item_count: 1, aggregate: { best: 1, acceptable: 0, weak: 0, disagreement: 0 }, comments: "DO-NOT-PRINT" } },
+      { body: { review_id: "review-1", status: "closed", item_count: 2, judgment_count: 1, reviewed_item_count: 1, aggregate: { best: 1, acceptable: 0, weak: 0, disagreement: 0 } } },
+    ]);
+    expect(await runCli(["create", "--name", "Example", "--idempotency-key", "ci-1", "--trace-id", "trace-a", "--trace-id", "trace-b"], h.env, h.io, h.fetcher)).toBe(0);
+    expect(await runCli(["status", "--review-id", "review-1"], h.env, h.io, h.fetcher)).toBe(0);
+    expect(await runCli(["close", "--review-id", "review-1"], h.env, h.io, h.fetcher)).toBe(0);
+    expect(h.requests.map((request) => request.url)).toEqual([
+      "http://127.0.0.1:9000/api/v1/reviews",
+      "http://127.0.0.1:9000/api/v1/reviews?id=review-1",
+      "http://127.0.0.1:9000/api/v1/reviews/close",
+    ]);
+    const rendered = [...h.output, ...h.errors].join("\n");
+    expect(rendered).toContain("Reviewer URL: https://blindbench.dev/review/verdict/opaque");
+    expect(rendered).not.toContain("DO-NOT-PRINT");
+    expect(rendered).not.toContain("secret-api-token");
+  });
+
+  test("HTTP failures never print response bodies", async () => {
+    const h = harness([{ status: 400, body: { error: "PRIVATE-CONTENT secret-api-token" } }]);
+    expect(await runCli(["status", "--review-id", "review-1"], h.env, h.io, h.fetcher)).toBe(1);
+    expect(h.errors).toEqual(["Blind Bench request failed (HTTP 400)."]);
+  });
+
+  test("rejects insecure remote URLs and partial uploads", async () => {
+    const insecure = harness([]);
+    expect(await runCli(
+      ["status", "--review-id", "review-1"],
+      { ...insecure.env, BLINDBENCH_URL: "http://example.test" },
+      insecure.io,
+      insecure.fetcher,
+    )).toBe(2);
+    expect(insecure.requests).toHaveLength(0);
+
+    const dir = await mkdtemp(join(tmpdir(), "blindbench-cli-"));
+    const path = join(dir, "record.json");
+    await writeFile(path, JSON.stringify({
+      version: "1",
+      input: { messages: [{ role: "user", content: "Synthetic" }] },
+    }));
+    const partial = harness([
+      { body: { imported: 0, deduped: 0, invalid: 1, truncated: false } },
+    ]);
+    expect(await runCli(["upload", path], partial.env, partial.io, partial.fetcher)).toBe(1);
+    expect(partial.errors).toEqual([
+      "Blind Bench rejected or truncated part of the upload.",
+    ]);
+  });
+
+  test("fails closed on malformed successful responses", async () => {
+    const malformed = harness([{ body: {} }]);
+    expect(await runCli(
+      ["create", "--name", "Example", "--idempotency-key", "key", "--trace-id", "trace-a"],
+      malformed.env,
+      malformed.io,
+      malformed.fetcher,
+    )).toBe(1);
+    expect(malformed.output).toEqual([]);
+    expect(malformed.errors).toEqual(["Blind Bench returned an invalid response."]);
+  });
+});

--- a/scripts/blindbench.ts
+++ b/scripts/blindbench.ts
@@ -1,0 +1,239 @@
+#!/usr/bin/env node
+/** Dependency-light customer CLI. It intentionally imports no Convex backend code. */
+import { readFile } from "node:fs/promises";
+import { pathToFileURL } from "node:url";
+
+const HELP = `Blind Bench customer CLI
+
+Usage:
+  npm run blindbench -- upload <eval-record.json>
+  npm run blindbench -- create --name <name> --idempotency-key <key> --trace-id <id> [--trace-id <id> ...] [--instructions <text>]
+  npm run blindbench -- status --review-id <id>
+  npm run blindbench -- close --review-id <id>
+  npm run blindbench -- --help
+
+Environment:
+  BLINDBENCH_URL        Convex site base URL, for example https://example.convex.site
+  BLINDBENCH_API_TOKEN  Project token with the command's required scopes
+`;
+
+type Io = { readonly out: (text: string) => void; readonly error: (text: string) => void };
+type Env = Readonly<Record<string, string | undefined>>;
+type Fetch = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+
+type ParsedCommand =
+  | { readonly kind: "help" }
+  | { readonly kind: "upload"; readonly path: string }
+  | { readonly kind: "create"; readonly name: string; readonly instructions?: string; readonly idempotencyKey: string; readonly traceIds: ReadonlyArray<string> }
+  | { readonly kind: "status"; readonly reviewId: string }
+  | { readonly kind: "close"; readonly reviewId: string };
+
+type ParseOutcome = { readonly ok: true; readonly command: ParsedCommand } | { readonly ok: false; readonly error: string };
+
+function parseFlags(args: ReadonlyArray<string>, allowed: ReadonlySet<string>, repeatable: ReadonlySet<string> = new Set()): ParseOutcome | Map<string, string[]> {
+  const values = new Map<string, string[]>();
+  for (let index = 0; index < args.length; index += 2) {
+    const flag = args[index];
+    const value = args[index + 1];
+    if (flag === undefined || !allowed.has(flag)) return { ok: false, error: `Unknown argument: ${flag ?? ""}` };
+    if (value === undefined || value.startsWith("--")) return { ok: false, error: `Missing value for ${flag}` };
+    const prior = values.get(flag) ?? [];
+    if (prior.length > 0 && !repeatable.has(flag)) return { ok: false, error: `Duplicate argument: ${flag}` };
+    prior.push(value);
+    values.set(flag, prior);
+  }
+  return values;
+}
+
+/** Parse CLI arguments without reading environment, disk, or network state. */
+export function parseArgs(argv: ReadonlyArray<string>): ParseOutcome {
+  if (argv.length === 0 || argv[0] === "--help" || argv[0] === "-h") return { ok: true, command: { kind: "help" } };
+  const command = argv[0];
+  if (command === "upload") {
+    if (argv.length !== 2 || argv[1] === undefined || argv[1].startsWith("--")) return { ok: false, error: "upload requires exactly one artifact path" };
+    return { ok: true, command: { kind: "upload", path: argv[1] } };
+  }
+  if (command === "create") {
+    const flags = parseFlags(argv.slice(1), new Set(["--name", "--instructions", "--idempotency-key", "--trace-id"]), new Set(["--trace-id"]));
+    if (!(flags instanceof Map)) return flags;
+    const name = flags.get("--name")?.[0]?.trim() ?? "";
+    const idempotencyKey = flags.get("--idempotency-key")?.[0]?.trim() ?? "";
+    const traceIds = (flags.get("--trace-id") ?? []).map((value) => value.trim()).filter((value) => value.length > 0);
+    if (!name) return { ok: false, error: "create requires --name" };
+    if (!idempotencyKey) return { ok: false, error: "create requires --idempotency-key" };
+    if (traceIds.length === 0) return { ok: false, error: "create requires at least one --trace-id" };
+    if (traceIds.length > 50) return { ok: false, error: "create accepts at most 50 --trace-id values" };
+    if (new Set(traceIds).size !== traceIds.length) return { ok: false, error: "create does not accept duplicate --trace-id values" };
+    const instructions = flags.get("--instructions")?.[0]?.trim();
+    return { ok: true, command: { kind: "create", name, ...(instructions ? { instructions } : {}), idempotencyKey, traceIds } };
+  }
+  if (command === "status" || command === "close") {
+    const flags = parseFlags(argv.slice(1), new Set(["--review-id"]));
+    if (!(flags instanceof Map)) return flags;
+    const reviewId = flags.get("--review-id")?.[0]?.trim() ?? "";
+    if (!reviewId) return { ok: false, error: `${command} requires --review-id` };
+    return { ok: true, command: { kind: command, reviewId } };
+  }
+  return { ok: false, error: `Unknown command: ${command}` };
+}
+
+function safeObject(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : {};
+}
+
+function safeNumber(record: Record<string, unknown>, key: string): number {
+  return typeof record[key] === "number" ? record[key] : 0;
+}
+
+function safeString(record: Record<string, unknown>, key: string): string {
+  return typeof record[key] === "string" ? record[key] : "";
+}
+
+function requireString(record: Record<string, unknown>, key: string): string {
+  const value = record[key];
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error("Blind Bench returned an invalid response.");
+  }
+  return value;
+}
+
+function requireCount(record: Record<string, unknown>, key: string): number {
+  const value = record[key];
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 0) {
+    throw new Error("Blind Bench returned an invalid response.");
+  }
+  return value;
+}
+
+function validateUploadResponse(record: Record<string, unknown>): void {
+  requireCount(record, "imported");
+  requireCount(record, "deduped");
+  requireCount(record, "invalid");
+  if (typeof record.truncated !== "boolean") {
+    throw new Error("Blind Bench returned an invalid response.");
+  }
+}
+
+function validateCreateResponse(record: Record<string, unknown>): void {
+  requireString(record, "review_id");
+  requireString(record, "status");
+  requireCount(record, "item_count");
+  const reviewUrl = requireString(record, "review_url");
+  let parsed: URL;
+  try {
+    parsed = new URL(reviewUrl);
+  } catch {
+    throw new Error("Blind Bench returned an invalid response.");
+  }
+  if (parsed.protocol !== "https:") {
+    throw new Error("Blind Bench returned an invalid response.");
+  }
+}
+
+function validateStatusResponse(record: Record<string, unknown>): void {
+  requireString(record, "review_id");
+  requireString(record, "status");
+  requireCount(record, "item_count");
+  requireCount(record, "judgment_count");
+  requireCount(record, "reviewed_item_count");
+  const aggregate = safeObject(record.aggregate);
+  for (const key of ["best", "acceptable", "weak", "disagreement"]) {
+    requireCount(aggregate, key);
+  }
+}
+
+async function request(fetcher: Fetch, url: string, token: string, init: RequestInit): Promise<Record<string, unknown>> {
+  let response: Response;
+  try {
+    response = await fetcher(url, { ...init, headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json", ...init.headers } });
+  } catch {
+    throw new Error("Could not reach Blind Bench.");
+  }
+  if (!response.ok) throw new Error(`Blind Bench request failed (HTTP ${response.status}).`);
+  try {
+    const value: unknown = await response.json();
+    return safeObject(value);
+  } catch {
+    throw new Error("Blind Bench returned an invalid JSON response.");
+  }
+}
+
+/** Execute one command through injectable IO/fetch seams. Returns a process exit code. */
+export async function runCli(
+  argv: ReadonlyArray<string>,
+  env: Env = process.env,
+  io: Io = { out: (text) => process.stdout.write(`${text}\n`), error: (text) => process.stderr.write(`${text}\n`) },
+  fetcher: Fetch = fetch,
+): Promise<number> {
+  const parsed = parseArgs(argv);
+  if (!parsed.ok) {
+    io.error(`${parsed.error}\nRun with --help for usage.`);
+    return 2;
+  }
+  if (parsed.command.kind === "help") {
+    io.out(HELP.trimEnd());
+    return 0;
+  }
+  const baseUrl = env.BLINDBENCH_URL?.trim().replace(/\/+$/, "");
+  const token = env.BLINDBENCH_API_TOKEN?.trim();
+  let parsedBaseUrl: URL | undefined;
+  try {
+    parsedBaseUrl = baseUrl ? new URL(baseUrl) : undefined;
+  } catch {
+    parsedBaseUrl = undefined;
+  }
+  const loopback = parsedBaseUrl?.hostname === "127.0.0.1"
+    || parsedBaseUrl?.hostname === "localhost"
+    || parsedBaseUrl?.hostname === "::1";
+  if (!parsedBaseUrl || (parsedBaseUrl.protocol !== "https:" && !loopback)) {
+    io.error("BLINDBENCH_URL must use HTTPS (HTTP is allowed only for loopback testing).");
+    return 2;
+  }
+  if (!token) {
+    io.error("BLINDBENCH_API_TOKEN is required.");
+    return 2;
+  }
+
+  try {
+    if (parsed.command.kind === "upload") {
+      let raw: string;
+      try {
+        raw = await readFile(parsed.command.path, "utf8");
+        JSON.parse(raw);
+      } catch {
+        io.error("Could not read a valid JSON artifact.");
+        return 2;
+      }
+      const result = await request(fetcher, `${baseUrl}/ingest/v1/traces`, token, { method: "POST", body: raw });
+      validateUploadResponse(result);
+      if (safeNumber(result, "invalid") > 0 || result.truncated === true) {
+        throw new Error("Blind Bench rejected or truncated part of the upload.");
+      }
+      io.out(`Upload complete: imported=${safeNumber(result, "imported")} deduped=${safeNumber(result, "deduped")} invalid=${safeNumber(result, "invalid")}`);
+      return 0;
+    }
+    if (parsed.command.kind === "create") {
+      const result = await request(fetcher, `${baseUrl}/api/v1/reviews`, token, {
+        method: "POST",
+        body: JSON.stringify({ name: parsed.command.name, ...(parsed.command.instructions ? { instructions: parsed.command.instructions } : {}), trace_ids: parsed.command.traceIds, idempotency_key: parsed.command.idempotencyKey }),
+      });
+      validateCreateResponse(result);
+      io.out(`Review ${safeString(result, "review_id")} is ${safeString(result, "status")} (${safeNumber(result, "item_count")} runs).`);
+      io.out(`Reviewer URL: ${safeString(result, "review_url")}`);
+      return 0;
+    }
+    const reviewId = encodeURIComponent(parsed.command.reviewId);
+    const result = parsed.command.kind === "status"
+      ? await request(fetcher, `${baseUrl}/api/v1/reviews?id=${reviewId}`, token, { method: "GET" })
+      : await request(fetcher, `${baseUrl}/api/v1/reviews/close`, token, { method: "POST", body: JSON.stringify({ review_id: parsed.command.reviewId }) });
+    validateStatusResponse(result);
+    io.out(`Review ${safeString(result, "review_id")} is ${safeString(result, "status")}: items=${safeNumber(result, "item_count")} judgments=${safeNumber(result, "judgment_count")}.`);
+    return 0;
+  } catch (cause: unknown) {
+    io.error(cause instanceof Error ? cause.message : "Blind Bench command failed.");
+    return 1;
+  }
+}
+
+const direct = process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (direct) process.exitCode = await runCli(process.argv.slice(2));

--- a/src/routes/orgs/projects/IngestEndpoint.ct.spec.tsx
+++ b/src/routes/orgs/projects/IngestEndpoint.ct.spec.tsx
@@ -1,0 +1,38 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+import { MemoryRouter } from "react-router-dom";
+import type { Id } from "../../../../convex/_generated/dataModel";
+import { ProjectProvider } from "@/contexts/ProjectContext";
+import { IngestEndpoint } from "./IngestEndpoint";
+
+const projectId = "project-automation-api" as Id<"projects">;
+
+test("data sources exposes least-privilege automation tokens and customer API guidance", async ({ mount }) => {
+  const component = await mount(
+    <MemoryRouter initialEntries={[`/orgs/example/projects/${projectId}/ingest`]}>
+      <ProjectProvider
+        value={{
+          project: {
+            _id: projectId,
+            _creationTime: 1,
+            organizationId: "org-1" as Id<"organizations">,
+            name: "Evaluation workspace",
+            createdById: "user-1" as Id<"users">,
+          },
+          projectId,
+          role: "owner",
+          blindMode: undefined,
+        }}
+      >
+        <IngestEndpoint />
+      </ProjectProvider>
+    </MemoryRouter>,
+  );
+
+  await expect(component.getByRole("heading", { name: "Continuous ingest" })).toBeVisible();
+  await expect(component.getByLabel("Access preset")).toHaveValue("ingest");
+  await component.getByLabel("Access preset").selectOption("automation");
+  await expect(component).toContainText("Scopes: traces:write, reviews:write, reviews:read.");
+  await expect(component.getByText("Automate blind review cycles", { exact: true })).toBeVisible();
+  await expect(component).toContainText("POST /api/v1/reviews — create and open");
+  await expect(component).toContainText("native-case-123");
+});

--- a/src/routes/orgs/projects/IngestEndpoint.tsx
+++ b/src/routes/orgs/projects/IngestEndpoint.tsx
@@ -55,8 +55,10 @@ export function IngestEndpoint() {
 
   const nativeIngestUrl = deriveNativeIngestUrl();
   const ingestUrl = deriveIngestUrl();
+  const apiBaseUrl = nativeIngestUrl.replace(/\/ingest\/v1\/traces$/, "");
 
   const [label, setLabel] = useState("Gateway token");
+  const [preset, setPreset] = useState<"ingest" | "automation">("ingest");
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState("");
   const [issued, setIssued] = useState<IssueResult | null>(null);
@@ -68,7 +70,10 @@ export function IngestEndpoint() {
     // A prior full-token card is stale once a new token is issued — clear it.
     setIssued(null);
     try {
-      const res = await issueToken({ projectId, label: label.trim() });
+      const scopes = preset === "automation"
+        ? (["traces:write", "reviews:write", "reviews:read"] as const)
+        : (["traces:write"] as const);
+      const res = await issueToken({ projectId, label: label.trim(), scopes: [...scopes] });
       setIssued(res);
     } catch (err) {
       setError(
@@ -125,7 +130,7 @@ export function IngestEndpoint() {
         </h2>
 
         <form onSubmit={handleIssue} className="flex flex-wrap items-end gap-2">
-          <div className="flex-1 space-y-1.5">
+          <div className="min-w-48 flex-1 space-y-1.5">
             <Label htmlFor="token-label">Label</Label>
             <Input
               id="token-label"
@@ -135,9 +140,26 @@ export function IngestEndpoint() {
               maxLength={80}
             />
           </div>
+          <div className="min-w-52 space-y-1.5">
+            <Label htmlFor="token-preset">Access preset</Label>
+            <select
+              id="token-preset"
+              value={preset}
+              onChange={(event) => setPreset(event.target.value === "automation" ? "automation" : "ingest")}
+              className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
+            >
+              <option value="ingest">Ingest only (default)</option>
+              <option value="automation">Automation (ingest + manage reviews)</option>
+            </select>
+          </div>
           <Button type="submit" disabled={busy}>
             {busy ? "Issuing…" : "Issue token"}
           </Button>
+          <p className="w-full text-xs text-muted-foreground">
+            {preset === "automation"
+              ? "Scopes: traces:write, reviews:write, reviews:read."
+              : "Scope: traces:write. This token cannot manage reviews."}
+          </p>
         </form>
 
         {error && (
@@ -161,9 +183,62 @@ export function IngestEndpoint() {
       {/* Native JSON — the default path */}
       <NativeIngestCard nativeUrl={nativeIngestUrl} />
 
+      {/* Customer automation API — available without repository access */}
+      <AutomationApiCard apiBaseUrl={apiBaseUrl} />
+
       {/* Gateway / OTLP adapter */}
       <GatewaySetupCard ingestUrl={ingestUrl} />
     </div>
+  );
+}
+
+function AutomationApiCard({ apiBaseUrl }: { apiBaseUrl: string }) {
+  const createExample = [
+    `curl -X POST ${apiBaseUrl}/api/v1/reviews \\`,
+    `  -H "Authorization: Bearer <automation-token>" \\`,
+    `  -H "Content-Type: application/json" \\`,
+    `  -d '{`,
+    `    "name": "Release candidate review",`,
+    `    "trace_ids": ["native-case-123"],`,
+    `    "idempotency_key": "release-2026-07-11"`,
+    `  }'`,
+  ].join("\n");
+
+  return (
+    <Card className="mt-8">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-base">
+          <KeyRound aria-hidden="true" className="h-4 w-4 text-primary" />
+          Automate blind review cycles
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4 text-sm text-muted-foreground">
+        <p>
+          Issue an <strong className="text-foreground">Automation</strong> token,
+          upload records, then create an open blind review from their stable trace
+          IDs. The API returns an opaque reviewer URL you can share immediately.
+        </p>
+        <div className="relative">
+          <pre className="overflow-x-auto rounded-lg border bg-muted/30 p-3 pr-12 font-mono text-xs text-foreground">
+            {createExample}
+          </pre>
+          <CopyButton text={createExample} label="Copy curl" variant="overlay" />
+        </div>
+        <div className="grid gap-2 rounded-lg border p-3 font-mono text-xs text-foreground">
+          <span>POST /api/v1/reviews — create and open</span>
+          <span>GET /api/v1/reviews?id=&lt;review_id&gt; — safe aggregate status</span>
+          <span>POST /api/v1/reviews/close — close and preserve judgments</span>
+        </div>
+        <p>
+          Prefix the record ID emitted by your harness with{" "}
+          <code className="text-foreground">native-</code>. For example, record{" "}
+          <code className="text-foreground">case-123</code> becomes trace ID{" "}
+          <code className="text-foreground">native-case-123</code>. Review status
+          never returns prompts, outputs, reviewer identities, comments, or model
+          provenance.
+        </p>
+      </CardContent>
+    </Card>
   );
 }
 
@@ -340,7 +415,7 @@ function TokenRow({ token }: { token: IngestToken }) {
           </span>
         </p>
         <p className="text-xs text-muted-foreground">
-          Created {formatTimestamp(token.createdAt)} · Last used{" "}
+          Created {formatTimestamp(token.createdAt)} · {token.scopes.join(", ")} · Last used{" "}
           {token.lastUsedAt ? formatTimestamp(token.lastUsedAt) : "never"}
         </p>
         {error && (

--- a/src/routes/traces/__smoke__/convexReactMock.tsx
+++ b/src/routes/traces/__smoke__/convexReactMock.tsx
@@ -237,6 +237,8 @@ export function useQuery(query: unknown) {
         return FIXTURE_REVIEW_DECK;
       case "comparisonCampaigns:listCampaigns":
         return FIXTURE_COMPARISON_REVIEWS;
+      case "ingestTokens:listIngestTokens":
+        return [];
       case "agentTraces:getTrace":
       case "agentTraceReviewSessions:getTrace":
         return FIXTURE_BLIND_TRACE;


### PR DESCRIPTION
## Summary

Adds a customer-operable vertical slice for BlindBench's canonical external workflow without requiring backend repository access:

`eval-record v1 upload → create/open verdict review → opaque reviewer URL → safe aggregate status → close`

Closes #352. Parent: #333.

## Customer contract

- Adds explicit project-token capabilities:
  - `traces:write`
  - `reviews:write`
  - `reviews:read`
- Keeps existing unscoped tokens backward-compatible as ingest-only.
- Adds public HTTP routes:
  - `POST /api/v1/reviews`
  - `GET /api/v1/reviews?id=<review_id>`
  - `POST /api/v1/reviews/close`
- Selects ingested runs by stable customer-visible native trace IDs.
- Returns an opaque guest reviewer URL.
- Exposes only lifecycle counts and aggregate verdict/disagreement status; no prompts, outputs, reviewer identities, comments, trace provenance, or share tokens.
- Adds bounded inputs, project tenancy checks, SHA-256 request fingerprints, and idempotent create/close behavior.
- Updates read-token `lastUsedAt` on successful polling.

## Customer surfaces

- Adds an explicit Automation token preset to Data sources while preserving Ingest only as the default.
- Adds customer-facing API guidance to the same screen.
- Adds `docs/customer-automation-api.md`.
- Adds a dependency-light HTTP CLI:
  - `upload`
  - `create`
  - `status`
  - `close`
- CLI fails closed on malformed 2xx responses, partial/truncated uploads, and insecure non-loopback HTTP URLs.

## Verification

- `npm run test:all`
  - build passed
  - eval tests: 23 files / 189 tests passed
  - Convex tests: 37 files / 291 tests passed
  - component tests: 15 passed
- `npm run test:blindbench-cli`
  - 6 tests passed
- Black-box CLI smoke through the actual command entrypoint against a standalone HTTP fixture:
  - upload succeeded
  - review creation returned an opaque reviewer URL
  - status succeeded
  - close succeeded
- `git diff --check` passed.

The Convex suite still emits the repository's existing scheduled-function transaction teardown warnings while exiting successfully.

## Independent review

A separate security/correctness reviewer identified malformed-2xx handling and populated reviewer-leakage coverage as medium findings. This branch now validates every endpoint response before printing success and seeds multiple reviewer decisions/notes while asserting an exact safe status projection. It also added legacy-token ingest coverage, declared body-size rejection, and read-token usage auditing.

## Deployment / rollout

This PR changes `convex/schema.ts` and Convex HTTP functions. Merge is not production activation: deploy Convex explicitly, then run one deployed synthetic two-principal smoke using an Automation token and the returned guest reviewer URL.

## Visual QA

The Data sources interaction is covered by `IngestEndpoint.ct.spec.tsx`, including the least-privilege default, selecting Automation, the exposed scopes, API guidance, and stable trace-ID mapping. A production-styled screenshot should be captured from the authenticated preview/deployment before merge; the repository's CT mount intentionally omits global app styles and was not used as visual evidence.
