### PR TITLE
feat: gate full-span training exports

### DIFF
--- a/convex/exports.ts
+++ b/convex/exports.ts
@@ -24,12 +24,19 @@ import type { Doc, Id } from "./_generated/dataModel";
 import { requireProjectRole } from "./lib/auth";
 import { readMessages } from "./lib/messages";
 import {
+  parseHarborReviewerProjection,
+  type HarborReviewerProjection,
+} from "../src/lib/evals/harborEvidence";
+import {
   buildExportManifest,
   gateRows,
   toJsonl,
-  renderStep,
-  renderTranscript,
   moreSensitive,
+  serializeAgentObservableEvent,
+  serializeAgentObservableTrajectoryContext,
+  TRAINING_EXPORT_LIMITS,
+  trainingExportSizeViolation,
+  utf8Bytes,
   type ClassifiedRow,
   type ExcludedRow,
   type ExportFormat,
@@ -44,6 +51,16 @@ const FORMAT = v.union(v.literal("dpo"), v.literal("annotated"), v.literal("sft"
 
 const DOWNLOAD_TTL_MS = 60 * 60 * 1000; // AC6: download expires after 1 hour
 const MAX_PAIRS_PER_RUN = 20; // cap best×weak explosion per run
+
+async function sha256(value: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(value));
+  return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+async function sha256Buffer(value: ArrayBuffer): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", value);
+  return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+}
 
 // {{word}} substitution — mirrors convex/runsActions.ts substituteVariables.
 const substitute = (t: string, vars: Record<string, string>): string =>
@@ -391,6 +408,42 @@ export const gatherTrajectoryPlan = internalQuery({
   },
 });
 
+// --- approved immutable source plan ------------------------------------------
+
+type ApprovedPlanRow =
+  | { readonly eligibility: "excluded"; readonly reason: ExcludedRow["reason"]; readonly privacyClass: PrivacyClass; readonly reviewerCount: number }
+  | { readonly eligibility: "eligible"; readonly format: "sft"; readonly privacyClass: PrivacyClass; readonly reviewerCount: number; readonly projectionStorageId: Id<"_storage">; readonly projectionSha256: string; readonly taskHash: string }
+  | { readonly eligibility: "eligible"; readonly format: "dpo"; readonly privacyClass: PrivacyClass; readonly reviewerCount: number; readonly winner: "left" | "right"; readonly divergenceStepIndex: number; readonly sharedPrefixHash: string; readonly taskHash: string; readonly leftProjectionStorageId: Id<"_storage">; readonly leftProjectionSha256: string; readonly rightProjectionStorageId: Id<"_storage">; readonly rightProjectionSha256: string };
+
+/** Resolve only immutable approval snapshot references; never rediscover spans/matchups. */
+export const gatherApprovedPlan = internalQuery({
+  args: { projectId: v.id("projects"), approvalId: v.id("trainingApprovals"), format: FORMAT, campaignId: v.optional(v.id("comparisonCampaigns")), verdictCampaignId: v.optional(v.id("verdictReviewCampaigns")) },
+  handler: async (ctx, args): Promise<{ readonly plan: ApprovedPlanRow[]; readonly policyVersion: string; readonly candidateCount: number; readonly reviewers: number }> => {
+    await requireProjectRole(ctx, args.projectId, ["owner", "editor"]);
+    const approval = await ctx.db.get(args.approvalId);
+    if (!approval || approval.projectId !== args.projectId) throw new Error("Training approval not found for this project.");
+    if (approval.status !== "active") throw new Error("Training approval is revoked; grant a new approval before exporting.");
+    if (args.format === "sft" && (approval.kind !== "verdict_campaign" || approval.verdictCampaignId !== args.verdictCampaignId)) throw new Error("This training approval does not cover the selected run review.");
+    if (args.format === "dpo" && (approval.kind !== "comparison_campaign" || approval.comparisonCampaignId !== args.campaignId)) throw new Error("This training approval does not cover the selected comparison review.");
+    if (trainingExportSizeViolation({ candidates: approval.candidateCount })) throw new Error("Approved candidate count exceeds the export limit.");
+    const items = await ctx.db.query("trainingApprovalItems").withIndex("by_approval_and_order", (q) => q.eq("approvalId", approval._id)).take(TRAINING_EXPORT_LIMITS.maxCandidates + 1);
+    if (items.length !== approval.candidateCount || trainingExportSizeViolation({ candidates: items.length })) throw new Error("Training approval snapshot is incomplete or oversized.");
+    const plan: ApprovedPlanRow[] = [];
+    for (const item of items) {
+      if (item.eligibility === "excluded") {
+        plan.push({ eligibility: "excluded", reason: item.exclusionReason ?? "insufficient_evidence", privacyClass: item.privacyClass, reviewerCount: item.reviewerCount });
+      } else if (args.format === "sft" && item.projectionStorageId && item.projectionSha256 && item.taskHash) {
+        plan.push({ eligibility: "eligible", format: "sft", privacyClass: item.privacyClass, reviewerCount: item.reviewerCount, projectionStorageId: item.projectionStorageId, projectionSha256: item.projectionSha256, taskHash: item.taskHash });
+      } else if (args.format === "dpo" && item.winner && item.divergenceStepIndex !== undefined && item.sharedPrefixHash && item.taskHash && item.leftTaskHash === item.taskHash && item.rightTaskHash === item.taskHash && item.leftProjectionStorageId && item.leftProjectionSha256 && item.rightProjectionStorageId && item.rightProjectionSha256) {
+        plan.push({ eligibility: "eligible", format: "dpo", privacyClass: item.privacyClass, reviewerCount: item.reviewerCount, winner: item.winner, divergenceStepIndex: item.divergenceStepIndex, sharedPrefixHash: item.sharedPrefixHash, taskHash: item.taskHash, leftProjectionStorageId: item.leftProjectionStorageId, leftProjectionSha256: item.leftProjectionSha256, rightProjectionStorageId: item.rightProjectionStorageId, rightProjectionSha256: item.rightProjectionSha256 });
+      } else {
+        throw new Error("Training approval snapshot is invalid for the requested format.");
+      }
+    }
+    return { plan, policyVersion: approval.policyVersion, candidateCount: approval.candidateCount, reviewers: approval.reviewerCount };
+  },
+});
+
 // --- record + list -----------------------------------------------------------
 
 export const recordExport = internalMutation({
@@ -399,14 +452,27 @@ export const recordExport = internalMutation({
     source: SOURCE,
     format: FORMAT,
     storageId: v.id("_storage"),
+    manifestStorageId: v.id("_storage"),
+    trainingApprovalId: v.id("trainingApprovals"),
+    campaignId: v.optional(v.id("comparisonCampaigns")),
+    verdictCampaignId: v.optional(v.id("verdictReviewCampaigns")),
     rowCount: v.number(),
     excludedCount: v.number(),
     manifest: v.string(),
     createdById: v.id("users"),
     createdAt: v.number(),
   },
-  handler: async (ctx, args): Promise<Id<"trainingExports">> =>
-    await ctx.db.insert("trainingExports", args),
+  handler: async (ctx, args): Promise<Id<"trainingExports">> => {
+    const approval = await ctx.db.get(args.trainingApprovalId);
+    if (!approval || approval.status !== "active" || approval.projectId !== args.projectId) throw new Error("Training approval is no longer active for this project.");
+    const verdictBound = approval.kind === "verdict_campaign" && approval.verdictCampaignId === args.verdictCampaignId && args.campaignId === undefined && args.format === "sft";
+    const comparisonBound = approval.kind === "comparison_campaign" && approval.comparisonCampaignId === args.campaignId && args.verdictCampaignId === undefined && args.format === "dpo";
+    if (!verdictBound && !comparisonBound) throw new Error("Training approval campaign binding changed before export was recorded.");
+    const existing = await ctx.db.query("trainingExports").withIndex("by_approval", (q) => q.eq("trainingApprovalId", approval._id)).take(TRAINING_EXPORT_LIMITS.maxExportsPerApproval);
+    if (existing.length >= TRAINING_EXPORT_LIMITS.maxExportsPerApproval) throw new Error("Training approval export limit reached.");
+    const { campaignId: _campaignId, verdictCampaignId: _verdictCampaignId, ...row } = args;
+    return await ctx.db.insert("trainingExports", row);
+  },
 });
 
 export const listExports = query({
@@ -418,16 +484,28 @@ export const listExports = query({
       .withIndex("by_project", (q) => q.eq("projectId", args.projectId))
       .order("desc")
       .take(50);
-    return rows.map((r) => ({
-      _id: r._id,
-      source: r.source,
-      format: r.format,
-      rowCount: r.rowCount,
-      excludedCount: r.excludedCount,
-      // Parsed ExportManifest, or null for exports created before #288.
-      manifest: r.manifest ? (JSON.parse(r.manifest) as ExportManifest) : null,
-      createdAt: r.createdAt,
-      expired: Date.now() - r.createdAt > DOWNLOAD_TTL_MS,
+    return await Promise.all(rows.map(async (r) => {
+      const expired = Date.now() - r.createdAt > DOWNLOAD_TTL_MS;
+      const approval = r.trainingApprovalId ? await ctx.db.get(r.trainingApprovalId) : null;
+      const availability = r.trainingApprovalId === undefined
+        ? "legacy_unapproved" as const
+        : !approval || approval.status === "revoked"
+          ? "revoked" as const
+          : expired
+            ? "expired" as const
+            : "available" as const;
+      return {
+        _id: r._id,
+        source: r.source,
+        format: r.format,
+        rowCount: r.rowCount,
+        excludedCount: r.excludedCount,
+        // Parsed legacy sidecar; never used as authorization evidence.
+        manifest: r.manifest ? (JSON.parse(r.manifest) as ExportManifest) : null,
+        createdAt: r.createdAt,
+        expired,
+        availability,
+      };
     }));
   },
 });
@@ -439,161 +517,174 @@ export const generateExport = action({
     projectId: v.id("projects"),
     source: SOURCE,
     format: FORMAT,
-    // Explicit consent to include prod-sensitive (confidential/pii/phi) rows.
+    // Retained in the RPC shape for explicit rejection of legacy clients.
     allowSensitive: v.optional(v.boolean()),
     campaignId: v.optional(v.id("comparisonCampaigns")),
     verdictCampaignId: v.optional(v.id("verdictReviewCampaigns")),
+    trainingApprovalId: v.optional(v.id("trainingApprovals")),
   },
-  handler: async (
-    ctx,
-    args,
-  ): Promise<{
+  handler: async (ctx, args): Promise<{
     exportId: Id<"trainingExports">;
     rowCount: number;
     excludedCount: number;
     manifest: ExportManifest;
   }> => {
-    if (
-      (args.campaignId !== undefined || args.verdictCampaignId !== undefined) &&
-      args.source !== "trajectory"
-    ) {
-      throw new Error("Review exports use the trajectory source.");
-    }
-    if (args.campaignId !== undefined && args.verdictCampaignId !== undefined) {
-      throw new Error("Export one review at a time.");
-    }
-    if (args.verdictCampaignId !== undefined && args.format !== "sft") {
-      throw new Error("Run verdict reviews export as SFT.");
-    }
-    if (args.format === "annotated") {
-      throw new Error("Annotated export isn’t available yet — use DPO or SFT.");
-    }
-    const userId = await ctx.runQuery(internal.exports.whoAmIForExport, {
+    // Authenticate/authorize before revealing approval state to the caller.
+    const userId = await ctx.runQuery(internal.exports.whoAmIForExport, { projectId: args.projectId });
+    if (args.trainingApprovalId === undefined) throw new Error("A separate active training approval is required before export.");
+    if (args.allowSensitive === true) throw new Error("Sensitive/private rows cannot be authorized for training export.");
+    if (args.source !== "trajectory") throw new Error("Approved review exports use the trajectory source.");
+    if ((args.campaignId === undefined) === (args.verdictCampaignId === undefined)) throw new Error("Export exactly one approved review result.");
+    if (args.verdictCampaignId !== undefined && args.format !== "sft") throw new Error("Run verdict reviews export as SFT.");
+    if (args.campaignId !== undefined && args.format !== "dpo") throw new Error("Comparison reviews export as DPO.");
+    if (args.format === "annotated") throw new Error("Annotated export isn’t available yet — use DPO or SFT.");
+
+    const approved = await ctx.runQuery(internal.exports.gatherApprovedPlan, {
       projectId: args.projectId,
+      approvalId: args.trainingApprovalId,
+      format: args.format,
+      campaignId: args.campaignId,
+      verdictCampaignId: args.verdictCampaignId,
     });
-
-    let classified: ClassifiedRow[];
-    let sourceExcluded: ExcludedRow[] = [];
-    let stats: ExportSourceStats;
-    if (args.source === "output_preference") {
-      const res = await ctx.runQuery(internal.exports.gatherOutputPrefRows, {
-        projectId: args.projectId,
-        format: args.format,
-      });
-      classified = res.rows;
-      stats = res.stats;
-    } else {
-      const res = await ctx.runQuery(internal.exports.gatherTrajectoryPlan, {
-        projectId: args.projectId,
-        format: args.format,
-        campaignId: args.campaignId,
-        verdictCampaignId: args.verdictCampaignId,
-      });
-      const hydrated = await hydrateTrajectory(ctx, res.plan, args.format);
-      classified = hydrated.rows;
-      sourceExcluded = hydrated.excluded;
-      stats = res.stats;
-    }
-
-    const gated = gateRows(classified, {
-      allowSensitive: args.allowSensitive,
-    });
+    const hydrated = await hydrateApprovedPlan(ctx, approved.plan);
+    const gated = gateRows(hydrated.rows, { allowSensitive: false });
     const included = gated.included;
-    const excluded = [...sourceExcluded, ...gated.excluded];
+    const excluded = [...hydrated.excluded, ...gated.excluded];
     const jsonl = toJsonl(args.format as ExportFormat, included);
+    const lines = jsonl ? jsonl.split("\n") : [];
+    if (lines.some((line) => trainingExportSizeViolation({ rowBytes: utf8Bytes(line) }) !== null)) throw new Error("A training export row exceeds the serialized row limit.");
+    if (trainingExportSizeViolation({ jsonlBytes: utf8Bytes(jsonl) })) throw new Error("Training export JSONL exceeds the total artifact limit.");
+    const rowHashes = await Promise.all(lines.map(sha256));
+    const datasetHash = await sha256(jsonl);
     const createdAt = Date.now();
     const manifest = buildExportManifest({
-      source: args.source,
+      source: "trajectory",
       format: args.format as ExportFormat,
       included,
       excluded,
-      allowSensitive: args.allowSensitive ?? false,
-      stats,
+      allowSensitive: false,
+      stats: { sourceUnits: approved.candidateCount, reviewers: approved.reviewers },
       generatedAt: createdAt,
+      approvalPolicyVersion: approved.policyVersion,
+      rowHashes,
+      datasetHash,
+      candidateCount: approved.candidateCount,
     });
+    if (!manifest.integrity.reconciled) throw new Error("Training export counts did not reconcile.");
+    const manifestText = JSON.stringify(manifest, null, 2) + "\n";
+    if (trainingExportSizeViolation({ manifestBytes: utf8Bytes(manifestText) })) throw new Error("Training export manifest exceeds the artifact limit.");
 
-    const storageId = await ctx.storage.store(
-      new Blob([jsonl], { type: "application/jsonl" }),
-    );
-    const exportId = await ctx.runMutation(internal.exports.recordExport, {
-      projectId: args.projectId,
-      source: args.source,
-      format: args.format,
-      storageId,
-      rowCount: included.length,
-      excludedCount: excluded.length,
-      manifest: JSON.stringify(manifest),
-      createdById: userId,
-      createdAt,
-    });
-    return {
-      exportId,
-      rowCount: included.length,
-      excludedCount: excluded.length,
-      manifest,
-    };
+    let storageId: Id<"_storage"> | undefined;
+    let manifestStorageId: Id<"_storage"> | undefined;
+    try {
+      storageId = await ctx.storage.store(new Blob([jsonl], { type: "application/jsonl" }));
+      manifestStorageId = await ctx.storage.store(new Blob([manifestText], { type: "application/json" }));
+      const exportId = await ctx.runMutation(internal.exports.recordExport, {
+        projectId: args.projectId,
+        source: "trajectory",
+        format: args.format,
+        storageId,
+        manifestStorageId,
+        trainingApprovalId: args.trainingApprovalId,
+        campaignId: args.campaignId,
+        verdictCampaignId: args.verdictCampaignId,
+        rowCount: included.length,
+        excludedCount: excluded.length,
+        manifest: JSON.stringify(manifest),
+        createdById: userId,
+        createdAt,
+      });
+      return { exportId, rowCount: included.length, excludedCount: excluded.length, manifest };
+    } catch (cause: unknown) {
+      for (const id of [storageId, manifestStorageId]) {
+        if (id !== undefined) {
+          try { await ctx.storage.delete(id); } catch { /* best-effort idempotent cleanup */ }
+        }
+      }
+      throw cause;
+    }
   },
 });
 
-// Read trajectory bodies from storage and assemble ExportRows.
-async function hydrateTrajectory(
+async function hydrateApprovedPlan(
   ctx: { storage: { get: (id: Id<"_storage">) => Promise<Blob | null> } },
-  plan: TrajectoryPlanRow[],
-  format: "dpo" | "sft" | "annotated",
+  plan: ReadonlyArray<ApprovedPlanRow>,
 ): Promise<{ rows: ClassifiedRow[]; excluded: ExcludedRow[] }> {
-  const cache = new Map<string, unknown>();
-  const read = async (id?: Id<"_storage">): Promise<unknown> => {
-    if (!id) return undefined;
-    if (cache.has(id)) return cache.get(id);
-    const blob = await ctx.storage.get(id);
-    let body: unknown = undefined;
-    if (blob) {
-      try {
-        body = JSON.parse(await blob.text());
-      } catch {
-        body = undefined;
-      }
-    }
-    cache.set(id, body);
-    return body;
+  if (trainingExportSizeViolation({ candidates: plan.length })) throw new Error("Approved candidate count exceeds the export limit.");
+  const readProjection = async (storageId: Id<"_storage">, expectedSha256: string): Promise<HarborReviewerProjection> => {
+    const blob = await ctx.storage.get(storageId);
+    if (!blob) throw new Error("Approved reviewer projection is unavailable.");
+    if (trainingExportSizeViolation({ projectionBytes: blob.size })) throw new Error("Approved reviewer projection exceeds the byte limit.");
+    const bytes = await blob.arrayBuffer();
+    if (await sha256Buffer(bytes) !== expectedSha256) throw new Error("Approved reviewer projection hash mismatch.");
+    const raw: unknown = JSON.parse(new TextDecoder().decode(bytes));
+    return parseHarborReviewerProjection(raw);
   };
-
-  const out: ClassifiedRow[] = [];
+  const rows: ClassifiedRow[] = [];
   const excluded: ExcludedRow[] = [];
-  for (const r of plan) {
-    if (r.excludeReason !== undefined) {
-      excluded.push({ reason: r.excludeReason, privacyClass: r.privacyClass });
+  let hydratedJsonlBytes = 0;
+  const appendBounded = (classified: ClassifiedRow): void => {
+    const format = classified.row.kind === "sft" ? "sft" : "dpo";
+    const rowBytes = utf8Bytes(toJsonl(format, [classified.row]));
+    if (trainingExportSizeViolation({ rowBytes })) throw new Error("A training export row exceeds the serialized row limit.");
+    hydratedJsonlBytes += rowBytes + (rows.length > 0 ? 1 : 0);
+    if (trainingExportSizeViolation({ jsonlBytes: hydratedJsonlBytes })) throw new Error("Training export JSONL exceeds the total artifact limit while hydrating.");
+    rows.push(classified);
+  };
+  for (const candidate of plan) {
+    if (candidate.eligibility === "excluded") {
+      excluded.push({ reason: candidate.reason, privacyClass: candidate.privacyClass });
       continue;
     }
-    if (format === "dpo" && r.chosen && r.rejected) {
-      const prefix = await Promise.all(
-        (r.prefix ?? []).map(async (s) => ({ meta: s.meta, body: await read(s.storageId) })),
-      );
-      const chosen = renderStep(r.chosen.meta, await read(r.chosen.storageId));
-      const rejected = renderStep(r.rejected.meta, await read(r.rejected.storageId));
-      out.push({
-        privacyClass: r.privacyClass,
-        row: { kind: "dpo", prompt: renderTranscript(prefix), chosen, rejected, metadata: r.metadata },
+    if (candidate.format === "sft") {
+      const projection = await readProjection(candidate.projectionStorageId, candidate.projectionSha256);
+      appendBounded({
+        privacyClass: candidate.privacyClass,
+        row: { kind: "sft", messages: [
+          { role: "user", content: serializeAgentObservableTrajectoryContext(projection) },
+          { role: "assistant", content: projection.finalOutput },
+        ] },
       });
-    } else if (format === "sft" && r.messages) {
-      const msgs = await Promise.all(
-        r.messages.map(async (s) => ({
-          role: s.meta.role ?? "assistant",
-          content: String(((await read(s.storageId)) as Record<string, unknown> | undefined)?.content ?? ""),
-        })),
-      );
-      const finalBody = (await read(r.finalAnswer)) as Record<string, unknown> | undefined;
-      if (finalBody?.text) {
-        const finalText = String(finalBody.text);
-        const last = msgs[msgs.length - 1];
-        if (last?.role !== "assistant" || last.content !== finalText) {
-          msgs.push({ role: "assistant", content: finalText });
-        }
-      }
-      out.push({ privacyClass: r.privacyClass, row: { kind: "sft", messages: msgs, metadata: r.metadata } });
+      continue;
     }
+    const [left, right] = await Promise.all([
+      readProjection(candidate.leftProjectionStorageId, candidate.leftProjectionSha256),
+      readProjection(candidate.rightProjectionStorageId, candidate.rightProjectionSha256),
+    ]);
+    const leftSteps = left.events.filter((event) => event.kind !== "final_output" && event.kind !== "termination");
+    const rightSteps = right.events.filter((event) => event.kind !== "final_output" && event.kind !== "termination");
+    const leftNext = leftSteps[candidate.divergenceStepIndex];
+    const rightNext = rightSteps[candidate.divergenceStepIndex];
+    if (!leftNext || !rightNext) {
+      excluded.push({ reason: "insufficient_evidence", privacyClass: candidate.privacyClass });
+      continue;
+    }
+    if (leftNext.kind === "assistant_reasoning" || rightNext.kind === "assistant_reasoning") {
+      excluded.push({ reason: "hidden_reasoning", privacyClass: candidate.privacyClass });
+      continue;
+    }
+    const chosen = candidate.winner === "left" ? leftNext : rightNext;
+    const rejected = candidate.winner === "left" ? rightNext : leftNext;
+    const serializedChosen = serializeAgentObservableEvent(chosen);
+    const serializedRejected = serializeAgentObservableEvent(rejected);
+    if (serializedChosen === null || serializedRejected === null) {
+      excluded.push({ reason: "post_hoc_or_non_observable", privacyClass: candidate.privacyClass });
+      continue;
+    }
+    const prefixProjection = candidate.winner === "left" ? left : right;
+    const prefixEvents = (candidate.winner === "left" ? leftSteps : rightSteps).slice(0, candidate.divergenceStepIndex);
+    appendBounded({
+      privacyClass: candidate.privacyClass,
+      row: {
+        kind: "dpo",
+        prompt: serializeAgentObservableTrajectoryContext({ taskPrompt: prefixProjection.taskPrompt, events: prefixEvents }),
+        chosen: serializedChosen,
+        rejected: serializedRejected,
+        metadata: { reviewer_count: candidate.reviewerCount, shared_prefix_sha256_verified: true, serialization: "agent-observable-trajectory-v1" },
+      },
+    });
   }
-  return { rows: out, excluded };
+  return { rows, excluded };
 }
 
 // Actions have no ctx.db; resolve the owner/editor caller via an internal query.
@@ -609,16 +700,19 @@ export const whoAmIForExport = internalQuery({
 
 export const downloadExport = action({
   args: { exportId: v.id("trainingExports") },
-  handler: async (ctx, args): Promise<{ url: string }> => {
+  handler: async (ctx, args): Promise<{ url: string; manifestUrl: string }> => {
     const meta = await ctx.runQuery(internal.exports.exportForDownload, {
       exportId: args.exportId,
     });
     if (Date.now() - meta.createdAt > DOWNLOAD_TTL_MS) {
       throw new Error("This export link has expired. Generate a fresh export.");
     }
-    const url = await ctx.storage.getUrl(meta.storageId);
-    if (!url) throw new Error("Export file is no longer available.");
-    return { url };
+    const [url, manifestUrl] = await Promise.all([
+      ctx.storage.getUrl(meta.storageId),
+      meta.manifestStorageId ? ctx.storage.getUrl(meta.manifestStorageId) : Promise.resolve(null),
+    ]);
+    if (!url || !manifestUrl) throw new Error("Export artifact or manifest is no longer available.");
+    return { url, manifestUrl };
   },
 });
 
@@ -627,10 +721,13 @@ export const exportForDownload = internalQuery({
   handler: async (
     ctx,
     args,
-  ): Promise<{ storageId: Id<"_storage">; createdAt: number }> => {
+  ): Promise<{ storageId: Id<"_storage">; manifestStorageId?: Id<"_storage">; createdAt: number }> => {
     const row = await ctx.db.get(args.exportId);
     if (!row) throw new Error("Export not found.");
     await requireProjectRole(ctx, row.projectId, ["owner", "editor"]);
-    return { storageId: row.storageId, createdAt: row.createdAt };
+    if (row.trainingApprovalId === undefined) throw new Error("This legacy export has no training approval and cannot be downloaded.");
+    const approval = await ctx.db.get(row.trainingApprovalId);
+    if (!approval || approval.status !== "active") throw new Error("Training approval is revoked; this export can no longer be downloaded.");
+    return { storageId: row.storageId, manifestStorageId: row.manifestStorageId, createdAt: row.createdAt };
   },
 });

--- a/convex/fullSpanIngest.ts
+++ b/convex/fullSpanIngest.ts
@@ -32,6 +32,7 @@ const reservationValidator = v.object({
   stableRunId: v.string(),
   attempt: v.string(),
   fingerprint: v.string(),
+  trainingTaskHash: v.string(),
   runQualification: qualificationValidator,
   evidenceCompleteness: v.union(v.literal("complete"), v.literal("insufficient")),
   canJudgeTaskSuccess: v.boolean(),
@@ -49,6 +50,7 @@ type ReservationInput = {
   readonly stableRunId: string;
   readonly attempt: string;
   readonly fingerprint: string;
+  readonly trainingTaskHash: string;
   readonly runQualification: "quality_eligible" | "fixture_only" | "insufficient";
   readonly evidenceCompleteness: "complete" | "insufficient";
   readonly canJudgeTaskSuccess: boolean;
@@ -438,6 +440,7 @@ function reservationInput(parsed: ParsedHarborEvidence, fingerprint: string): Re
     stableRunId: parsed.run.stableId,
     attempt: parsed.run.attempt,
     fingerprint,
+    trainingTaskHash: parsed.trainingTaskHash,
     runQualification: parsed.projection.runQualification,
     evidenceCompleteness: parsed.projection.evidenceCompleteness,
     canJudgeTaskSuccess: parsed.projection.canJudgeTaskSuccess,

--- a/convex/lib/trainingExport.ts
+++ b/convex/lib/trainingExport.ts
@@ -23,6 +23,39 @@
  */
 
 export type ExportFormat = "dpo" | "annotated" | "sft";
+
+/** Conservative Convex-safe hard caps for approved export generation. */
+export const TRAINING_EXPORT_LIMITS = {
+  maxCandidates: 50,
+  maxProjectionBytes: 512 * 1024,
+  maxRowBytes: 768 * 1024,
+  maxJsonlBytes: 4 * 1024 * 1024,
+  maxManifestBytes: 512 * 1024,
+  maxExportsPerApproval: 20,
+} as const;
+
+/** UTF-8 byte length used by every export size gate. */
+export function utf8Bytes(value: string): number {
+  return new TextEncoder().encode(value).byteLength;
+}
+
+export type TrainingExportSizeInput = {
+  readonly candidates?: number;
+  readonly projectionBytes?: number;
+  readonly rowBytes?: number;
+  readonly jsonlBytes?: number;
+  readonly manifestBytes?: number;
+};
+
+/** Return the first exceeded hard cap; exact-limit values are accepted. */
+export function trainingExportSizeViolation(input: TrainingExportSizeInput): keyof TrainingExportSizeInput | null {
+  if (input.candidates !== undefined && input.candidates > TRAINING_EXPORT_LIMITS.maxCandidates) return "candidates";
+  if (input.projectionBytes !== undefined && input.projectionBytes > TRAINING_EXPORT_LIMITS.maxProjectionBytes) return "projectionBytes";
+  if (input.rowBytes !== undefined && input.rowBytes > TRAINING_EXPORT_LIMITS.maxRowBytes) return "rowBytes";
+  if (input.jsonlBytes !== undefined && input.jsonlBytes > TRAINING_EXPORT_LIMITS.maxJsonlBytes) return "jsonlBytes";
+  if (input.manifestBytes !== undefined && input.manifestBytes > TRAINING_EXPORT_LIMITS.maxManifestBytes) return "manifestBytes";
+  return null;
+}
 export type PrivacyClass = "public" | "internal" | "confidential" | "pii" | "phi";
 
 export interface Annotation {
@@ -79,7 +112,15 @@ export interface ExcludedRow {
     | "review_disagreement"
     | "no_preference"
     | "no_approved_verdict"
-    | "invalid_sft_shape";
+    | "invalid_sft_shape"
+    | "not_full_span"
+    | "fixture_only"
+    | "insufficient_evidence"
+    | "sensitive"
+    | "hidden_reasoning"
+    | "post_hoc_or_non_observable"
+    | "task_mismatch"
+    | "canary_or_private_leak";
   privacyClass: PrivacyClass;
 }
 
@@ -97,6 +138,7 @@ const SENSITIVE_CLASSES: ReadonlySet<PrivacyClass> = new Set([
 // Belt-and-suspenders leak scan: email + common secret-key prefixes.
 const EMAIL = /[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}/i;
 const API_KEY = /\b(sk-[a-z0-9]{16,}|xox[baprs]-[a-z0-9-]{10,}|AKIA[0-9A-Z]{12,}|ghp_[a-z0-9]{20,})\b/i;
+const PRIVATE_OR_CANARY = /HIDDEN_VERIFIER_CANARY_|analysis_metadata|assistant_reasoning|(?:provider|model|harness)[_-]?(?:id|name)?\s*[:=]/i;
 
 const rowText = (row: ExportRow): string => {
   switch (row.kind) {
@@ -159,12 +201,88 @@ export function gateRows(
       excluded.push({ reason: "pii_leak", privacyClass });
       continue;
     }
+    if (PRIVATE_OR_CANARY.test(text)) {
+      excluded.push({ reason: "canary_or_private_leak", privacyClass });
+      continue;
+    }
     included.push(row);
   }
   return { included, excluded };
 }
 
-// --- trajectory rendering (steps → readable text for DPO prompt/answers) -----
+// --- reviewer-safe training trajectory serialization -------------------------
+
+/** Agent-observable event shape accepted by the safe training serializer. */
+export interface AgentObservableEvent {
+  readonly sequence: number;
+  readonly kind: string;
+  readonly role?: string;
+  readonly content?: string;
+  readonly callId?: string;
+  readonly toolName?: string;
+  readonly status?: string;
+  readonly arguments?: unknown;
+  readonly result?: unknown;
+  readonly error?: string;
+}
+
+const AGENT_OBSERVABLE_KINDS: ReadonlySet<string> = new Set([
+  "user_message",
+  "assistant_message",
+  "tool_call",
+  "tool_result",
+  "tool_error",
+]);
+
+/** True only for context/action events the agent could observe at inference. */
+export function isAgentObservableTrainingEvent(event: AgentObservableEvent): boolean {
+  return AGENT_OBSERVABLE_KINDS.has(event.kind);
+}
+
+/** Serialize one allowlisted event without timestamps or provenance. */
+export function serializeAgentObservableEvent(event: AgentObservableEvent): string | null {
+  if (!isAgentObservableTrainingEvent(event)) return null;
+  return JSON.stringify({
+    sequence: event.sequence,
+    kind: event.kind,
+    ...(event.role ? { role: event.role } : {}),
+    ...(event.content ? { content: event.content } : {}),
+    ...(event.toolName ? { tool: event.toolName } : {}),
+    ...(event.status ? { status: event.status } : {}),
+    ...(event.arguments !== undefined ? { arguments: event.arguments } : {}),
+    ...(event.result !== undefined ? { result: event.result } : {}),
+    ...(event.error ? { error: event.error } : {}),
+  });
+}
+
+/**
+ * Serialize task + agent-observable chronology only. Iteration stops at the
+ * first final output even if malformed/post-hoc events follow it. Objective
+ * outcomes, rewards, verifier/workspace/policy events, reasoning, final output,
+ * lifecycle, and termination are never included in model input.
+ */
+export function serializeAgentObservableTrajectoryContext(input: {
+  readonly taskPrompt: string;
+  readonly events: ReadonlyArray<AgentObservableEvent>;
+}): string {
+  const observedEvents: unknown[] = [];
+  for (const event of input.events) {
+    if (event.kind === "final_output") break;
+    const serialized = serializeAgentObservableEvent(event);
+    if (serialized !== null) {
+      const parsed: unknown = JSON.parse(serialized);
+      observedEvents.push(parsed);
+    }
+  }
+  return JSON.stringify({
+    schema: "blindbench.agent-observable-trajectory",
+    version: 1,
+    task: input.taskPrompt,
+    observed_events: observedEvents,
+  });
+}
+
+// --- legacy trajectory rendering (steps → readable text) ---------------------
 
 export interface StepMeta {
   kind: "message" | "tool_call" | "tool_result" | "state" | "policy_event";
@@ -236,7 +354,7 @@ export interface ExportSourceStats {
  */
 export interface ExportManifest {
   schema: "blindbench.training-export";
-  version: 1;
+  version: 2;
   generated_at: number;
   source: "trajectory" | "output_preference";
   format: ExportFormat;
@@ -249,6 +367,21 @@ export interface ExportManifest {
   };
   source_units: number;
   reviewers: number;
+  policy: {
+    training_approval_required: true;
+    approval_status: "active";
+    policy_version: string;
+    privacy_policy: "public_or_internal_only";
+    safe_trajectory_serialization: "agent-observable-trajectory-v1";
+  };
+  integrity: {
+    candidate_count: number;
+    included_count: number;
+    excluded_count: number;
+    reconciled: boolean;
+    row_hashes: string[];
+    dataset_hash: string;
+  };
   fireworks: { compatible: boolean; row_shape: string };
   notes: string[];
 }
@@ -261,6 +394,10 @@ export function buildExportManifest(input: {
   allowSensitive: boolean;
   stats: ExportSourceStats;
   generatedAt: number;
+  approvalPolicyVersion?: string;
+  rowHashes?: string[];
+  datasetHash?: string;
+  candidateCount?: number;
 }): ExportManifest {
   const { source, format, included, excluded, allowSensitive, stats, generatedAt } = input;
 
@@ -311,7 +448,7 @@ export function buildExportManifest(input: {
 
   return {
     schema: "blindbench.training-export",
-    version: 1,
+    version: 2,
     generated_at: generatedAt,
     source,
     format,
@@ -324,6 +461,21 @@ export function buildExportManifest(input: {
     },
     source_units: stats.sourceUnits,
     reviewers: stats.reviewers,
+    policy: {
+      training_approval_required: true,
+      approval_status: "active",
+      policy_version: input.approvalPolicyVersion ?? "legacy-test-only",
+      privacy_policy: "public_or_internal_only",
+      safe_trajectory_serialization: "agent-observable-trajectory-v1",
+    },
+    integrity: {
+      candidate_count: input.candidateCount ?? included.length + excluded.length,
+      included_count: included.length,
+      excluded_count: excluded.length,
+      reconciled: (input.candidateCount ?? included.length + excluded.length) === included.length + excluded.length,
+      row_hashes: input.rowHashes ?? [],
+      dataset_hash: input.datasetHash ?? "",
+    },
     fireworks: {
       compatible: true,
       row_shape: format === "sft" ? "messages[]" : "prompt/chosen/rejected",
@@ -361,7 +513,46 @@ export function toJsonl(format: ExportFormat, rows: ExportRow[]): string {
   return jsonl(
     rows.map((r) => {
       const s = r as SftRow;
-      return s.metadata ? { messages: s.messages, metadata: s.metadata } : { messages: s.messages };
+      return { messages: s.messages };
     }),
   );
+}
+
+async function digest(value: string): Promise<string> {
+  const bytes = new TextEncoder().encode(value);
+  const hash = await crypto.subtle.digest("SHA-256", bytes);
+  return [...new Uint8Array(hash)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+/**
+ * Verify an approved export artifact against its v2 manifest without logging
+ * row content. This is the same local/no-network seam used by synthetic Convex
+ * integration tests before an operator handoff.
+ */
+export async function verifyApprovedExportArtifact(
+  jsonl: string,
+  manifest: ExportManifest,
+): Promise<{ readonly ready: boolean; readonly reasons: string[] }> {
+  const reasons: string[] = [];
+  const lines = jsonl === "" ? [] : jsonl.split("\n");
+  if (manifest.schema !== "blindbench.training-export" || manifest.version !== 2) reasons.push("unsupported_manifest");
+  if (!manifest.integrity.reconciled) reasons.push("counts_not_reconciled");
+  if (manifest.row_count !== lines.length || manifest.integrity.included_count !== lines.length) reasons.push("row_count_mismatch");
+  if (manifest.integrity.excluded_count !== manifest.excluded_count) reasons.push("excluded_count_mismatch");
+  if (manifest.integrity.candidate_count !== manifest.row_count + manifest.excluded_count) reasons.push("candidate_count_mismatch");
+  const actualHashes: string[] = [];
+  for (const line of lines) {
+    try {
+      const parsed: unknown = JSON.parse(line);
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) reasons.push("invalid_row_shape");
+      else if (manifest.format === "sft" && (Object.keys(parsed).length !== 1 || !("messages" in parsed))) reasons.push("invalid_sft_shape");
+      else if (manifest.format === "dpo" && !("prompt" in parsed && "chosen" in parsed && "rejected" in parsed)) reasons.push("invalid_dpo_shape");
+    } catch {
+      reasons.push("invalid_jsonl");
+    }
+    actualHashes.push(await digest(line));
+  }
+  if (JSON.stringify(actualHashes) !== JSON.stringify(manifest.integrity.row_hashes)) reasons.push("row_hash_mismatch");
+  if (await digest(jsonl) !== manifest.integrity.dataset_hash) reasons.push("dataset_hash_mismatch");
+  return { ready: reasons.length === 0, reasons: [...new Set(reasons)] };
 }

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -836,6 +836,7 @@ const schema = defineSchema({
     stableRunId: v.string(),
     attempt: v.string(),
     fingerprint: v.string(),
+    trainingTaskHash: v.string(),
     status: v.union(
       v.literal("pending"),
       v.literal("staged"),
@@ -1143,10 +1144,70 @@ const schema = defineSchema({
     .index("by_matchup", ["matchupId"])
     .index("by_matchup_and_user", ["matchupId", "userId"]),
 
-  // #53 (export bridge): a generated training-data export. The JSONL is in
-  // storage; this row tracks provenance + counts and gates the download to a
-  // 1-hour window (AC6). `excludedCount` reflects rows dropped by the
-  // data-boundary gate (reported to the user, never silently lost).
+  // #287: an owner-issued, revocable training approval over one immutable,
+  // closed human-review result. Candidate child rows snapshot the exact
+  // reviewer-safe evidence fingerprint and aggregate judgment that was approved;
+  // exporters never fall back to mutable/raw trace discovery.
+  trainingApprovals: defineTable({
+    projectId: v.id("projects"),
+    kind: v.union(v.literal("verdict_campaign"), v.literal("comparison_campaign")),
+    verdictCampaignId: v.optional(v.id("verdictReviewCampaigns")),
+    comparisonCampaignId: v.optional(v.id("comparisonCampaigns")),
+    status: v.union(v.literal("active"), v.literal("revoked")),
+    policyVersion: v.string(),
+    candidateCount: v.number(),
+    reviewerCount: v.number(),
+    eligibleCount: v.number(),
+    excludedCount: v.number(),
+    approvedById: v.id("users"),
+    approvedAt: v.number(),
+    revokedById: v.optional(v.id("users")),
+    revokedAt: v.optional(v.number()),
+  })
+    .index("by_project", ["projectId"])
+    .index("by_verdict_campaign", ["verdictCampaignId"])
+    .index("by_comparison_campaign", ["comparisonCampaignId"]),
+
+  trainingApprovalItems: defineTable({
+    approvalId: v.id("trainingApprovals"),
+    projectId: v.id("projects"),
+    sortOrder: v.number(),
+    agentTraceId: v.optional(v.id("agentTraces")),
+    matchupId: v.optional(v.id("agentTraceMatchups")),
+    winner: v.optional(v.union(v.literal("left"), v.literal("right"))),
+    divergenceStepIndex: v.optional(v.number()),
+    sharedPrefixHash: v.optional(v.string()),
+    taskHash: v.optional(v.string()),
+    leftTaskHash: v.optional(v.string()),
+    rightTaskHash: v.optional(v.string()),
+    projectionStorageId: v.optional(v.id("_storage")),
+    projectionSha256: v.optional(v.string()),
+    leftProjectionStorageId: v.optional(v.id("_storage")),
+    leftProjectionSha256: v.optional(v.string()),
+    rightProjectionStorageId: v.optional(v.id("_storage")),
+    rightProjectionSha256: v.optional(v.string()),
+    privacyClass: v.union(
+      v.literal("public"), v.literal("internal"), v.literal("confidential"),
+      v.literal("pii"), v.literal("phi"),
+    ),
+    reviewerCount: v.number(),
+    eligibility: v.union(v.literal("eligible"), v.literal("excluded")),
+    exclusionReason: v.optional(v.union(
+      v.literal("not_full_span"),
+      v.literal("fixture_only"),
+      v.literal("insufficient_evidence"),
+      v.literal("sensitive"),
+      v.literal("no_approved_verdict"),
+      v.literal("review_disagreement"),
+      v.literal("non_comparable_prefix"),
+      v.literal("no_preference"),
+      v.literal("task_mismatch"),
+    )),
+  }).index("by_approval_and_order", ["approvalId", "sortOrder"]),
+
+  // #53/#287: a generated training-data export. Both JSONL and its safe
+  // manifest are storage-backed. Every new export is bound to an active,
+  // revocable approval; legacy unapproved rows cannot be downloaded.
   trainingExports: defineTable({
     projectId: v.id("projects"),
     source: v.union(
@@ -1159,6 +1220,8 @@ const schema = defineSchema({
       v.literal("sft"),
     ),
     storageId: v.id("_storage"),
+    manifestStorageId: v.optional(v.id("_storage")),
+    trainingApprovalId: v.optional(v.id("trainingApprovals")),
     rowCount: v.number(),
     excludedCount: v.number(),
     // #288: JSON-serialized ExportManifest (Fireworks handoff report). Optional
@@ -1166,7 +1229,9 @@ const schema = defineSchema({
     manifest: v.optional(v.string()),
     createdById: v.id("users"),
     createdAt: v.number(),
-  }).index("by_project", ["projectId"]),
+  })
+    .index("by_project", ["projectId"])
+    .index("by_approval", ["trainingApprovalId"]),
 
   // #263: per-project ingest tokens for the OTLP push endpoint. Opaque 128-bit
   // bearer token (generateToken), stored plaintext with a by_token index — the

--- a/convex/tests/agentTraceReviewSessions.test.ts
+++ b/convex/tests/agentTraceReviewSessions.test.ts
@@ -176,26 +176,22 @@ describe("opaque trajectory review sessions", () => {
     expect((await asReviewer1.query(api.agentTraceReviewSessions.getMatchup, { token: token1 })).winner).toBe("left");
     expect((await asReviewer2.query(api.agentTraceReviewSessions.getMatchup, { token: token2 })).winner).toBe("right");
 
-    const exported = await asOwner.action(api.exports.generateExport, {
+    await expect(asOwner.action(api.exports.generateExport, {
       projectId: ids.projectId,
       source: "trajectory",
       format: "dpo",
-    });
-    expect(exported.rowCount).toBe(0);
-    expect(exported.manifest.excluded_by_reason.review_disagreement).toBe(1);
+    })).rejects.toThrow(/training approval/i);
 
     await asReviewer2.mutation(api.agentTraceReviewSessions.decideMatchup, {
       token: token2,
       winner: "tie",
       reasonTags: [],
     });
-    const tieExport = await asOwner.action(api.exports.generateExport, {
+    await expect(asOwner.action(api.exports.generateExport, {
       projectId: ids.projectId,
       source: "trajectory",
       format: "dpo",
-    });
-    expect(tieExport.rowCount).toBe(0);
-    expect(tieExport.manifest.excluded_by_reason.no_preference).toBe(1);
+    })).rejects.toThrow(/training approval/i);
   });
 
   test("mismatched prefixes are persisted invalid and excluded with an explicit manifest reason", async () => {
@@ -215,12 +211,10 @@ describe("opaque trajectory review sessions", () => {
     expect(matchup?.invalidReason).toBe("prefix_mismatch");
     expect((await asReviewer1.query(api.agentTraceReviewSessions.listMine, {})).filter((session) => session.kind === "matchup")).toHaveLength(0);
 
-    const exported = await asOwner.action(api.exports.generateExport, {
+    await expect(asOwner.action(api.exports.generateExport, {
       projectId: ids.projectId,
       source: "trajectory",
       format: "dpo",
-    });
-    expect(exported.rowCount).toBe(0);
-    expect(exported.manifest.excluded_by_reason.non_comparable_prefix).toBe(1);
+    })).rejects.toThrow(/training approval/i);
   });
 });

--- a/convex/tests/comparisonCampaigns.test.ts
+++ b/convex/tests/comparisonCampaigns.test.ts
@@ -353,18 +353,15 @@ describe("blind comparison campaigns", () => {
     await asOwner.mutation(api.comparisonCampaigns.closeCampaign, {
       campaignId: imported.campaignId,
     });
-    const exported = await asOwner.action(api.exports.generateExport, {
+    await expect(asOwner.action(api.exports.generateExport, {
       projectId: ids.projectId,
       campaignId: imported.campaignId,
       source: "trajectory",
       format: "dpo",
-    });
-    expect(exported).toMatchObject({ rowCount: 3, excludedCount: 3 });
-    expect(exported.manifest).toMatchObject({
-      format: "dpo",
-      source_units: 6,
-      reviewers: 1,
-    });
+    })).rejects.toThrow(/training approval/i);
+    await expect(asOwner.action(api.trainingApprovals.approveComparisonCampaign, {
+      campaignId: imported.campaignId,
+    })).rejects.toThrow(/no quality-eligible/i);
 
     await expect(asGuest.mutation(api.comparisonCampaigns.submitChoice, {
       sessionToken,

--- a/convex/tests/csvImport.test.ts
+++ b/convex/tests/csvImport.test.ts
@@ -124,13 +124,11 @@ describe("mapped CSV import through the trajectory spine", () => {
     });
     await asReviewer.mutation(api.agentTraceReviewSessions.setVerdict, { token, rating: "best" });
 
-    const exported = await asOwner.action(api.exports.generateExport, {
+    await expect(asOwner.action(api.exports.generateExport, {
       projectId: ids.projectId,
       source: "trajectory",
       format: "sft",
-    });
-    expect(exported.rowCount).toBe(1);
-    expect(exported.manifest).toMatchObject({ format: "sft", source_units: 1, reviewers: 1 });
+    })).rejects.toThrow(/training approval/i);
   });
 
   test("persists valid rows and deduplicates a repeated upload", async () => {

--- a/convex/tests/dogfoodFlow.test.ts
+++ b/convex/tests/dogfoodFlow.test.ts
@@ -85,31 +85,14 @@ describe("M31 dogfood — full flywheel on real trajectories", () => {
     const persistedMatchup = await t.run(async (ctx) => await ctx.db.get(matchupId));
     expect(persistedMatchup?.comparabilityStatus).toBe("invalid");
 
-    // 4. EXPORT — the real Harbor pair is honestly excluded because its
-    // normalized prefixes differ. The old flow overclaimed this as DPO-ready.
-    const dpo = await asOwner.action(api.exports.generateExport, {
+    // 4. EXPORT — verdict/preference data alone is never training consent.
+    // These legacy Harbor fixtures are not strict full-span evidence and cannot
+    // receive a #287 approval.
+    await expect(asOwner.action(api.exports.generateExport, {
       projectId: ids.projectId, source: "trajectory", format: "dpo",
-    });
-    expect(dpo.rowCount).toBe(0);
-    expect(dpo.manifest).toMatchObject({
-      schema: "blindbench.training-export",
-      version: 1,
-      source: "trajectory",
-      format: "dpo",
-      excluded_by_reason: { non_comparable_prefix: 1 },
-    });
-
-    // SFT from the best-verdict trajectory.
-    const sft = await asOwner.action(api.exports.generateExport, {
+    })).rejects.toThrow(/training approval/i);
+    await expect(asOwner.action(api.exports.generateExport, {
       projectId: ids.projectId, source: "trajectory", format: "sft",
-    });
-    expect(sft.rowCount).toBeGreaterThanOrEqual(1);
-    expect(sft.manifest).toMatchObject({
-      format: "sft",
-      fireworks: { row_shape: "messages[]" },
-    });
-
-    expect(dpo.excludedCount).toBe(1);
-    expect(sft.rowCount).toBeGreaterThanOrEqual(1);
+    })).rejects.toThrow(/training approval/i);
   });
 });

--- a/convex/tests/exports.test.ts
+++ b/convex/tests/exports.test.ts
@@ -55,13 +55,6 @@ const persist = async (as: Ident, projectId: Id<"projects">, run: JeevesClogRunE
   return res.agentTraceId;
 };
 
-const readExport = async (t: ReturnType<typeof convexTest>, exportId: Id<"trainingExports">) =>
-  await t.run(async (ctx) => {
-    const row = await ctx.db.get(exportId);
-    const blob = row ? await ctx.storage.get(row.storageId) : null;
-    return blob ? await blob.text() : "";
-  });
-
 describe("#53 training export", () => {
   test("trajectory DPO: winner's divergence step is chosen, loser's rejected, prefix is the prompt", async () => {
     const t = convexTest(schema);
@@ -74,15 +67,9 @@ describe("#53 training export", () => {
     });
     await asOwner.mutation(api.agentTraceReview.decideMatchup, { matchupId, winner: "left", reasonTags: ["accuracy"] });
 
-    const res = await asOwner.action(api.exports.generateExport, {
+    await expect(asOwner.action(api.exports.generateExport, {
       projectId: ids.projectId, source: "trajectory", format: "dpo",
-    });
-    expect(res.rowCount).toBe(1);
-    const line = JSON.parse(await readExport(t, res.exportId));
-    expect(line.chosen).toContain("create_escalation"); // winner (left) next action
-    expect(line.rejected).toContain("close_ticket"); // loser (right) next action
-    expect(line.prompt).toContain("lookup_account"); // shared prefix
-    expect(line.prompt).not.toContain("create_escalation"); // prefix stops before divergence
+    })).rejects.toThrow(/training approval/i);
   });
 
   test("output-preference DPO: best vs weak with the resolved prompt", async () => {
@@ -109,14 +96,9 @@ describe("#53 training export", () => {
       await ctx.db.insert("outputPreferences", { runId, outputId: bad, userId: ids.ownerUserId, rating: "weak" });
     });
 
-    const res = await asOwner.action(api.exports.generateExport, {
+    await expect(asOwner.action(api.exports.generateExport, {
       projectId: ids.projectId, source: "output_preference", format: "dpo",
-    });
-    expect(res.rowCount).toBe(1);
-    const line = JSON.parse(await readExport(t, res.exportId));
-    expect(line.prompt).toContain("Handle a refund for the customer."); // {{topic}} substituted
-    expect(line.chosen).toBe("Happy to refund you.");
-    expect(line.rejected).toBe("No refunds.");
+    })).rejects.toThrow(/training approval/i);
   });
 
   test("consent gate: a pii-classed trajectory is excluded unless allowSensitive", async () => {
@@ -137,12 +119,8 @@ describe("#53 training export", () => {
     });
     await asOwner.mutation(api.agentTraceReview.decideMatchup, { matchupId, winner: "left", reasonTags: [] });
 
-    const denied = await asOwner.action(api.exports.generateExport, { projectId: ids.projectId, source: "trajectory", format: "dpo" });
-    expect(denied.rowCount).toBe(0);
-    expect(denied.excludedCount).toBe(1);
-
-    const consented = await asOwner.action(api.exports.generateExport, { projectId: ids.projectId, source: "trajectory", format: "dpo", allowSensitive: true });
-    expect(consented.rowCount).toBe(1);
+    await expect(asOwner.action(api.exports.generateExport, { projectId: ids.projectId, source: "trajectory", format: "dpo" })).rejects.toThrow(/training approval/i);
+    await expect(asOwner.action(api.exports.generateExport, { projectId: ids.projectId, source: "trajectory", format: "dpo", allowSensitive: true })).rejects.toThrow(/training approval|sensitive/i);
   });
 
   test("export is owner/editor only — an evaluator is denied", async () => {
@@ -153,16 +131,22 @@ describe("#53 training export", () => {
     ).rejects.toThrow(/Permission denied/);
   });
 
-  test("download link expires after 1 hour", async () => {
+  test("legacy exports without approval cannot be downloaded", async () => {
     const t = convexTest(schema);
     const { ids, asOwner } = await seed(t);
-    const res = await asOwner.action(api.exports.generateExport, { projectId: ids.projectId, source: "output_preference", format: "dpo" });
-    // Fresh download works.
-    await expect(asOwner.action(api.exports.downloadExport, { exportId: res.exportId })).resolves.toBeTruthy();
-    // Age the row past the TTL.
-    await t.run(async (ctx) => {
-      await ctx.db.patch(res.exportId, { createdAt: Date.now() - 2 * 60 * 60 * 1000 });
+    const exportId = await t.run(async (ctx) => {
+      const storageId = await ctx.storage.store(new Blob(["{}"]));
+      return await ctx.db.insert("trainingExports", {
+        projectId: ids.projectId,
+        source: "trajectory",
+        format: "dpo",
+        storageId,
+        rowCount: 0,
+        excludedCount: 0,
+        createdById: ids.ownerUserId,
+        createdAt: Date.now(),
+      });
     });
-    await expect(asOwner.action(api.exports.downloadExport, { exportId: res.exportId })).rejects.toThrow(/expired/);
+    await expect(asOwner.action(api.exports.downloadExport, { exportId })).rejects.toThrow(/no training approval/i);
   });
 });

--- a/convex/tests/fixtures/daytona-reviewer-contract.json
+++ b/convex/tests/fixtures/daytona-reviewer-contract.json
@@ -1,0 +1,173 @@
+{
+  "analysis_metadata": {
+    "harness": {
+      "name": "harbor",
+      "version": "0.18.0"
+    },
+    "model": "fictional-model",
+    "provider": "fictional-provider"
+  },
+  "harness": {
+    "name": "harbor/pi",
+    "schema": "0.18.0"
+  },
+  "outcomes": {
+    "evidence_completeness": "complete",
+    "infrastructure": "succeeded",
+    "process": "succeeded",
+    "verifier": "passed"
+  },
+  "raw": {
+    "path": "agent/pi.txt",
+    "sha256": "04aa4346b7fb1c18e250e8bf6cb58700f821d425ceee2b10667e6d6ea52f6d98"
+  },
+  "reviewer": {
+    "environment_class": "isolated-sandbox",
+    "events": [
+      {
+        "content": "Fix it",
+        "id": "evt-edf7014b929db412d2f2d48610c1d94b",
+        "kind": "user_message",
+        "sequence": 0,
+        "timestamp": "2026-07-11T00:00:01+00:00"
+      },
+      {
+        "content": "inspect",
+        "id": "evt-dc9ac476ec689e9dc183e4a38fc35345",
+        "kind": "assistant_reasoning",
+        "sequence": 1,
+        "stop_reason": "toolUse",
+        "timestamp": "2026-07-11T00:00:02+00:00"
+      },
+      {
+        "content": "I will edit.",
+        "id": "evt-e42e6a1577f43a9acd465903f1da5122",
+        "kind": "assistant_message",
+        "sequence": 2,
+        "stop_reason": "toolUse",
+        "timestamp": "2026-07-11T00:00:02+00:00"
+      },
+      {
+        "arguments": {
+          "newText": "y",
+          "oldText": "x",
+          "path": "[WORKSPACE_PATH]"
+        },
+        "call_id": "call-1",
+        "id": "evt-f7ade93ebcb71caeca2165ec6dad04b3",
+        "kind": "tool_call",
+        "sequence": 3,
+        "tool_name": "edit"
+      },
+      {
+        "call_id": "call-1",
+        "id": "evt-1975e4fa7b7eb14b7caa95769775ef4a",
+        "kind": "tool_result",
+        "result": {
+          "content": [
+            {
+              "text": "edited [WORKSPACE_PATH]",
+              "type": "text"
+            }
+          ]
+        },
+        "sequence": 4,
+        "tool_name": "edit"
+      },
+      {
+        "content": "Done.",
+        "id": "evt-801e849f712d9419a74239162701e795",
+        "kind": "final_output",
+        "sequence": 5,
+        "stop_reason": "stop",
+        "timestamp": "2026-07-11T00:00:04+00:00"
+      },
+      {
+        "content": "completed",
+        "id": "evt-a15347c3ae291944e6aaa18fbdd1a801",
+        "kind": "termination",
+        "sequence": 6
+      }
+    ],
+    "evidence": {
+      "changed_files": [
+        {
+          "path": "calculator.py",
+          "status": "modified"
+        }
+      ],
+      "changed_files_reference": {
+        "path": "workspace/changed-files.json",
+        "reviewer_sha256": "a261fd8af97a65e61a18809a9811c2f8dd210070c9d1e8219d6853cb487766d0",
+        "sha256": "a261fd8af97a65e61a18809a9811c2f8dd210070c9d1e8219d6853cb487766d0"
+      },
+      "patch": "--- a/calculator.py\n+++ b/calculator.py\n-left - right\n+left + right\n",
+      "patch_reference": {
+        "path": "workspace/patch.diff",
+        "reviewer_sha256": "9d7f7d211e9c2fdbcf3c75ef502a3c8b2a00460b96de61b063fb767c101b6b19",
+        "sha256": "9d7f7d211e9c2fdbcf3c75ef502a3c8b2a00460b96de61b063fb767c101b6b19"
+      },
+      "patch_truncated": false,
+      "verifier_command_summary": "hidden deterministic verifier",
+      "verifier_exit_code": 0,
+      "verifier_references": [
+        {
+          "path": "verifier/stdout.txt",
+          "reviewer_sha256": "c421e765f9eba8af20c9a4ec7f3f1ef20c0c25420ccd3b3b097a2b40afb6eb9e",
+          "sha256": "c421e765f9eba8af20c9a4ec7f3f1ef20c0c25420ccd3b3b097a2b40afb6eb9e"
+        },
+        {
+          "path": "verifier/stderr.txt",
+          "reviewer_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        }
+      ],
+      "verifier_stderr": "",
+      "verifier_stderr_truncated": false,
+      "verifier_stdout": "fixture passed\n",
+      "verifier_stdout_truncated": false,
+      "verifier_timed_out": false
+    },
+    "harness_schema": "harbor/pi-jsonl@0.18.0",
+    "outcomes": {
+      "evidence_completeness": "complete",
+      "infrastructure": "succeeded",
+      "process": "succeeded",
+      "verifier": "passed"
+    },
+    "rewards": {
+      "command_exit": 1.0,
+      "reward": 1.0,
+      "stdout_assertion": 1.0
+    },
+    "task": {
+      "id": "fictional-calculator",
+      "privacy_class": "public",
+      "prompt": "Correct the fictional calculator.",
+      "revision": "1"
+    }
+  },
+  "rewards": {
+    "command_exit": 1.0,
+    "reward": 1.0,
+    "stdout_assertion": 1.0
+  },
+  "run": {
+    "attempt": "fictional-attempt",
+    "ended_at": "2026-07-11T00:00:03+00:00",
+    "id": "daytona-consumer-contract",
+    "started_at": "2026-07-11T00:00:00+00:00",
+    "status": "quality_eligible",
+    "termination_reason": "completed"
+  },
+  "schema": "mogil.harbor-evidence",
+  "usage": {
+    "cache_read_tokens": 0,
+    "cache_write_tokens": 0,
+    "cost_usd": 0.03,
+    "input_tokens": 6,
+    "output_tokens": 4,
+    "total_tokens": 10
+  },
+  "version": "1.0"
+}

--- a/convex/tests/fullSpanIngest.test.ts
+++ b/convex/tests/fullSpanIngest.test.ts
@@ -5,6 +5,7 @@ import { api, internal } from "../_generated/api";
 import type { Id } from "../_generated/dataModel";
 import schema from "../schema";
 import producerFixture from "./fixtures/mogil-harbor-evidence-v1.json";
+import isolatedSandboxProducerFixture from "./fixtures/daytona-reviewer-contract.json";
 
 // Sanitized static fixture generated through the authoritative Mogil Bench
 // HarborEvidence Pydantic model; copied here so BlindBench has no runtime
@@ -37,6 +38,7 @@ function reservation(stableRunId: string, attempt: string) {
     stableRunId,
     attempt,
     fingerprint: `fingerprint-${stableRunId}`,
+    trainingTaskHash: `task-hash-${stableRunId}`,
     runQualification: "quality_eligible" as const,
     evidenceCompleteness: "complete" as const,
     canJudgeTaskSuccess: true,
@@ -115,6 +117,32 @@ describe("POST /ingest/v1/eval-runs authoritative batch contract", () => {
     expect(stored.traces).toHaveLength(3);
     expect(stored.spans.every((row) => row.status === "ready" && row.runQualification === "quality_eligible" && row.canJudgeTaskSuccess)).toBe(true);
     expect(stored.spans.every((row) => row.rawEvidenceStorageId && row.reviewerProjectionStorageId && row.rawEvidenceStorageId !== row.reviewerProjectionStorageId)).toBe(true);
+  });
+
+  test("ingests copied Docker and provider-neutral isolated-sandbox producer contracts without projecting environment provenance", async () => {
+    const { t, ids, owner } = await setup();
+    const automation = await issueAutomation(owner, ids.project);
+    const isolated = JSON.parse(JSON.stringify(isolatedSandboxProducerFixture)) as Record<string, unknown>;
+    const response = await t.fetch("/ingest/v1/eval-runs", {
+      method: "POST",
+      headers: headers(automation.token),
+      body: envelope([artifact(), isolated]),
+    });
+    expect(response.status).toBe(200);
+    expect(await responseBody(response)).toEqual({ complete: 2, imported: 2, deduped: 0, invalid: 0 });
+    const stored = await t.run(async (ctx) => {
+      const spans = await ctx.db.query("fullSpanEvalRuns").collect();
+      return await Promise.all(spans.map(async (span) => ({
+        raw: span.rawEvidenceStorageId ? await (await ctx.storage.get(span.rawEvidenceStorageId))?.text() : undefined,
+        projection: span.reviewerProjectionStorageId ? await (await ctx.storage.get(span.reviewerProjectionStorageId))?.text() : undefined,
+      })));
+    });
+    expect(stored.some((row) => row.raw?.includes('"environment_class":"docker"'))).toBe(true);
+    expect(stored.some((row) => row.raw?.includes('"environment_class":"isolated-sandbox"'))).toBe(true);
+    for (const row of stored) {
+      expect(row.projection).not.toMatch(/docker|isolated-sandbox|daytona/i);
+      expect(row.projection).not.toContain("fictional-provider");
+    }
   });
 
   test("replays and mixed batches deterministically, while conflicts reserve nothing", async () => {
@@ -218,6 +246,7 @@ describe("POST /ingest/v1/eval-runs authoritative batch contract", () => {
           stableRunId: `crash-${stage}`,
           attempt: `attempt-${stage}`,
           fingerprint: `fingerprint-${stage}`,
+          trainingTaskHash: `task-hash-${stage}`,
           status: "pending",
           leaseId: `lease-${stage}`,
           leaseExpiresAt: 1,

--- a/convex/tests/fullSpanTrainingExport.test.ts
+++ b/convex/tests/fullSpanTrainingExport.test.ts
@@ -1,0 +1,363 @@
+/// <reference types="vite/client" />
+import { readFileSync } from "node:fs";
+import { convexTest } from "convex-test";
+import { describe, expect, test } from "vitest";
+import { api, internal } from "../_generated/api";
+import type { Id } from "../_generated/dataModel";
+import schema from "../schema";
+import isolatedSandboxFixture from "./fixtures/daytona-reviewer-contract.json";
+import { TRAINING_EXPORT_LIMITS, verifyApprovedExportArtifact } from "../lib/trainingExport";
+
+const fixture = JSON.parse(readFileSync(new URL("./fixtures/mogil-harbor-evidence-v1.json", import.meta.url), "utf8")) as unknown;
+const headers = (token: string) => ({ authorization: `Bearer ${token}`, "content-type": "application/json" });
+
+async function setup(artifact: unknown = fixture) {
+  const t = convexTest(schema);
+  const ids = await t.run(async (ctx) => {
+    const ownerId = await ctx.db.insert("users", { name: "Owner", email: "owner@test.invalid" });
+    const guestId = await ctx.db.insert("users", { name: "Reviewer", email: "reviewer@test.invalid" });
+    const orgId = await ctx.db.insert("organizations", { name: "Synthetic", slug: "synthetic", createdById: ownerId });
+    await ctx.db.insert("organizationMembers", { organizationId: orgId, userId: ownerId, role: "owner" });
+    const projectId = await ctx.db.insert("projects", { organizationId: orgId, name: "Synthetic", createdById: ownerId });
+    await ctx.db.insert("projectCollaborators", { projectId, userId: ownerId, role: "owner", invitedById: ownerId, invitedAt: 1 });
+    return { ownerId, guestId, projectId };
+  });
+  const owner = t.withIdentity({ subject: `${ids.ownerId}|s`, tokenIdentifier: `test|${ids.ownerId}` });
+  const guest = t.withIdentity({ subject: `${ids.guestId}|s`, tokenIdentifier: `test|${ids.guestId}` });
+  const issued = await owner.mutation(api.ingestTokens.issueIngestToken, {
+    projectId: ids.projectId,
+    label: "synthetic",
+    scopes: ["traces:write"],
+  });
+  const response = await t.fetch("/ingest/v1/eval-runs", {
+    method: "POST",
+    headers: headers(issued.token),
+    body: JSON.stringify({ runs: [artifact] }),
+  });
+  expect(response.status).toBe(200);
+  const traceId = await t.run(async (ctx) => {
+    const row = await ctx.db.query("fullSpanEvalRuns").unique();
+    if (!row?.agentTraceId) throw new Error("fixture trace missing");
+    return row.agentTraceId;
+  });
+  const campaignId = await owner.mutation(api.verdictReviewCampaigns.create, {
+    projectId: ids.projectId,
+    name: "Synthetic full-span review",
+    traceIds: [traceId],
+  });
+  const campaign = await owner.query(api.verdictReviewCampaigns.getOwnerCampaign, { campaignId });
+  await owner.mutation(api.verdictReviewCampaigns.openCampaign, { campaignId });
+  const joined = await guest.mutation(api.verdictReviewCampaigns.joinCampaign, {
+    shareToken: campaign.shareToken,
+    displayName: "Synthetic reviewer",
+  });
+  const runStatus = (artifact as { readonly run?: { readonly status?: unknown } }).run?.status;
+  await guest.mutation(api.agentTraceReviewSessions.setVerdict, {
+    token: joined.sessionToken,
+    rating: runStatus === "quality_eligible" ? "best" : "insufficient_evidence",
+  });
+  await owner.mutation(api.verdictReviewCampaigns.closeCampaign, { campaignId });
+  return { t, ids, owner, guest, campaignId };
+}
+
+async function exportText(t: ReturnType<typeof convexTest>, exportId: Id<"trainingExports">) {
+  return await t.run(async (ctx) => {
+    const row = await ctx.db.get(exportId);
+    if (!row) throw new Error("export missing");
+    const blob = await ctx.storage.get(row.storageId);
+    return blob ? await blob.text() : "";
+  });
+}
+
+describe("#287 approved full-span training export", () => {
+  test("quality eligibility and a positive verdict remain denied until owner approval; revocation denies later export", async () => {
+    const { owner, guest, ids, campaignId } = await setup();
+    await expect(guest.action(api.trainingApprovals.approveVerdictCampaign, { campaignId })).rejects.toThrow(/Permission denied/);
+    await expect(owner.action(api.exports.generateExport, {
+      projectId: ids.projectId,
+      verdictCampaignId: campaignId,
+      source: "trajectory",
+      format: "sft",
+    })).rejects.toThrow(/training approval/i);
+
+    const approval = await owner.action(api.trainingApprovals.approveVerdictCampaign, { campaignId });
+    const generated = await owner.action(api.exports.generateExport, {
+      projectId: ids.projectId,
+      verdictCampaignId: campaignId,
+      trainingApprovalId: approval.approvalId,
+      source: "trajectory",
+      format: "sft",
+    });
+    expect(generated.rowCount).toBe(1);
+
+    await owner.mutation(api.trainingApprovals.revoke, { approvalId: approval.approvalId });
+    await expect(owner.action(api.exports.generateExport, {
+      projectId: ids.projectId,
+      verdictCampaignId: campaignId,
+      trainingApprovalId: approval.approvalId,
+      source: "trajectory",
+      format: "sft",
+    })).rejects.toThrow(/revoked|active/i);
+  });
+
+  test("fixture-only full-span evidence cannot receive training approval", async () => {
+    const artifact = JSON.parse(JSON.stringify(fixture)) as { run: { status: string } };
+    artifact.run.status = "fixture_complete";
+    const { owner, campaignId } = await setup(artifact);
+    await expect(owner.action(api.trainingApprovals.approveVerdictCampaign, { campaignId })).rejects.toThrow(/no quality-eligible/i);
+  });
+
+  test("private full-span evidence remains ineligible even after a positive verdict", async () => {
+    const artifact = JSON.parse(JSON.stringify(fixture)) as { reviewer: { task: { privacy_class: string } } };
+    artifact.reviewer.task.privacy_class = "confidential";
+    const { owner, campaignId } = await setup(artifact);
+    await expect(owner.action(api.trainingApprovals.approveVerdictCampaign, { campaignId })).rejects.toThrow(/no quality-eligible/i);
+  });
+
+  test("approved same-task shared-prefix full spans produce a reviewer-safe DPO pair", async () => {
+    const { t, owner, ids } = await setup();
+    const second = JSON.parse(JSON.stringify(fixture)) as { run: { id: string; attempt: string }; reviewer: { events: Array<{ kind: string; tool_name?: string }> } };
+    second.run.id = "mogil-producer-fixture-v1-alternative";
+    second.run.attempt = "attempt-fixture-alternative";
+    for (const event of second.reviewer.events) {
+      if (event.kind === "tool_call" || event.kind === "tool_result") event.tool_name = "bash";
+    }
+    const issued = await owner.mutation(api.ingestTokens.issueIngestToken, { projectId: ids.projectId, label: "alternative", scopes: ["traces:write"] });
+    const response = await t.fetch("/ingest/v1/eval-runs", { method: "POST", headers: headers(issued.token), body: JSON.stringify({ runs: [second] }) });
+    expect(response.status).toBe(200);
+    const traces = await t.run(async (ctx) => (await ctx.db.query("fullSpanEvalRuns").collect()).map((row) => row.agentTraceId).filter((id): id is Id<"agentTraces"> => id !== undefined));
+    const leftTraceId = traces[0];
+    const rightTraceId = traces[1];
+    if (!leftTraceId || !rightTraceId) throw new Error("two traces required");
+    const campaignId = await t.run(async (ctx) => await ctx.db.insert("comparisonCampaigns", { projectId: ids.projectId, name: "Synthetic pair", status: "closed", shareToken: "opaque-pair", importKey: "safe-pair", caseCount: 1, judgmentCount: 1, createdById: ids.ownerId, createdAt: 1, closedAt: 2 }));
+    const matchupId = await owner.mutation(api.agentTraceReview.createMatchup, { leftTraceId, rightTraceId, divergenceStepIndex: 3, leftBlindLabel: "A", rightBlindLabel: "B", campaignId, caseKey: "same-task" });
+    await owner.mutation(api.agentTraceReview.decideMatchup, { matchupId, winner: "left", reasonTags: ["accuracy"] });
+    const approval = await owner.action(api.trainingApprovals.approveComparisonCampaign, { campaignId });
+    await t.run(async (ctx) => { await ctx.db.patch(matchupId, { divergenceStepIndex: 0, prefixHash: "mutated-after-approval" }); });
+    const generated = await owner.action(api.exports.generateExport, { projectId: ids.projectId, campaignId, trainingApprovalId: approval.approvalId, source: "trajectory", format: "dpo" });
+    const jsonl = await exportText(t, generated.exportId);
+    const row = JSON.parse(jsonl) as { prompt: string; chosen: string; rejected: string };
+    expect(row.chosen).not.toBe(row.rejected);
+    expect(row.prompt).toContain("Fix fictional widget arithmetic.");
+    expect(row.prompt).toContain("I will edit.");
+    expect(`${row.chosen}\n${row.rejected}`).toMatch(/change_file|run_command/);
+    expect(JSON.stringify(row)).not.toMatch(/assistant_reasoning|objective_outcomes|verifier|infrastructure|reward|workspace_change|policy_event|termination|fictional-provider|fictional-model|harbor\/pi|call-1/);
+    await expect(verifyApprovedExportArtifact(jsonl, generated.manifest)).resolves.toEqual({ ready: true, reasons: [] });
+  });
+
+  test("approved comparable but degenerate DPO produces an explicit verified zero-row artifact", async () => {
+    const { t, owner, ids } = await setup();
+    const second = JSON.parse(JSON.stringify(fixture)) as { run: { id: string; attempt: string } };
+    second.run.id = "mogil-producer-fixture-v1-second";
+    second.run.attempt = "attempt-fixture-002";
+    const issued = await owner.mutation(api.ingestTokens.issueIngestToken, { projectId: ids.projectId, label: "second", scopes: ["traces:write"] });
+    const response = await t.fetch("/ingest/v1/eval-runs", { method: "POST", headers: headers(issued.token), body: JSON.stringify({ runs: [second] }) });
+    expect(response.status).toBe(200);
+    const traces = await t.run(async (ctx) => (await ctx.db.query("fullSpanEvalRuns").collect()).map((row) => row.agentTraceId).filter((id): id is Id<"agentTraces"> => id !== undefined));
+    expect(traces).toHaveLength(2);
+    const campaignId = await t.run(async (ctx) => await ctx.db.insert("comparisonCampaigns", {
+      projectId: ids.projectId, name: "Degenerate synthetic pair", status: "closed", shareToken: "opaque-comparison", importKey: "degenerate-pair", caseCount: 1, judgmentCount: 1, createdById: ids.ownerId, createdAt: 1, closedAt: 2,
+    }));
+    const leftTraceId = traces[0];
+    const rightTraceId = traces[1];
+    if (!leftTraceId || !rightTraceId) throw new Error("two traces required");
+    const matchupId = await owner.mutation(api.agentTraceReview.createMatchup, {
+      leftTraceId, rightTraceId, divergenceStepIndex: 3, leftBlindLabel: "A", rightBlindLabel: "B", campaignId, caseKey: "synthetic-case",
+    });
+    await owner.mutation(api.agentTraceReview.decideMatchup, { matchupId, winner: "left", reasonTags: ["accuracy"] });
+    const approval = await owner.action(api.trainingApprovals.approveComparisonCampaign, { campaignId });
+    const generated = await owner.action(api.exports.generateExport, {
+      projectId: ids.projectId, campaignId, trainingApprovalId: approval.approvalId, source: "trajectory", format: "dpo",
+    });
+    const jsonl = await exportText(t, generated.exportId);
+    expect(jsonl).toBe("");
+    expect(generated.manifest.excluded_by_reason.degenerate).toBe(1);
+    expect(generated.manifest.notes.some((note) => note.includes("No comparable preference pairs"))).toBe(true);
+    await expect(verifyApprovedExportArtifact(jsonl, generated.manifest)).resolves.toEqual({ ready: true, reasons: [] });
+  });
+
+  test.each([0, 3])("rejects different reviewer-safe tasks independently of prefix at divergence %i", async (divergenceStepIndex) => {
+    const { t, owner, ids } = await setup();
+    const second = JSON.parse(JSON.stringify(fixture)) as { run: { id: string; attempt: string }; reviewer: { task: { prompt: string } } };
+    second.run.id = `different-task-${divergenceStepIndex}`;
+    second.run.attempt = `different-task-attempt-${divergenceStepIndex}`;
+    second.reviewer.task.prompt = "A different reviewer-safe task.";
+    const issued = await owner.mutation(api.ingestTokens.issueIngestToken, { projectId: ids.projectId, label: `different-${divergenceStepIndex}`, scopes: ["traces:write"] });
+    expect((await t.fetch("/ingest/v1/eval-runs", { method: "POST", headers: headers(issued.token), body: JSON.stringify({ runs: [second] }) })).status).toBe(200);
+    const traces = await t.run(async (ctx) => (await ctx.db.query("fullSpanEvalRuns").collect()).flatMap((row) => row.agentTraceId ? [row.agentTraceId] : []));
+    const leftTraceId = traces[0], rightTraceId = traces[1];
+    if (!leftTraceId || !rightTraceId) throw new Error("two traces required");
+    const campaignId = await t.run(async (ctx) => await ctx.db.insert("comparisonCampaigns", { projectId: ids.projectId, name: "Different tasks", status: "closed", shareToken: `different-${divergenceStepIndex}`, importKey: `different-${divergenceStepIndex}`, caseCount: 1, judgmentCount: 1, createdById: ids.ownerId, createdAt: 1, closedAt: 2 }));
+    const matchupId = await owner.mutation(api.agentTraceReview.createMatchup, { leftTraceId, rightTraceId, divergenceStepIndex, leftBlindLabel: "A", rightBlindLabel: "B", campaignId, caseKey: "different-task" });
+    expect((await t.run(async (ctx) => ctx.db.get(matchupId)))?.comparabilityStatus).toBe("valid");
+    await owner.mutation(api.agentTraceReview.decideMatchup, { matchupId, winner: "left", reasonTags: [] });
+    const prepared = await owner.query(internal.trainingApprovals.prepareComparisonApproval, { campaignId });
+    expect(prepared.candidates[0]?.exclusionReason).toBe("task_mismatch");
+    await expect(owner.action(api.trainingApprovals.approveComparisonCampaign, { campaignId })).rejects.toThrow(/no quality-eligible/i);
+  });
+
+  test("approval snapshots exact projection bytes and ignores later mutable span pointers", async () => {
+    const { t, owner, ids, campaignId } = await setup();
+    const approval = await owner.action(api.trainingApprovals.approveVerdictCampaign, { campaignId });
+    await t.run(async (ctx) => {
+      const span = await ctx.db.query("fullSpanEvalRuns").unique();
+      if (!span) throw new Error("span missing");
+      const replacement = await ctx.storage.store(new Blob([JSON.stringify({ poisoned: true })]));
+      await ctx.db.patch(span._id, { reviewerProjectionStorageId: replacement, trainingTaskHash: "mutated-task" });
+    });
+    const generated = await owner.action(api.exports.generateExport, { projectId: ids.projectId, verdictCampaignId: campaignId, trainingApprovalId: approval.approvalId, source: "trajectory", format: "sft" });
+    expect(await exportText(t, generated.exportId)).toContain("Fix fictional widget arithmetic.");
+  });
+
+  test("generation fails closed when immutable projection bytes do not match the approval hash", async () => {
+    const { t, owner, ids, campaignId } = await setup();
+    const approval = await owner.action(api.trainingApprovals.approveVerdictCampaign, { campaignId });
+    await t.run(async (ctx) => {
+      const item = await ctx.db.query("trainingApprovalItems").withIndex("by_approval_and_order", (q) => q.eq("approvalId", approval.approvalId)).unique();
+      if (!item) throw new Error("approval item missing");
+      await ctx.db.patch(item._id, { projectionSha256: "0".repeat(64) });
+    });
+    await expect(owner.action(api.exports.generateExport, { projectId: ids.projectId, verdictCampaignId: campaignId, trainingApprovalId: approval.approvalId, source: "trajectory", format: "sft" })).rejects.toThrow(/hash mismatch/i);
+  });
+
+  test("record mutation atomically rejects active approvals with the wrong campaign binding", async () => {
+    const { t, owner, ids, campaignId } = await setup();
+    const approval = await owner.action(api.trainingApprovals.approveVerdictCampaign, { campaignId });
+    const blobs = await t.run(async (ctx) => ({ jsonl: await ctx.storage.store(new Blob(["row"])), manifest: await ctx.storage.store(new Blob(["{}"])) }));
+    await expect(t.mutation(internal.exports.recordExport, { projectId: ids.projectId, source: "trajectory", format: "sft", storageId: blobs.jsonl, manifestStorageId: blobs.manifest, trainingApprovalId: approval.approvalId, rowCount: 1, excludedCount: 0, manifest: "{}", createdById: ids.ownerId, createdAt: 1 })).rejects.toThrow(/campaign binding/i);
+    await t.run(async (ctx) => { await ctx.storage.delete(blobs.jsonl); await ctx.storage.delete(blobs.manifest); });
+  });
+
+  test("generation racing revocation cannot retain usable export blobs", async () => {
+    const { t, owner, ids, campaignId } = await setup();
+    const approval = await owner.action(api.trainingApprovals.approveVerdictCampaign, { campaignId });
+    const generating = owner.action(api.exports.generateExport, { projectId: ids.projectId, verdictCampaignId: campaignId, trainingApprovalId: approval.approvalId, source: "trajectory", format: "sft" });
+    const revoking = owner.mutation(api.trainingApprovals.revoke, { approvalId: approval.approvalId });
+    await Promise.allSettled([generating, revoking]);
+    const state = await t.run(async (ctx) => {
+      const approvalRow = await ctx.db.get(approval.approvalId);
+      const exports = await ctx.db.query("trainingExports").withIndex("by_approval", (q) => q.eq("trainingApprovalId", approval.approvalId)).collect();
+      return { status: approvalRow?.status, blobs: await Promise.all(exports.flatMap((row) => [ctx.storage.get(row.storageId), ...(row.manifestStorageId ? [ctx.storage.get(row.manifestStorageId)] : [])])) };
+    });
+    expect(state.status).toBe("revoked");
+    expect(state.blobs.every((blob) => blob === null)).toBe(true);
+    const orphanAttempt = await t.run(async (ctx) => ({ jsonl: await ctx.storage.store(new Blob(["race"])), manifest: await ctx.storage.store(new Blob(["{}"])) }));
+    await expect(t.mutation(internal.exports.recordExport, {
+      projectId: ids.projectId, source: "trajectory", format: "sft", storageId: orphanAttempt.jsonl, manifestStorageId: orphanAttempt.manifest,
+      trainingApprovalId: approval.approvalId, verdictCampaignId: campaignId, rowCount: 1, excludedCount: 0, manifest: "{}", createdById: ids.ownerId, createdAt: Date.now(),
+    })).rejects.toThrow(/no longer active/i);
+    await t.run(async (ctx) => { await ctx.storage.delete(orphanAttempt.jsonl); await ctx.storage.delete(orphanAttempt.manifest); });
+  });
+
+  test("record rejection after storage cleans both newly-created blobs", async () => {
+    const { t, owner, ids, campaignId } = await setup();
+    const approval = await owner.action(api.trainingApprovals.approveVerdictCampaign, { campaignId });
+    await t.run(async (ctx) => {
+      const storageId = await ctx.storage.store(new Blob(["existing"]));
+      const manifestStorageId = await ctx.storage.store(new Blob(["{}"]));
+      for (let index = 0; index < TRAINING_EXPORT_LIMITS.maxExportsPerApproval; index++) {
+        await ctx.db.insert("trainingExports", { projectId: ids.projectId, source: "trajectory", format: "sft", storageId, manifestStorageId, trainingApprovalId: approval.approvalId, rowCount: 1, excludedCount: 0, manifest: "{}", createdById: ids.ownerId, createdAt: index });
+      }
+    });
+    const before = await t.run(async (ctx) => (await ctx.db.system.query("_storage").collect()).length);
+    await expect(owner.action(api.exports.generateExport, { projectId: ids.projectId, verdictCampaignId: campaignId, trainingApprovalId: approval.approvalId, source: "trajectory", format: "sft" })).rejects.toThrow(/export limit/i);
+    const after = await t.run(async (ctx) => (await ctx.db.system.query("_storage").collect()).length);
+    expect(after).toBe(before);
+  });
+
+  test("revocation invalidates pre-issued URLs and list marks new and legacy rows unavailable", async () => {
+    const { t, owner, ids, campaignId } = await setup();
+    const approval = await owner.action(api.trainingApprovals.approveVerdictCampaign, { campaignId });
+    const generated = await owner.action(api.exports.generateExport, { projectId: ids.projectId, verdictCampaignId: campaignId, trainingApprovalId: approval.approvalId, source: "trajectory", format: "sft" });
+    const issued = await owner.action(api.exports.downloadExport, { exportId: generated.exportId });
+    const legacyId = await t.run(async (ctx) => {
+      const storageId = await ctx.storage.store(new Blob(["legacy"]));
+      return await ctx.db.insert("trainingExports", { projectId: ids.projectId, source: "trajectory", format: "sft", storageId, rowCount: 1, excludedCount: 0, createdById: ids.ownerId, createdAt: Date.now() });
+    });
+    await owner.mutation(api.trainingApprovals.revoke, { approvalId: approval.approvalId });
+    await expect(owner.action(api.exports.downloadExport, { exportId: generated.exportId })).rejects.toThrow(/revoked|unavailable/i);
+    const rows = await owner.query(api.exports.listExports, { projectId: ids.projectId });
+    expect(rows.find((row) => row._id === generated.exportId)?.availability).toBe("revoked");
+    expect(rows.find((row) => row._id === legacyId)?.availability).toBe("legacy_unapproved");
+    const deleted = await t.run(async (ctx) => {
+      const row = await ctx.db.get(generated.exportId);
+      return row ? [await ctx.storage.get(row.storageId), row.manifestStorageId ? await ctx.storage.get(row.manifestStorageId) : null] : [];
+    });
+    expect(deleted).toEqual([null, null]);
+    expect(issued.url).toBeTruthy();
+    expect(issued.manifestUrl).toBeTruthy();
+    expect((await t.fetch(new URL(issued.url).pathname)).status).not.toBe(200);
+    expect((await t.fetch(new URL(issued.manifestUrl).pathname)).status).not.toBe(200);
+  });
+
+  test("approval projection cap accepts exact bytes and rejects one byte above", async () => {
+    for (const [size, allowed] of [[TRAINING_EXPORT_LIMITS.maxProjectionBytes, true], [TRAINING_EXPORT_LIMITS.maxProjectionBytes + 1, false]] as const) {
+      const state = await setup();
+      await state.t.run(async (ctx) => {
+        const span = await ctx.db.query("fullSpanEvalRuns").unique();
+        if (!span) throw new Error("span missing");
+        const projection = await ctx.storage.store(new Blob(["x".repeat(size)]));
+        await ctx.db.patch(span._id, { reviewerProjectionStorageId: projection });
+      });
+      const approval = state.owner.action(api.trainingApprovals.approveVerdictCampaign, { campaignId: state.campaignId });
+      if (allowed) await expect(approval).resolves.toMatchObject({ eligibleCount: 1 });
+      else await expect(approval).rejects.toThrow(/byte limit/i);
+    }
+  });
+
+  test("approval candidate cap accepts exactly the limit and rejects one above", async () => {
+    const atLimit = await setup();
+    const traceId = await atLimit.t.run(async (ctx) => (await ctx.db.query("fullSpanEvalRuns").unique())?.agentTraceId);
+    if (!traceId) throw new Error("trace missing");
+    const makeCampaign = async (count: number, suffix: string) => await atLimit.t.run(async (ctx) => {
+      const campaignId = await ctx.db.insert("verdictReviewCampaigns", { projectId: atLimit.ids.projectId, name: suffix, status: "closed", shareToken: suffix, itemCount: count, judgmentCount: count, createdById: atLimit.ids.ownerId, createdAt: 1, closedAt: 2 });
+      for (let index = 0; index < count; index++) {
+        const itemId = await ctx.db.insert("verdictReviewItems", { campaignId, projectId: atLimit.ids.projectId, agentTraceId: traceId, sortOrder: index });
+        await ctx.db.insert("verdictReviewDecisions", { campaignId, itemId, projectId: atLimit.ids.projectId, agentTraceId: traceId, userId: atLimit.ids.guestId, rating: "best", decidedAt: 1 });
+      }
+      return campaignId;
+    });
+    const allowed = await makeCampaign(TRAINING_EXPORT_LIMITS.maxCandidates, "at-limit");
+    await expect(atLimit.owner.action(api.trainingApprovals.approveVerdictCampaign, { campaignId: allowed })).resolves.toMatchObject({ eligibleCount: TRAINING_EXPORT_LIMITS.maxCandidates });
+    const denied = await makeCampaign(TRAINING_EXPORT_LIMITS.maxCandidates + 1, "above-limit");
+    await expect(atLimit.owner.action(api.trainingApprovals.approveVerdictCampaign, { campaignId: denied })).rejects.toThrow(/at most|supports/i);
+  });
+
+  test("isolated-sandbox producer provenance stays out of approved SFT and its manifest", async () => {
+    const { t, owner, ids, campaignId } = await setup(isolatedSandboxFixture);
+    const approval = await owner.action(api.trainingApprovals.approveVerdictCampaign, { campaignId });
+    const generated = await owner.action(api.exports.generateExport, {
+      projectId: ids.projectId, verdictCampaignId: campaignId, trainingApprovalId: approval.approvalId, source: "trajectory", format: "sft",
+    });
+    const jsonl = await exportText(t, generated.exportId);
+    expect(jsonl).not.toMatch(/isolated-sandbox|daytona|fictional-provider|fictional-model|harbor\/pi/i);
+    expect(JSON.stringify(generated.manifest)).not.toMatch(/isolated-sandbox|daytona|provider|model|harness/i);
+    await expect(verifyApprovedExportArtifact(jsonl, generated.manifest)).resolves.toEqual({ ready: true, reasons: [] });
+  });
+
+  test("writes messages-only reviewer-safe SFT with exact hashes and aggregate-only manifest", async () => {
+    const { t, owner, ids, campaignId } = await setup();
+    const approval = await owner.action(api.trainingApprovals.approveVerdictCampaign, { campaignId });
+    const generated = await owner.action(api.exports.generateExport, {
+      projectId: ids.projectId,
+      verdictCampaignId: campaignId,
+      trainingApprovalId: approval.approvalId,
+      source: "trajectory",
+      format: "sft",
+    });
+    const jsonl = await exportText(t, generated.exportId);
+    const parsed = JSON.parse(jsonl.trim()) as Record<string, unknown>;
+    expect(Object.keys(parsed)).toEqual(["messages"]);
+    const serialized = JSON.stringify(parsed);
+    expect(serialized).toContain("Fix fictional widget arithmetic.");
+    expect(serialized).toContain("I will edit.");
+    expect(serialized).toContain("change_file");
+    expect(serialized).toContain("edited [WORKSPACE_PATH]");
+    expect(serialized).not.toMatch(/assistant_reasoning|objective_outcomes|verifier|infrastructure|reward|workspace_change|policy_event|termination|fictional-provider|fictional-model|analysis_metadata|attempt-fixture|call-1/);
+    expect(generated.manifest.integrity).toMatchObject({ reconciled: true, candidate_count: 1 });
+    expect(generated.manifest.integrity.row_hashes).toHaveLength(1);
+    expect(generated.manifest.integrity.dataset_hash).toMatch(/^[a-f0-9]{64}$/);
+    await expect(verifyApprovedExportArtifact(jsonl, generated.manifest)).resolves.toEqual({ ready: true, reasons: [] });
+    expect(JSON.stringify(generated.manifest)).not.toContain(String(ids.projectId));
+  });
+});

--- a/convex/tests/trainingExport.test.ts
+++ b/convex/tests/trainingExport.test.ts
@@ -2,6 +2,10 @@ import { describe, expect, test } from "vitest";
 import {
   buildExportManifest,
   gateRows,
+  TRAINING_EXPORT_LIMITS,
+  trainingExportSizeViolation,
+  serializeAgentObservableEvent,
+  serializeAgentObservableTrajectoryContext,
   toJsonl,
   type ClassifiedRow,
   type ExportRow,
@@ -13,6 +17,54 @@ const dpo = (over: Partial<Record<string, string>> = {}): ExportRow => ({
   chosen: over.chosen ?? "escalated appropriately",
   rejected: over.rejected ?? "ignored the request",
   metadata: { evaluator_count: 2 },
+});
+
+describe("#287 bounded export limits", () => {
+  test.each([
+    ["candidates", "maxCandidates"],
+    ["projectionBytes", "maxProjectionBytes"],
+    ["rowBytes", "maxRowBytes"],
+    ["jsonlBytes", "maxJsonlBytes"],
+    ["manifestBytes", "maxManifestBytes"],
+  ] as const)("accepts %s exactly at its cap and rejects one byte/item above", (field, limitField) => {
+    const limit = TRAINING_EXPORT_LIMITS[limitField];
+    expect(trainingExportSizeViolation({ [field]: limit })).toBeNull();
+    expect(trainingExportSizeViolation({ [field]: limit + 1 })).toBe(field);
+  });
+});
+
+describe("#287 agent-observable trajectory serialization", () => {
+  test("allowlists inference-time context and cuts chronology at terminal final output", () => {
+    const context = serializeAgentObservableTrajectoryContext({
+      taskPrompt: "Fix the widget.",
+      events: [
+        { sequence: 0, kind: "user_message", role: "user", content: "Fix it." },
+        { sequence: 1, kind: "assistant_reasoning", content: "private reasoning" },
+        { sequence: 2, kind: "assistant_message", role: "assistant", content: "I will inspect." },
+        { sequence: 3, kind: "tool_call", callId: "operation-1", toolName: "read_file", arguments: { path: "widget.ts" } },
+        { sequence: 4, kind: "tool_result", callId: "operation-1", toolName: "read_file", result: { text: "source" } },
+        { sequence: 5, kind: "workspace_change", content: "post-hoc changed files" },
+        { sequence: 6, kind: "verifier_result", content: "oracle passed" },
+        { sequence: 7, kind: "reward", content: "reward=1" },
+        { sequence: 8, kind: "policy_event", content: "post-hoc policy" },
+        { sequence: 9, kind: "final_output", content: "Fixed." },
+        { sequence: 10, kind: "user_message", role: "user", content: "must not appear after final" },
+        { sequence: 11, kind: "termination", content: "completed" },
+      ],
+    });
+    expect(context).toContain("Fix the widget.");
+    expect(context).toContain("I will inspect.");
+    expect(context).toContain("read_file");
+    expect(context).toContain("source");
+    expect(context).not.toContain("operation-1");
+    expect(context).not.toMatch(/private reasoning|workspace_change|changed files|verifier|oracle|reward|policy|final_output|must not appear|termination/);
+    expect(context).not.toMatch(/objective_outcomes|infrastructure|succeeded|passed/);
+  });
+
+  test.each(["assistant_reasoning", "verifier_result", "workspace_change", "policy_event", "outcome", "reward", "lifecycle", "termination", "final_output"])(
+    "rejects %s as a DPO chosen/rejected action",
+    (kind) => expect(serializeAgentObservableEvent({ sequence: 1, kind, content: "oracle" })).toBeNull(),
+  );
 });
 
 describe("#53 training-export data-boundary gate", () => {
@@ -39,6 +91,15 @@ describe("#53 training-export data-boundary gate", () => {
     const { included, excluded } = gateRows(rows);
     expect(included).toHaveLength(1);
     expect(excluded.every((e) => e.reason === "pii_leak")).toBe(true);
+  });
+
+  test("canary or private provenance markers are excluded even from public rows", () => {
+    const { included, excluded } = gateRows([
+      { row: dpo({ chosen: "HIDDEN_VERIFIER_CANARY_BLOCKING_123" }), privacyClass: "public" },
+      { row: dpo({ chosen: "analysis_metadata: private" }), privacyClass: "public" },
+    ]);
+    expect(included).toHaveLength(0);
+    expect(excluded.map((row) => row.reason)).toEqual(["canary_or_private_leak", "canary_or_private_leak"]);
   });
 
   test("degenerate DPO pairs (chosen === rejected) are excluded — no training signal", () => {
@@ -102,7 +163,7 @@ describe("#53 JSONL serializers produce valid, parseable output", () => {
     const lines = out.split("\n");
     expect(lines).toHaveLength(2);
     expect(JSON.parse(lines[0]!)).not.toHaveProperty("metadata");
-    expect(JSON.parse(lines[1]!).metadata).toEqual({ preference: "best" });
+    expect(JSON.parse(lines[1]!)).not.toHaveProperty("metadata");
     // valid JSONL: every line parses
     for (const l of lines) expect(() => JSON.parse(l)).not.toThrow();
   });
@@ -127,7 +188,7 @@ describe("#288 export manifest (Fireworks handoff report)", () => {
     });
 
     expect(manifest.schema).toBe("blindbench.training-export");
-    expect(manifest.version).toBe(1);
+    expect(manifest.version).toBe(2);
     expect(manifest).toMatchObject({ source: "output_preference", format: "dpo" });
     expect(manifest.row_count).toBe(included.length);
     expect(manifest.excluded_count).toBe(excluded.length);

--- a/convex/tests/verdictReviewCampaigns.test.ts
+++ b/convex/tests/verdictReviewCampaigns.test.ts
@@ -232,18 +232,15 @@ describe("verdict review campaigns", () => {
       campaignId,
     })).toEqual({ added: 0, alreadyPresent: 1, excluded: 0 });
 
-    const exported = await asOwner.action(api.exports.generateExport, {
+    await expect(asOwner.action(api.exports.generateExport, {
       projectId: ids.projectId,
       verdictCampaignId: campaignId,
       source: "trajectory",
       format: "sft",
-    });
-    expect(exported).toMatchObject({ rowCount: 1, excludedCount: 0 });
-    expect(exported.manifest).toMatchObject({
-      format: "sft",
-      source_units: 1,
-      reviewers: 2,
-    });
+    })).rejects.toThrow(/training approval/i);
+    await expect(asOwner.action(api.trainingApprovals.approveVerdictCampaign, {
+      campaignId,
+    })).rejects.toThrow(/no quality-eligible/i);
   });
 
   test("rejects owner self-review, closes submissions, and resumes a guest idempotently", async () => {

--- a/convex/trainingApprovals.ts
+++ b/convex/trainingApprovals.ts
@@ -1,0 +1,228 @@
+/** Explicit, revocable owner approval snapshots for training export (#287). */
+import { v } from "convex/values";
+import { action, internalMutation, internalQuery, mutation, query, type QueryCtx } from "./_generated/server";
+import { internal } from "./_generated/api";
+import type { Doc, Id } from "./_generated/dataModel";
+import { requireProjectRole } from "./lib/auth";
+import { TRAINING_EXPORT_LIMITS, trainingExportSizeViolation } from "./lib/trainingExport";
+
+export const TRAINING_POLICY_VERSION = "full-span-training-v2";
+
+type PrivacyClass = Doc<"agentTraces">["privacyClass"];
+type ExclusionReason = Doc<"trainingApprovalItems">["exclusionReason"];
+type ProjectionRef = { readonly storageId: Id<"_storage">; readonly taskHash: string; readonly privacyClass: PrivacyClass };
+type ProjectionSnapshot = ProjectionRef & { readonly sha256: string };
+type Candidate = {
+  readonly agentTraceId?: Id<"agentTraces">;
+  readonly matchupId?: Id<"agentTraceMatchups">;
+  readonly winner?: "left" | "right";
+  readonly divergenceStepIndex?: number;
+  readonly sharedPrefixHash?: string;
+  readonly taskHash?: string;
+  readonly projection?: ProjectionSnapshot;
+  readonly leftProjection?: ProjectionSnapshot;
+  readonly rightProjection?: ProjectionSnapshot;
+  readonly privacyClass: PrivacyClass;
+  readonly reviewerCount: number;
+  readonly eligibility: "eligible" | "excluded";
+  readonly exclusionReason?: ExclusionReason;
+};
+type PreparedCandidate = Omit<Candidate, "projection" | "leftProjection" | "rightProjection"> & {
+  readonly projection?: ProjectionRef;
+  readonly leftProjection?: ProjectionRef;
+  readonly rightProjection?: ProjectionRef;
+};
+type ApprovalResult = { readonly approvalId: Id<"trainingApprovals">; readonly eligibleCount: number; readonly excludedCount: number };
+type PreparedResult = { readonly existing: ApprovalResult | null; readonly projectId: Id<"projects">; readonly reviewerCount: number; readonly candidates: PreparedCandidate[] };
+
+const PRIVACY = v.union(v.literal("public"), v.literal("internal"), v.literal("confidential"), v.literal("pii"), v.literal("phi"));
+const EXCLUSION = v.union(v.literal("not_full_span"), v.literal("fixture_only"), v.literal("insufficient_evidence"), v.literal("sensitive"), v.literal("no_approved_verdict"), v.literal("review_disagreement"), v.literal("non_comparable_prefix"), v.literal("no_preference"), v.literal("task_mismatch"));
+const SNAPSHOT = v.object({ storageId: v.id("_storage"), sha256: v.string(), taskHash: v.string(), privacyClass: PRIVACY });
+const CANDIDATE = v.object({
+  agentTraceId: v.optional(v.id("agentTraces")), matchupId: v.optional(v.id("agentTraceMatchups")),
+  winner: v.optional(v.union(v.literal("left"), v.literal("right"))), divergenceStepIndex: v.optional(v.number()),
+  sharedPrefixHash: v.optional(v.string()), taskHash: v.optional(v.string()), projection: v.optional(SNAPSHOT),
+  leftProjection: v.optional(SNAPSHOT), rightProjection: v.optional(SNAPSHOT), privacyClass: PRIVACY,
+  reviewerCount: v.number(), eligibility: v.union(v.literal("eligible"), v.literal("excluded")), exclusionReason: v.optional(EXCLUSION),
+});
+
+function sensitive(value: PrivacyClass): boolean { return value === "confidential" || value === "pii" || value === "phi"; }
+function combinedPrivacy(left: PrivacyClass, right: PrivacyClass): PrivacyClass {
+  if (sensitive(left)) return left;
+  if (sensitive(right)) return right;
+  return left === "internal" || right === "internal" ? "internal" : "public";
+}
+
+async function projectionRef(ctx: QueryCtx, trace: Doc<"agentTraces"> | null): Promise<{ readonly eligible: true; readonly ref: ProjectionRef } | { readonly eligible: false; readonly reason: ExclusionReason; readonly privacyClass: PrivacyClass }> {
+  const privacyClass = trace?.privacyClass ?? "internal";
+  if (!trace) return { eligible: false, reason: "insufficient_evidence", privacyClass };
+  if (sensitive(privacyClass)) return { eligible: false, reason: "sensitive", privacyClass };
+  const span = await ctx.db.query("fullSpanEvalRuns").withIndex("by_trace", (q) => q.eq("agentTraceId", trace._id)).unique();
+  if (!span || span.status !== "ready") return { eligible: false, reason: "not_full_span", privacyClass };
+  if (span.runQualification === "fixture_only") return { eligible: false, reason: "fixture_only", privacyClass };
+  if (span.runQualification !== "quality_eligible" || !span.canJudgeTaskSuccess || span.evidenceCompleteness !== "complete" || !span.reviewerProjectionStorageId) return { eligible: false, reason: "insufficient_evidence", privacyClass };
+  return { eligible: true, ref: { storageId: span.reviewerProjectionStorageId, taskHash: span.trainingTaskHash, privacyClass } };
+}
+
+async function sha256Bytes(bytes: ArrayBuffer): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
+  return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+async function snapshotRef(storage: { get: (id: Id<"_storage">) => Promise<Blob | null> }, ref: ProjectionRef): Promise<ProjectionSnapshot> {
+  const blob = await storage.get(ref.storageId);
+  if (!blob) throw new Error("Reviewer projection is unavailable for approval.");
+  if (trainingExportSizeViolation({ projectionBytes: blob.size })) throw new Error("Reviewer projection exceeds the training approval byte limit.");
+  return { ...ref, sha256: await sha256Bytes(await blob.arrayBuffer()) };
+}
+
+export const prepareVerdictApproval = internalQuery({
+  args: { campaignId: v.id("verdictReviewCampaigns") },
+  handler: async (ctx, args): Promise<PreparedResult> => {
+    const campaign = await ctx.db.get(args.campaignId);
+    if (!campaign) throw new Error("Review not found.");
+    await requireProjectRole(ctx, campaign.projectId, ["owner"]);
+    if (campaign.status !== "closed") throw new Error("Close the review before granting training approval.");
+    const active = (await ctx.db.query("trainingApprovals").withIndex("by_verdict_campaign", (q) => q.eq("verdictCampaignId", campaign._id)).order("desc").collect()).find((row) => row.status === "active");
+    if (active) return { existing: { approvalId: active._id, eligibleCount: active.eligibleCount, excludedCount: active.excludedCount }, projectId: campaign.projectId, reviewerCount: active.reviewerCount, candidates: [] as PreparedCandidate[] };
+    const items = await ctx.db.query("verdictReviewItems").withIndex("by_campaign", (q) => q.eq("campaignId", campaign._id)).take(TRAINING_EXPORT_LIMITS.maxCandidates + 1);
+    if (items.length === 0 || trainingExportSizeViolation({ candidates: items.length })) throw new Error(`Training approval supports 1 to ${TRAINING_EXPORT_LIMITS.maxCandidates} candidates.`);
+    items.sort((a, b) => a.sortOrder - b.sortOrder);
+    const candidates: PreparedCandidate[] = [];
+    const reviewers = new Set<string>();
+    for (const item of items) {
+      const trace = await ctx.db.get(item.agentTraceId);
+      const decisions = await ctx.db.query("verdictReviewDecisions").withIndex("by_item", (q) => q.eq("itemId", item._id)).collect();
+      decisions.forEach((decision) => reviewers.add(String(decision.userId)));
+      const evidence = await projectionRef(ctx, trace);
+      if (!evidence.eligible) candidates.push({ agentTraceId: item.agentTraceId, privacyClass: evidence.privacyClass, reviewerCount: decisions.length, eligibility: "excluded", exclusionReason: evidence.reason });
+      else if (decisions.some((decision) => decision.rating === "weak" || decision.rating === "insufficient_evidence")) candidates.push({ agentTraceId: item.agentTraceId, projection: evidence.ref, taskHash: evidence.ref.taskHash, privacyClass: evidence.ref.privacyClass, reviewerCount: decisions.length, eligibility: "excluded", exclusionReason: "review_disagreement" });
+      else if (!decisions.some((decision) => decision.rating === "best")) candidates.push({ agentTraceId: item.agentTraceId, projection: evidence.ref, taskHash: evidence.ref.taskHash, privacyClass: evidence.ref.privacyClass, reviewerCount: decisions.length, eligibility: "excluded", exclusionReason: "no_approved_verdict" });
+      else candidates.push({ agentTraceId: item.agentTraceId, projection: evidence.ref, taskHash: evidence.ref.taskHash, privacyClass: evidence.ref.privacyClass, reviewerCount: decisions.length, eligibility: "eligible" });
+    }
+    return { existing: null, projectId: campaign.projectId, reviewerCount: reviewers.size, candidates };
+  },
+});
+
+export const prepareComparisonApproval = internalQuery({
+  args: { campaignId: v.id("comparisonCampaigns") },
+  handler: async (ctx, args): Promise<PreparedResult> => {
+    const campaign = await ctx.db.get(args.campaignId);
+    if (!campaign) throw new Error("Comparison review not found.");
+    await requireProjectRole(ctx, campaign.projectId, ["owner"]);
+    if (campaign.status !== "closed") throw new Error("Close the comparison before granting training approval.");
+    const active = (await ctx.db.query("trainingApprovals").withIndex("by_comparison_campaign", (q) => q.eq("comparisonCampaignId", campaign._id)).order("desc").collect()).find((row) => row.status === "active");
+    if (active) return { existing: { approvalId: active._id, eligibleCount: active.eligibleCount, excludedCount: active.excludedCount }, projectId: campaign.projectId, reviewerCount: active.reviewerCount, candidates: [] as PreparedCandidate[] };
+    const matchups = await ctx.db.query("agentTraceMatchups").withIndex("by_campaign", (q) => q.eq("campaignId", campaign._id)).take(TRAINING_EXPORT_LIMITS.maxCandidates + 1);
+    if (matchups.length === 0 || trainingExportSizeViolation({ candidates: matchups.length })) throw new Error(`Training approval supports 1 to ${TRAINING_EXPORT_LIMITS.maxCandidates} candidates.`);
+    matchups.sort((a, b) => (a.sortOrder ?? 0) - (b.sortOrder ?? 0));
+    const candidates: PreparedCandidate[] = [];
+    const reviewers = new Set<string>();
+    for (const matchup of matchups) {
+      const decisions = await ctx.db.query("agentTraceMatchupDecisions").withIndex("by_matchup", (q) => q.eq("matchupId", matchup._id)).collect();
+      decisions.forEach((decision) => reviewers.add(String(decision.userId)));
+      const directional = decisions.filter((decision) => decision.winner === "left" || decision.winner === "right");
+      const winner = directional[0]?.winner;
+      if (matchup.comparabilityStatus !== "valid" || !matchup.prefixHash) { candidates.push({ matchupId: matchup._id, privacyClass: "internal", reviewerCount: decisions.length, eligibility: "excluded", exclusionReason: "non_comparable_prefix" }); continue; }
+      if (directional.length === 0 || decisions.some((decision) => ["tie", "neither", "skip"].includes(decision.winner))) { candidates.push({ matchupId: matchup._id, privacyClass: "internal", reviewerCount: decisions.length, eligibility: "excluded", exclusionReason: "no_preference" }); continue; }
+      if ((winner !== "left" && winner !== "right") || directional.some((decision) => decision.winner !== winner)) { candidates.push({ matchupId: matchup._id, privacyClass: "internal", reviewerCount: decisions.length, eligibility: "excluded", exclusionReason: "review_disagreement" }); continue; }
+      const [leftTrace, rightTrace] = await Promise.all([ctx.db.get(matchup.leftTraceId), ctx.db.get(matchup.rightTraceId)]);
+      const [left, right] = await Promise.all([projectionRef(ctx, leftTrace), projectionRef(ctx, rightTrace)]);
+      if (!left.eligible) { candidates.push({ matchupId: matchup._id, winner, privacyClass: left.privacyClass, reviewerCount: decisions.length, eligibility: "excluded", exclusionReason: left.reason }); continue; }
+      if (!right.eligible) { candidates.push({ matchupId: matchup._id, winner, privacyClass: right.privacyClass, reviewerCount: decisions.length, eligibility: "excluded", exclusionReason: right.reason }); continue; }
+      const privacyClass = combinedPrivacy(left.ref.privacyClass, right.ref.privacyClass);
+      if (left.ref.taskHash !== right.ref.taskHash) { candidates.push({ matchupId: matchup._id, winner, leftProjection: left.ref, rightProjection: right.ref, privacyClass, reviewerCount: decisions.length, eligibility: "excluded", exclusionReason: "task_mismatch" }); continue; }
+      candidates.push({ matchupId: matchup._id, winner, divergenceStepIndex: matchup.divergenceStepIndex, sharedPrefixHash: matchup.prefixHash, taskHash: left.ref.taskHash, leftProjection: left.ref, rightProjection: right.ref, privacyClass, reviewerCount: decisions.length, eligibility: "eligible" });
+    }
+    return { existing: null, projectId: campaign.projectId, reviewerCount: reviewers.size, candidates };
+  },
+});
+
+export const commitApproval = internalMutation({
+  args: { kind: v.union(v.literal("verdict_campaign"), v.literal("comparison_campaign")), campaignId: v.string(), projectId: v.id("projects"), reviewerCount: v.number(), candidates: v.array(CANDIDATE), approvedById: v.id("users") },
+  handler: async (ctx, args) => {
+    if (args.candidates.length === 0 || trainingExportSizeViolation({ candidates: args.candidates.length })) throw new Error("Training approval candidate count is invalid.");
+    const normalizedCampaignId = args.kind === "verdict_campaign" ? ctx.db.normalizeId("verdictReviewCampaigns", args.campaignId) : ctx.db.normalizeId("comparisonCampaigns", args.campaignId);
+    if (!normalizedCampaignId) throw new Error("Training approval campaign is invalid.");
+    const campaign = await ctx.db.get(normalizedCampaignId);
+    if (!campaign || campaign.projectId !== args.projectId || campaign.status !== "closed") throw new Error("Training approval campaign changed before commit.");
+    const active = args.kind === "verdict_campaign"
+      ? (await ctx.db.query("trainingApprovals").withIndex("by_verdict_campaign", (q) => q.eq("verdictCampaignId", normalizedCampaignId as Id<"verdictReviewCampaigns">)).collect()).find((row) => row.status === "active")
+      : (await ctx.db.query("trainingApprovals").withIndex("by_comparison_campaign", (q) => q.eq("comparisonCampaignId", normalizedCampaignId as Id<"comparisonCampaigns">)).collect()).find((row) => row.status === "active");
+    if (active) return { approvalId: active._id, eligibleCount: active.eligibleCount, excludedCount: active.excludedCount };
+    for (const candidate of args.candidates.filter((item) => item.eligibility === "eligible")) {
+      if (args.kind === "verdict_campaign") {
+        if (!candidate.agentTraceId || !candidate.projection || candidate.taskHash !== candidate.projection.taskHash) throw new Error("Verdict approval snapshot is incomplete.");
+        const span = await ctx.db.query("fullSpanEvalRuns").withIndex("by_trace", (q) => q.eq("agentTraceId", candidate.agentTraceId)).unique();
+        if (!span || span.reviewerProjectionStorageId !== candidate.projection.storageId || span.trainingTaskHash !== candidate.taskHash) throw new Error("Verdict approval source changed before commit.");
+      } else {
+        if (!candidate.matchupId || !candidate.leftProjection || !candidate.rightProjection || !candidate.sharedPrefixHash || candidate.divergenceStepIndex === undefined || candidate.leftProjection.taskHash !== candidate.rightProjection.taskHash || candidate.taskHash !== candidate.leftProjection.taskHash) throw new Error("Comparison approval snapshot is incomplete or tasks differ.");
+        const matchup = await ctx.db.get(candidate.matchupId);
+        if (!matchup || matchup.campaignId !== normalizedCampaignId || matchup.prefixHash !== candidate.sharedPrefixHash || matchup.divergenceStepIndex !== candidate.divergenceStepIndex) throw new Error("Comparison approval source changed before commit.");
+        const [leftSpan, rightSpan] = await Promise.all([
+          ctx.db.query("fullSpanEvalRuns").withIndex("by_trace", (q) => q.eq("agentTraceId", matchup.leftTraceId)).unique(),
+          ctx.db.query("fullSpanEvalRuns").withIndex("by_trace", (q) => q.eq("agentTraceId", matchup.rightTraceId)).unique(),
+        ]);
+        if (!leftSpan || !rightSpan || leftSpan.reviewerProjectionStorageId !== candidate.leftProjection.storageId || rightSpan.reviewerProjectionStorageId !== candidate.rightProjection.storageId || leftSpan.trainingTaskHash !== candidate.taskHash || rightSpan.trainingTaskHash !== candidate.taskHash) throw new Error("Comparison approval evidence changed before commit.");
+      }
+    }
+    const eligibleCount = args.candidates.filter((candidate) => candidate.eligibility === "eligible").length;
+    if (eligibleCount === 0) throw new Error("Training approval denied: this review has no quality-eligible, non-sensitive approved candidates.");
+    const verdictCampaignId = args.kind === "verdict_campaign" ? normalizedCampaignId as Id<"verdictReviewCampaigns"> : undefined;
+    const comparisonCampaignId = args.kind === "comparison_campaign" ? normalizedCampaignId as Id<"comparisonCampaigns"> : undefined;
+    const approvalId = await ctx.db.insert("trainingApprovals", { projectId: args.projectId, kind: args.kind, verdictCampaignId, comparisonCampaignId, status: "active", policyVersion: TRAINING_POLICY_VERSION, candidateCount: args.candidates.length, reviewerCount: args.reviewerCount, eligibleCount, excludedCount: args.candidates.length - eligibleCount, approvedById: args.approvedById, approvedAt: Date.now() });
+    for (let sortOrder = 0; sortOrder < args.candidates.length; sortOrder++) {
+      const candidate = args.candidates[sortOrder]; if (!candidate) continue;
+      await ctx.db.insert("trainingApprovalItems", { approvalId, projectId: args.projectId, sortOrder, agentTraceId: candidate.agentTraceId, matchupId: candidate.matchupId, winner: candidate.winner, divergenceStepIndex: candidate.divergenceStepIndex, sharedPrefixHash: candidate.sharedPrefixHash, taskHash: candidate.taskHash, leftTaskHash: candidate.leftProjection?.taskHash, rightTaskHash: candidate.rightProjection?.taskHash, projectionStorageId: candidate.projection?.storageId, projectionSha256: candidate.projection?.sha256, leftProjectionStorageId: candidate.leftProjection?.storageId, leftProjectionSha256: candidate.leftProjection?.sha256, rightProjectionStorageId: candidate.rightProjection?.storageId, rightProjectionSha256: candidate.rightProjection?.sha256, privacyClass: candidate.privacyClass, reviewerCount: candidate.reviewerCount, eligibility: candidate.eligibility, exclusionReason: candidate.exclusionReason });
+    }
+    return { approvalId, eligibleCount, excludedCount: args.candidates.length - eligibleCount };
+  },
+});
+
+async function snapshotPrepared(storage: { get: (id: Id<"_storage">) => Promise<Blob | null> }, candidates: ReadonlyArray<PreparedCandidate>): Promise<Candidate[]> {
+  const result: Candidate[] = [];
+  for (const candidate of candidates) result.push({ ...candidate, projection: candidate.projection ? await snapshotRef(storage, candidate.projection) : undefined, leftProjection: candidate.leftProjection ? await snapshotRef(storage, candidate.leftProjection) : undefined, rightProjection: candidate.rightProjection ? await snapshotRef(storage, candidate.rightProjection) : undefined });
+  return result;
+}
+
+/** Owner action: hash exact verdict projection bytes, then atomically commit refs. */
+export const approveVerdictCampaign = action({
+  args: { campaignId: v.id("verdictReviewCampaigns") },
+  handler: async (ctx, args): Promise<ApprovalResult> => {
+    const prepared: PreparedResult = await ctx.runQuery(internal.trainingApprovals.prepareVerdictApproval, args);
+    if (prepared.existing) return prepared.existing;
+    const userId: Id<"users"> = await ctx.runQuery(internal.trainingApprovals.ownerForApproval, { projectId: prepared.projectId });
+    return await ctx.runMutation(internal.trainingApprovals.commitApproval, { kind: "verdict_campaign", campaignId: String(args.campaignId), projectId: prepared.projectId, reviewerCount: prepared.reviewerCount, candidates: await snapshotPrepared(ctx.storage, prepared.candidates), approvedById: userId });
+  },
+});
+
+/** Owner action: hash both exact DPO projection blobs, then atomically commit. */
+export const approveComparisonCampaign = action({
+  args: { campaignId: v.id("comparisonCampaigns") },
+  handler: async (ctx, args): Promise<ApprovalResult> => {
+    const prepared: PreparedResult = await ctx.runQuery(internal.trainingApprovals.prepareComparisonApproval, args);
+    if (prepared.existing) return prepared.existing;
+    const userId: Id<"users"> = await ctx.runQuery(internal.trainingApprovals.ownerForApproval, { projectId: prepared.projectId });
+    return await ctx.runMutation(internal.trainingApprovals.commitApproval, { kind: "comparison_campaign", campaignId: String(args.campaignId), projectId: prepared.projectId, reviewerCount: prepared.reviewerCount, candidates: await snapshotPrepared(ctx.storage, prepared.candidates), approvedById: userId });
+  },
+});
+
+export const ownerForApproval = internalQuery({ args: { projectId: v.id("projects") }, handler: async (ctx, args) => (await requireProjectRole(ctx, args.projectId, ["owner"])).userId });
+
+/** Revoke approval and delete every bounded export blob so issued URLs die. */
+export const revoke = mutation({
+  args: { approvalId: v.id("trainingApprovals") },
+  handler: async (ctx, args) => {
+    const approval = await ctx.db.get(args.approvalId); if (!approval) throw new Error("Training approval not found.");
+    const { userId } = await requireProjectRole(ctx, approval.projectId, ["owner"]);
+    if (approval.status === "revoked") return { revoked: true };
+    const exports = await ctx.db.query("trainingExports").withIndex("by_approval", (q) => q.eq("trainingApprovalId", approval._id)).take(TRAINING_EXPORT_LIMITS.maxExportsPerApproval + 1);
+    if (exports.length > TRAINING_EXPORT_LIMITS.maxExportsPerApproval) throw new Error("Training approval has too many exports to revoke safely.");
+    await ctx.db.patch(approval._id, { status: "revoked", revokedById: userId, revokedAt: Date.now() });
+    for (const row of exports) { await ctx.storage.delete(row.storageId); if (row.manifestStorageId) await ctx.storage.delete(row.manifestStorageId); }
+    return { revoked: true };
+  },
+});
+
+export const getForVerdictCampaign = query({ args: { campaignId: v.id("verdictReviewCampaigns") }, handler: async (ctx, args) => { const campaign = await ctx.db.get(args.campaignId); if (!campaign) throw new Error("Review not found."); const { collaborator } = await requireProjectRole(ctx, campaign.projectId, ["owner", "editor"]); const approval = (await ctx.db.query("trainingApprovals").withIndex("by_verdict_campaign", (q) => q.eq("verdictCampaignId", campaign._id)).order("desc").collect())[0]; return { canApprove: collaborator.role === "owner", approval: approval ? { id: approval._id, status: approval.status, policyVersion: approval.policyVersion, eligibleCount: approval.eligibleCount, excludedCount: approval.excludedCount, approvedAt: approval.approvedAt, revokedAt: approval.revokedAt } : null }; } });
+export const getForComparisonCampaign = query({ args: { campaignId: v.id("comparisonCampaigns") }, handler: async (ctx, args) => { const campaign = await ctx.db.get(args.campaignId); if (!campaign) throw new Error("Comparison review not found."); const { collaborator } = await requireProjectRole(ctx, campaign.projectId, ["owner", "editor"]); const approval = (await ctx.db.query("trainingApprovals").withIndex("by_comparison_campaign", (q) => q.eq("comparisonCampaignId", campaign._id)).order("desc").collect())[0]; return { canApprove: collaborator.role === "owner", approval: approval ? { id: approval._id, status: approval.status, policyVersion: approval.policyVersion, eligibleCount: approval.eligibleCount, excludedCount: approval.excludedCount, approvedAt: approval.approvedAt, revokedAt: approval.revokedAt } : null }; } });

--- a/docs/full-span-ingest.md
+++ b/docs/full-span-ingest.md
@@ -1,6 +1,11 @@
 # Mogil Harbor/Pi full-span evidence ingest
 
-This endpoint consumes the artifact produced by Mogil Bench's authoritative `HarborEvidence` Pydantic model (`mogil_bench/evidence.py`). BlindBench does not import Mogil Bench at runtime; a sanitized Pydantic-generated fixture is pinned at `convex/tests/fixtures/mogil-harbor-evidence-v1.json`.
+This endpoint consumes the artifact produced by Mogil Bench's authoritative `HarborEvidence` Pydantic model (`mogil_bench/evidence.py`). BlindBench does not import Mogil Bench at runtime. Two explicit static consumer contracts are pinned:
+
+- `convex/tests/fixtures/mogil-harbor-evidence-v1.json` — existing Docker producer contract.
+- `convex/tests/fixtures/daytona-reviewer-contract.json` — byte-for-byte copy of `/root/github_repos/ventures/mogil-bench-daytona/tests/fixtures/daytona-reviewer-contract.json` (SHA-256 `9b13f2e540885198db736ae55930d0f5da9d03d38e4adc748e0553acc288e316` at copy time).
+
+The Daytona contract fixture must never be locally synthesized or edited. Synchronize it only by recopying the producer fixture, reviewing its schema diff, and updating the recorded hash.
 
 ## Endpoint, auth, and envelope
 
@@ -71,7 +76,7 @@ Each `runs[]` member has exactly these top-level fields:
   "analysis_metadata": { "provider": "private", "model": "private" },
   "reviewer": {
     "task": { "id": "task", "revision": "1", "privacy_class": "internal", "prompt": "Reviewer-safe prompt" },
-    "environment_class": "docker",
+    "environment_class": "docker | isolated-sandbox",
     "harness_schema": "harbor/pi-jsonl@0.18.0",
     "events": [],
     "outcomes": {},
@@ -81,7 +86,7 @@ Each `runs[]` member has exactly these top-level fields:
 }
 ```
 
-`reviewer.outcomes` and `reviewer.rewards` have the same strict shapes as their top-level counterparts and must agree with them.
+`reviewer.outcomes` and `reviewer.rewards` have the same strict shapes as their top-level counterparts and must agree with them. `reviewer.environment_class` accepts exactly `docker` for existing Docker artifacts or the provider-neutral `isolated-sandbox` value for externally isolated runners. Vendor/backend names are not accepted in that field and the environment class remains private provenance—it is omitted from reviewer UI and training exports.
 
 ### Canonical events
 
@@ -130,3 +135,5 @@ Reservations carry an ownership lease that is renewed before each run and throug
 Internal trace IDs are namespaced as `full-span:{run.id}`. Review creation resolves full-span runs through `fullSpanEvalRuns.stableRunId`; it does not share the legacy/native/OTLP trace-ID namespace.
 
 The exact producer artifact—including `analysis_metadata`, raw reference, and private harness metadata—is retained only in a private raw storage blob. The separately serialized reviewer projection omits private metadata, raw path/hash, original event/call/source/session IDs, model/provider/harness provenance, credentials, canaries, and absolute host paths. The complete serialized projection is checked against the leakage policy before storage.
+
+Training use is a separate, revocable owner decision after a closed human review; objective eligibility or a positive verdict never grants it automatically. See [`full-span-training-export.md`](./full-span-training-export.md).

--- a/docs/full-span-training-export.md
+++ b/docs/full-span-training-export.md
@@ -1,0 +1,105 @@
+# Approved full-span training export runbook
+
+Blind Bench can turn a **closed, strict Mogil/Harbor full-span review** into deterministic Fireworks-compatible SFT or DPO artifacts. It does not run training, call Fireworks, or authorize customer/private data automatically.
+
+## Safety contract
+
+The operator flow is deliberately separate:
+
+```text
+review → close → owner training approval → export → verify
+```
+
+A `quality_eligible` objective result and a positive human verdict/preference are necessary but **not training consent**. An organization/project owner must grant a separate training approval on the closed Result. Editors may export an active approval but cannot grant or revoke it. Guest/blind review surfaces have no approval or export functions.
+
+Approval is default-deny:
+
+- approval snapshots the exact reviewer-projection storage ID and SHA-256 of its exact bytes; DPO snapshots both sides, winner, divergence index, persisted shared-prefix hash, and reviewer-safe task prompt/revision hash;
+- generation reads only those immutable snapshot references and rejects missing, oversized, or hash-mismatched blobs—it never rediscovers the current span or matchup;
+- only strict full-span evidence with `runQualification=quality_eligible`, complete integrity-bound reviewer evidence, and a positive human judgment is eligible;
+- fixture-only, insufficient, non-full-span, confidential, PII, and PHI candidates are excluded;
+- a sensitivity override is not available on the approved path;
+- export recording atomically rechecks active approval plus project/campaign/format binding; failed partial generation deletes every blob it created;
+- revocation blocks every later export/download and deletes all bounded JSONL/manifest blobs tied to the approval, invalidating previously issued direct storage URLs;
+- customer or production data requires a separate product/data-boundary decision. Do not use the approval control as a substitute for written authorization.
+
+## SFT artifact
+
+Each JSONL line has exactly one top-level key:
+
+```json
+{"messages":[{"role":"user","content":"…"},{"role":"assistant","content":"…"}]}
+```
+
+No metadata is embedded in SFT JSONL. The assistant completion is the immutable reviewer-safe final output. Tool-rich context uses `blindbench.agent-observable-trajectory` version 1 inside the user message. Its explicit allowlist is `user_message`, `assistant_message`, `tool_call`, `tool_result`, and `tool_error`:
+
+- reviewer-safe task prompt;
+- sanitized observed user/assistant messages and aliased tool calls/results;
+- chronology stops at the first terminal `final_output`, which is used only as the assistant target;
+- no assistant reasoning, objective outcomes/rewards, verifier results, post-agent workspace changes, policy/lifecycle/termination events, raw evidence, source/model/provider/harness provenance, credentials, canaries, absolute paths, or raw trace/call IDs.
+
+Objective outcomes remain eligibility and aggregate-manifest gates only; they never enter JSONL prompts/messages. This serialization is inference-available trajectory context, not hidden chain-of-thought or post-hoc oracle training data.
+
+## DPO artifact
+
+DPO is emitted only for an approved closed comparison when:
+
+1. both candidates are quality-eligible strict full spans;
+2. both independently share the same immutable SHA-256 task hash over reviewer-safe task prompt + producer task revision (including at divergence step 0);
+3. the persisted SHA-256 prefix proof matches at the same divergence step;
+4. reviewers resolve to one directional winner;
+5. the chosen/rejected next actions are reviewer-safe, agent-observable allowlisted events, non-empty, and non-identical.
+
+Ties, neither/cannot-judge, disagreement, prefix mismatch, hidden-reasoning or post-hoc/non-observable divergence, sensitive data, and degenerate pairs are explicit exclusions. A valid zero-row DPO artifact has an empty JSONL file plus a manifest whose counts reconcile and whose notes explain why no pair was written.
+
+## Manifest
+
+`blindbench.training-export` version 2 is stored and downloaded beside the JSONL. It contains only aggregate/safe handoff data:
+
+- source and reviewer counts;
+- row and exclusion counts plus reasons;
+- schema, policy, and safe-serialization versions;
+- active training-approval and public/internal-only sensitivity policy state;
+- exact SHA-256 hash for each JSONL line;
+- SHA-256 of the exact JSONL artifact bytes;
+- candidate reconciliation (`candidate_count = included_count + excluded_count`);
+- Fireworks row-shape declaration and zero-row notes.
+
+It intentionally omits project/org/user/trace/run IDs, approver identity, provider/model/harness provenance, prompts, completions, comments, and raw evidence.
+
+JSONL bytes are deterministic for one immutable approval snapshot, so row and dataset hashes are stable. The manifest is operational metadata: `generated_at` intentionally varies on each generation, while its row hashes and `dataset_hash` continue to identify the deterministic JSONL bytes.
+
+## Hard size limits
+
+Convex storage is blob-oriented rather than a true streaming writer, so export fails closed under conservative caps:
+
+| Boundary | Maximum |
+| --- | ---: |
+| Candidates per approval/export | 50 |
+| Exact reviewer projection blob | 512 KiB |
+| One serialized JSONL row | 768 KiB |
+| Total JSONL artifact | 4 MiB |
+| Manifest | 512 KiB |
+| Exports retained per active approval | 20 |
+
+Exact-limit values are accepted; one byte/item above is rejected before artifact handoff. Candidate count is checked during both approval and generation.
+
+## Operator steps
+
+1. Import strict full-span evidence using [`full-span-ingest.md`](./full-span-ingest.md).
+2. Create and open a blind **Score runs** or **Compare attempts** review.
+3. Collect independent human judgments and close the review.
+4. Open **Results**, choose the closed result, inspect objective outcomes and human verdicts separately, then select **Approve for training**. Only owners see an enabled approval control.
+5. Select **Export approved SFT** or **Export eligible DPO**. Keep the downloaded manifest with the JSONL.
+6. Verify the exact artifact and manifest. The Convex integration gate calls `verifyApprovedExportArtifact`; repository verification is:
+
+   ```bash
+   npm run test:convex -- --run convex/tests/fullSpanTrainingExport.test.ts
+   ```
+
+   The test imports the static sanitized Mogil producer fixture, reviews it as a separate principal, grants explicit owner approval, generates the artifact, and verifies row/dataset hashes without network calls.
+7. If authorization changes, select **Revoke training approval**. Do not hand off any prior files; Blind Bench also blocks later downloads.
+
+## Stop before Fireworks
+
+This runbook ends at verified artifact handoff. It does not authorize `firectl`, a Fireworks API call, training spend, deployment, paid comparison, or use of customer/private logs. Those require a separate explicit decision outside this workflow.

--- a/docs/training-export-verifier.md
+++ b/docs/training-export-verifier.md
@@ -1,6 +1,8 @@
 # Training export artifact verifier
 
-Use this local verifier before handing Fireworks-ready JSONL artifacts to Fireworks or to a customer. It checks that the compiler output is internally consistent and preserves the data-boundary contract.
+Use this local verifier before handing Fireworks-ready JSONL artifacts to Fireworks or to a customer. It checks that the legacy local compiler output is internally consistent and preserves the data-boundary contract.
+
+For product-generated, explicitly approved strict full-span SFT/DPO artifacts, use the v2 manifest verifier and operator flow in [`full-span-training-export.md`](./full-span-training-export.md). That verifier checks exact line hashes, exact dataset bytes, approval/policy state, row shape, and count reconciliation against the static sanitized Mogil producer fixture.
 
 ```bash
 npm run dataset:demo

--- a/src/lib/evals/harborEvidence.test.ts
+++ b/src/lib/evals/harborEvidence.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, test } from "vitest";
-import fixture from "../../../convex/tests/fixtures/mogil-harbor-evidence-v1.json";
+import dockerFixture from "../../../convex/tests/fixtures/mogil-harbor-evidence-v1.json";
+import isolatedSandboxFixture from "../../../convex/tests/fixtures/daytona-reviewer-contract.json";
 import { parseHarborEvidenceV1 } from "./harborEvidence";
 
-// Static sanitized contract fixture generated through Mogil Bench's authoritative
-// HarborEvidence Pydantic model in mogil-bench-trajectory/src/mogil_bench/evidence.py.
-const artifact = (): Record<string, unknown> => JSON.parse(JSON.stringify(fixture)) as Record<string, unknown>;
+// Static sanitized contracts generated through Mogil Bench's authoritative
+// HarborEvidence Pydantic model. daytona-reviewer-contract.json is copied
+// byte-for-byte from mogil-bench-daytona/tests/fixtures and must not be edited
+// locally; update it only by recopying the producer contract fixture.
+const artifact = (): Record<string, unknown> => JSON.parse(JSON.stringify(dockerFixture)) as Record<string, unknown>;
 const row = (value: unknown): Record<string, unknown> => {
   if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("object expected");
   return value as Record<string, unknown>;
@@ -38,6 +41,37 @@ describe("authoritative mogil.harbor-evidence v1.0 contract", () => {
     for (const hidden of ["analysis_metadata", "fictional-provider", "fictional-model", "harbor/pi", "agent/pi.txt", "call-1"]) {
       expect(serialized).not.toContain(hidden);
     }
+  });
+
+  test.each([
+    ["docker", dockerFixture],
+    ["isolated-sandbox", isolatedSandboxFixture],
+  ])("accepts the copied %s producer contract without exposing environment/provider provenance", async (environmentClass, producerFixture) => {
+    const parsed = await parseHarborEvidenceV1(JSON.parse(JSON.stringify(producerFixture)) as unknown);
+    expect(parsed.projection.runQualification).toBe("quality_eligible");
+    const serialized = JSON.stringify(parsed.projection);
+    expect(serialized).not.toContain(environmentClass);
+    expect(serialized).not.toMatch(/daytona|provider|fictional-provider|harness/i);
+  });
+
+  test.each(["host", "sandbox", "daytona", "isolated_sandbox", ""])(
+    "rejects unsupported reviewer environment class %j",
+    async (environmentClass) => {
+      const body = artifact();
+      row(body.reviewer).environment_class = environmentClass;
+      await expect(parseHarborEvidenceV1(body)).rejects.toThrow(/environment_class/i);
+    },
+  );
+
+  test("training task hash binds reviewer-safe prompt and producer revision", async () => {
+    const first = artifact();
+    const revised = artifact();
+    row(row(revised.reviewer).task).revision = "2";
+    const changedPrompt = artifact();
+    row(row(changedPrompt.reviewer).task).prompt = "A different task.";
+    const [baseline, revision, prompt] = await Promise.all([parseHarborEvidenceV1(first), parseHarborEvidenceV1(revised), parseHarborEvidenceV1(changedPrompt)]);
+    expect(revision.trainingTaskHash).not.toBe(baseline.trainingTaskHash);
+    expect(prompt.trainingTaskHash).not.toBe(baseline.trainingTaskHash);
   });
 
   test("accepts bounded producer stop reasons only on assistant emissions", async () => {

--- a/src/lib/evals/harborEvidence.ts
+++ b/src/lib/evals/harborEvidence.ts
@@ -15,6 +15,7 @@ const EVENT_KINDS = new Set([
   "tool_result", "tool_error", "final_output", "termination",
 ]);
 const RUN_STATUSES = new Set(["quality_eligible", "fixture_complete", "insufficient"]);
+const REVIEWER_ENVIRONMENT_CLASSES = new Set(["docker", "isolated-sandbox"]);
 const PROCESS_STATUSES = new Set(["succeeded", "failed"]);
 const VERIFIER_STATUSES = new Set(["passed", "failed", "not_run"]);
 const INFRASTRUCTURE_STATUSES = new Set(["succeeded", "failed"]);
@@ -80,6 +81,8 @@ export type ParsedHarborEvidence = {
   };
   readonly trace: AgentRunTrace;
   readonly projection: HarborReviewerProjection;
+  /** SHA-256 of the reviewer-safe task prompt + producer task revision. */
+  readonly trainingTaskHash: string;
   readonly objective: {
     readonly process: OutcomeStatus;
     readonly verifier: OutcomeStatus;
@@ -377,12 +380,15 @@ export async function parseHarborEvidenceV1(raw: unknown): Promise<ParsedHarborE
 
   const reviewer = rec(root.reviewer, "reviewer");
   exact(reviewer, ["task", "environment_class", "harness_schema", "events", "outcomes", "rewards", "evidence"], "reviewer");
-  if (reviewer.environment_class !== "docker") throw new Error('reviewer.environment_class must be "docker"');
+  const environmentClass = text(reviewer.environment_class, "reviewer.environment_class", 32);
+  if (!REVIEWER_ENVIRONMENT_CLASSES.has(environmentClass)) {
+    throw new Error('reviewer.environment_class must be "docker" or "isolated-sandbox"');
+  }
   if (reviewer.harness_schema !== "harbor/pi-jsonl@0.18.0") throw new Error("reviewer.harness_schema is unsupported");
   const task = rec(reviewer.task, "reviewer.task");
   exact(task, ["id", "revision", "privacy_class", "prompt"], "reviewer.task");
   text(task.id, "reviewer.task.id", 200);
-  text(task.revision, "reviewer.task.revision", 200);
+  const taskRevision = text(task.revision, "reviewer.task.revision", 200);
   const privacy = text(task.privacy_class, "reviewer.task.privacy_class", 30);
   if (!PRIVACY.has(privacy)) throw new Error("reviewer.task.privacy_class is unsupported");
   const taskPrompt = sanitizeString(text(task.prompt, "reviewer.task.prompt"));
@@ -391,7 +397,7 @@ export async function parseHarborEvidenceV1(raw: unknown): Promise<ParsedHarborE
 
   const hiddenProvenance = [
     ...Object.values(harness).filter((item): item is string => typeof item === "string"),
-    reviewer.environment_class,
+    environmentClass,
     reviewer.harness_schema,
     rawReference.path,
     ...collectPrivateStrings(analysis),
@@ -637,6 +643,7 @@ export async function parseHarborEvidenceV1(raw: unknown): Promise<ParsedHarborE
     run: { stableId, attempt, status: runStatus as ParsedHarborEvidence["run"]["status"] },
     trace,
     projection: safeProjection,
+    trainingTaskHash: await sha256Text(stableStringify({ prompt: safeProjection.taskPrompt, revision: taskRevision })),
     objective: {
       process: { status: topOutcomes.process },
       verifier: { status: topOutcomes.verifier },

--- a/src/routes/orgs/projects/CanonicalReviewJourney.ct.spec.tsx
+++ b/src/routes/orgs/projects/CanonicalReviewJourney.ct.spec.tsx
@@ -58,6 +58,9 @@ test("create review, judge blind, inspect result, and reuse evidence", async ({ 
   await expect(component).toContainText("support · pi · claude-sonnet");
   await component.getByRole("button", { name: "Add approved runs to regression set" }).click();
   await expect(component).toContainText("1 added to the regression set");
+  await expect(component.getByRole("button", { name: "Export approved SFT" })).toBeDisabled();
+  await component.getByRole("button", { name: "Approve for training" }).click();
+  await expect(component).toContainText("Training approval granted for 1 eligible run");
 
   await component.update(
     <MemoryRouter initialEntries={[`/orgs/demo/projects/${projectId}/results`]}>

--- a/src/routes/orgs/projects/ComparisonCampaignDetail.tsx
+++ b/src/routes/orgs/projects/ComparisonCampaignDetail.tsx
@@ -28,6 +28,9 @@ export function ComparisonCampaignDetail() {
   // SAFETY: Convex validates the route value as a table ID at the RPC boundary.
   const id = campaignId as Id<"comparisonCampaigns">;
   const campaign = useQuery(api.comparisonCampaigns.getOwnerCampaign, { campaignId: id });
+  const trainingApproval = useQuery(api.trainingApprovals.getForComparisonCampaign, { campaignId: id });
+  const approveTraining = useAction(api.trainingApprovals.approveComparisonCampaign);
+  const revokeTraining = useMutation(api.trainingApprovals.revoke);
   const openCampaign = useMutation(api.comparisonCampaigns.openCampaign);
   const closeCampaign = useMutation(api.comparisonCampaigns.closeCampaign);
   const generateExport = useAction(api.exports.generateExport);
@@ -68,7 +71,41 @@ export function ComparisonCampaignDetail() {
     }
   }
 
+  async function approveForTraining() {
+    setBusy(true);
+    setError("");
+    setReuseMessage("");
+    try {
+      const result = await approveTraining({ campaignId: id });
+      setReuseMessage(`Training approval granted for ${result.eligibleCount} comparable pair${result.eligibleCount === 1 ? "" : "s"}; ${result.excludedCount} excluded.`);
+    } catch (cause: unknown) {
+      setError(friendlyError(cause, "Could not grant training approval for this comparison."));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function revokeTrainingApproval() {
+    const approvalId = trainingApproval?.approval?.id;
+    if (approvalId === undefined || !window.confirm("Revoke training approval? Future exports and downloads from this approval will be blocked.")) return;
+    setBusy(true);
+    setError("");
+    try {
+      await revokeTraining({ approvalId });
+      setReuseMessage("Training approval revoked. Future exports and downloads are blocked.");
+    } catch (cause: unknown) {
+      setError(friendlyError(cause, "Could not revoke this training approval."));
+    } finally {
+      setBusy(false);
+    }
+  }
+
   async function download() {
+    const approvalId = trainingApproval?.approval?.status === "active" ? trainingApproval.approval.id : undefined;
+    if (approvalId === undefined) {
+      setError("Grant a separate training approval before exporting DPO data.");
+      return;
+    }
     setBusy(true);
     setError("");
     setReuseMessage("");
@@ -76,6 +113,7 @@ export function ComparisonCampaignDetail() {
       const data = await generateExport({
         projectId,
         campaignId: id,
+        trainingApprovalId: approvalId,
         source: "trajectory",
         format: "dpo",
       });
@@ -83,12 +121,12 @@ export function ComparisonCampaignDetail() {
         setReuseMessage(`No DPO rows were eligible. ${data.excludedCount} pairs were explicitly excluded for ties, disagreement, or comparability.`);
         return;
       }
-      const { url } = await downloadExport({ exportId: data.exportId });
+      const { url, manifestUrl } = await downloadExport({ exportId: data.exportId });
       const anchor = document.createElement("a");
       anchor.href = url;
       anchor.download = `${currentCampaign.name.replace(/[^a-z0-9]+/gi, "-").toLowerCase()}-dpo.jsonl`;
       anchor.click();
-      setReuseMessage(`${data.rowCount} DPO rows ready; ${data.excludedCount} excluded.`);
+      setReuseMessage(`${data.rowCount} DPO rows ready; ${data.excludedCount} excluded. Keep the manifest with the JSONL: ${manifestUrl}`);
     } catch (cause: unknown) {
       setError(friendlyError(cause, "Could not export this comparison."));
     } finally {
@@ -152,9 +190,14 @@ export function ComparisonCampaignDetail() {
           <CardContent className="space-y-3">
             <div className="flex flex-wrap gap-2">
               <Button variant="outline" onClick={() => void copyEvidence()}><ClipboardCopy className="h-4 w-4" /> Copy evidence summary</Button>
-              <Button variant="outline" onClick={() => void download()} disabled={busy || currentCampaign.results.judgments === 0}><Download className="h-4 w-4" /> Export eligible DPO</Button>
+              {trainingApproval?.approval?.status === "active" ? (
+                <Button variant="outline" onClick={() => void revokeTrainingApproval()} disabled={busy || !trainingApproval.canApprove}>Revoke training approval</Button>
+              ) : (
+                <Button variant="outline" onClick={() => void approveForTraining()} disabled={busy || currentCampaign.results.judgments === 0 || !trainingApproval?.canApprove}>Approve for training</Button>
+              )}
+              <Button variant="outline" onClick={() => void download()} disabled={busy || trainingApproval?.approval?.status !== "active"}><Download className="h-4 w-4" /> Export eligible DPO</Button>
             </div>
-            <p className="text-xs text-muted-foreground">DPO includes only directional choices with a verified shared prefix. Ties, neither, cannot-judge, disagreement, and prefix mismatch are reported as exclusions.</p>
+            <p className="text-xs text-muted-foreground">A positive preference is not training consent. An owner must separately approve this closed result. DPO then includes only quality-eligible full-span pairs with a verified shared prefix and reviewer-safe next actions; ties, disagreement, private data, hidden reasoning, and prefix mismatch are explicit exclusions.</p>
             {reuseMessage && <p className="text-sm text-muted-foreground" role="status">{reuseMessage}</p>}
           </CardContent>
         </Card>

--- a/src/routes/orgs/projects/ExportTraining.ct.spec.tsx
+++ b/src/routes/orgs/projects/ExportTraining.ct.spec.tsx
@@ -1,0 +1,18 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+import type { Id } from "../../../../convex/_generated/dataModel";
+import { ProjectProvider } from "@/contexts/ProjectContext";
+import { ExportTraining } from "./ExportTraining";
+
+const projectId = "test-project" as Id<"projects">;
+const projectValue = {
+  project: { _id: projectId, _creationTime: 1, organizationId: "org-1" as Id<"organizations">, name: "Synthetic", createdById: "owner-1" as Id<"users"> },
+  projectId,
+  role: "owner" as const,
+  blindMode: undefined,
+};
+
+test("recent export list marks revoked and legacy-unapproved artifacts unavailable", async ({ mount }) => {
+  const component = await mount(<ProjectProvider value={projectValue}><ExportTraining /></ProjectProvider>);
+  await expect(component.getByRole("button", { name: "Revoked" })).toBeDisabled();
+  await expect(component.getByRole("button", { name: "Unavailable" })).toBeDisabled();
+});

--- a/src/routes/orgs/projects/ExportTraining.tsx
+++ b/src/routes/orgs/projects/ExportTraining.tsx
@@ -427,6 +427,14 @@ function RecentExportRow({
 
   const sourceLabel = SOURCE_LABELS[row.source as Source] ?? row.source;
   const formatLabel = FORMAT_LABELS[row.format as Format] ?? row.format.toUpperCase();
+  const unavailable = row.availability !== "available";
+  const availabilityLabel = row.availability === "revoked"
+    ? "Revoked"
+    : row.availability === "legacy_unapproved"
+      ? "Unavailable"
+      : row.availability === "expired"
+        ? "Expired"
+        : "Download";
 
   return (
     <div className="flex flex-wrap items-center justify-between gap-3 px-4 py-3">
@@ -450,11 +458,11 @@ function RecentExportRow({
         variant="outline"
         size="sm"
         onClick={handleDownload}
-        disabled={row.expired || busy}
-        className={cn(row.expired && "text-muted-foreground")}
+        disabled={unavailable || busy}
+        className={cn(unavailable && "text-muted-foreground")}
       >
         <Download aria-hidden="true" className="h-3.5 w-3.5" />
-        {row.expired ? "Expired" : busy ? "Preparing…" : "Download"}
+        {busy ? "Preparing…" : availabilityLabel}
       </Button>
     </div>
   );

--- a/src/routes/orgs/projects/VerdictReviewDetail.tsx
+++ b/src/routes/orgs/projects/VerdictReviewDetail.tsx
@@ -22,6 +22,9 @@ export function VerdictReviewDetail() {
   const campaign = useQuery(api.verdictReviewCampaigns.getOwnerCampaign, {
     campaignId: id,
   });
+  const trainingApproval = useQuery(api.trainingApprovals.getForVerdictCampaign, { campaignId: id });
+  const approveTraining = useAction(api.trainingApprovals.approveVerdictCampaign);
+  const revokeTraining = useMutation(api.trainingApprovals.revoke);
   const openCampaign = useMutation(api.verdictReviewCampaigns.openCampaign);
   const closeCampaign = useMutation(api.verdictReviewCampaigns.closeCampaign);
   const promoteRuns = useMutation(api.verdictReviewCampaigns.promoteAcceptedRuns);
@@ -79,7 +82,41 @@ export function VerdictReviewDetail() {
     }
   }
 
+  async function approveForTraining() {
+    setBusy(true);
+    setError("");
+    setReuseMessage("");
+    try {
+      const result = await approveTraining({ campaignId: id });
+      setReuseMessage(`Training approval granted for ${result.eligibleCount} eligible run${result.eligibleCount === 1 ? "" : "s"}; ${result.excludedCount} excluded.`);
+    } catch (cause: unknown) {
+      setError(friendlyError(cause, "Could not grant training approval for this review."));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function revokeTrainingApproval() {
+    const approvalId = trainingApproval?.approval?.id;
+    if (approvalId === undefined || !window.confirm("Revoke training approval? Future exports and downloads from this approval will be blocked.")) return;
+    setBusy(true);
+    setError("");
+    try {
+      await revokeTraining({ approvalId });
+      setReuseMessage("Training approval revoked. Future exports and downloads are blocked.");
+    } catch (cause: unknown) {
+      setError(friendlyError(cause, "Could not revoke this training approval."));
+    } finally {
+      setBusy(false);
+    }
+  }
+
   async function exportSft() {
+    const approvalId = trainingApproval?.approval?.status === "active" ? trainingApproval.approval.id : undefined;
+    if (approvalId === undefined) {
+      setError("Grant a separate training approval before exporting SFT data.");
+      return;
+    }
     setBusy(true);
     setError("");
     setReuseMessage("");
@@ -87,6 +124,7 @@ export function VerdictReviewDetail() {
       const result = await generateExport({
         projectId,
         verdictCampaignId: id,
+        trainingApprovalId: approvalId,
         source: "trajectory",
         format: "sft",
       });
@@ -94,9 +132,9 @@ export function VerdictReviewDetail() {
         setReuseMessage(`No SFT rows were eligible. ${result.excludedCount} runs were explicitly excluded by review or data-boundary gates.`);
         return;
       }
-      const { url } = await downloadExport({ exportId: result.exportId });
+      const { url, manifestUrl } = await downloadExport({ exportId: result.exportId });
       window.open(url, "_blank", "noopener,noreferrer");
-      setReuseMessage(`${result.rowCount} approved SFT rows ready; ${result.excludedCount} excluded.`);
+      setReuseMessage(`${result.rowCount} approved SFT rows ready; ${result.excludedCount} excluded. Keep the manifest with the JSONL: ${manifestUrl}`);
     } catch (cause: unknown) {
       setError(friendlyError(cause, "Could not export approved runs."));
     } finally {
@@ -172,10 +210,15 @@ export function VerdictReviewDetail() {
             <div className="flex flex-wrap gap-2">
               <Button variant="outline" onClick={() => void copyEvidence()} disabled={busy}><ClipboardCopy className="h-4 w-4" /> Copy evidence summary</Button>
               <Button variant="outline" onClick={() => void promote()} disabled={busy || currentCampaign.results.judgments === 0}><Database className="h-4 w-4" /> Add approved runs to regression set</Button>
-              <Button variant="outline" onClick={() => void exportSft()} disabled={busy || currentCampaign.results.judgments === 0}><Download className="h-4 w-4" /> Export approved SFT</Button>
+              {trainingApproval?.approval?.status === "active" ? (
+                <Button variant="outline" onClick={() => void revokeTrainingApproval()} disabled={busy || !trainingApproval.canApprove}>Revoke training approval</Button>
+              ) : (
+                <Button variant="outline" onClick={() => void approveForTraining()} disabled={busy || currentCampaign.results.judgments === 0 || !trainingApproval?.canApprove}>Approve for training</Button>
+              )}
+              <Button variant="outline" onClick={() => void exportSft()} disabled={busy || trainingApproval?.approval?.status !== "active"}><Download className="h-4 w-4" /> Export approved SFT</Button>
             </div>
             <p className="text-xs text-muted-foreground">
-              Regression promotion uses majority non-weak verdicts. SFT requires at least one Strong verdict and excludes any run with a Weak verdict; every exclusion is reported.
+              Review verdicts and objective quality eligibility do not grant training use. An owner must separately approve this closed result. SFT then includes only immutable reviewer-safe full-span evidence with a Strong verdict, and revocation blocks later export/download.
             </p>
             {reuseMessage && <p className="text-sm text-muted-foreground" role="status">{reuseMessage}</p>}
           </CardContent>

--- a/src/routes/traces/__smoke__/convexReactMock.tsx
+++ b/src/routes/traces/__smoke__/convexReactMock.tsx
@@ -38,6 +38,7 @@ const noopMutation = async () => undefined;
 const createVerdictReview = async () => "verdict-review-test";
 const joinVerdictReview = async () => ({ sessionToken: "opaque-verdict-session" });
 const promoteAcceptedRuns = async () => ({ added: 1, alreadyPresent: 0, excluded: 0 });
+const approveTraining = async () => ({ approvalId: "approval-test", eligibleCount: 1, excludedCount: 0 });
 const createImportProject = async () => ({ orgSlug: "test-org", projectId: "test-project" });
 const PAGINATED = {
   results: FIXTURE_STEPS,
@@ -55,7 +56,8 @@ export function useAction(action?: unknown) {
     const name = getFunctionName(action as never);
     if (name === "comparisonCampaigns:importPairedCsv") return importPairedComparison;
     if (name === "exports:generateExport") return async () => ({ exportId: "export-1", rowCount: 1, excludedCount: 0, manifest: {} });
-    if (name === "exports:downloadExport") return async () => ({ url: "data:application/json,fixture" });
+    if (name === "exports:downloadExport") return async () => ({ url: "data:application/json,fixture", manifestUrl: "data:application/json,manifest" });
+    if (name === "trainingApprovals:approveVerdictCampaign" || name === "trainingApprovals:approveComparisonCampaign") return approveTraining;
   } catch {
     // Keep unrelated component-test actions on the stable body fixture.
   }
@@ -235,8 +237,16 @@ export function useQuery(query: unknown) {
         return FIXTURE_OWNER_VERDICT_REVIEW;
       case "verdictReviewCampaigns:getReview":
         return FIXTURE_REVIEW_DECK;
+      case "trainingApprovals:getForVerdictCampaign":
+      case "trainingApprovals:getForComparisonCampaign":
+        return { canApprove: true, approval: null };
       case "comparisonCampaigns:listCampaigns":
         return FIXTURE_COMPARISON_REVIEWS;
+      case "exports:listExports":
+        return [
+          { _id: "export-revoked", source: "trajectory", format: "sft", rowCount: 1, excludedCount: 0, manifest: null, createdAt: 2, expired: false, availability: "revoked" },
+          { _id: "export-legacy", source: "trajectory", format: "dpo", rowCount: 1, excludedCount: 0, manifest: null, createdAt: 1, expired: false, availability: "legacy_unapproved" },
+        ];
       case "ingestTokens:listIngestTokens":
         return [];
       case "agentTraces:getTrace":


### PR DESCRIPTION
Closes #287

## Summary

- add a separate owner-only, revocable training approval after closed full-span verdict/comparison reviews
- keep quality eligibility and positive human judgment insufficient until explicit training approval
- snapshot exact reviewer-safe projection storage references, SHA-256 bytes, task hashes, DPO winner/divergence/shared-prefix evidence, and reviewer counts
- generate Fireworks-compatible messages-only SFT JSONL and same-task/shared-prefix DPO only
- exclude hidden reasoning, verifier outcomes/rewards, post-agent workspace/policy/lifecycle events, provider/model/harness provenance, sensitive data, canaries, and opaque call IDs
- atomically revalidate approval/project/campaign/format when recording an export
- delete partial blobs on failure and all approval-bound blobs on revocation, invalidating pre-issued URLs
- enforce conservative candidate/projection/row/JSONL/manifest/export-count limits
- add aggregate-only v2 manifests with exact row/dataset hashes, exclusions, reconciliation, and explicit zero-row DPO state
- expose authenticated approve → export → revoke controls; guest review remains blinded and cannot approve/export
- accept the provider-neutral Daytona environment contract through a byte-identical Mogil producer fixture

## Verification

- `npm run test:evals` — 219 passed
- `npm run test:convex` — 336 passed
- `npm run test:ct` — 19 passed
- `npm run build` — passed
- `git diff --check` — passed
- producer/consumer Daytona fixture `cmp` — identical
- changed-file secret scan — clean

## Data and execution boundaries

- no Fireworks API call or training job
- no production review approval/export
- no customer, Pennie, or Migo data
- no raw trace/run/user IDs in manifests
- JSONL bytes are deterministic for a snapshot; manifest `generated_at` is intentionally generation-specific
