### PR TITLE
fix: stage full-span task hash migration

### DIFF
--- a/convex/exports.ts
+++ b/convex/exports.ts
@@ -24,6 +24,7 @@ import type { Doc, Id } from "./_generated/dataModel";
 import { requireProjectRole } from "./lib/auth";
 import { readMessages } from "./lib/messages";
 import {
+  deriveTrainingTaskHash,
   parseHarborReviewerProjection,
   type HarborReviewerProjection,
 } from "../src/lib/evals/harborEvidence";
@@ -611,14 +612,17 @@ async function hydrateApprovedPlan(
   plan: ReadonlyArray<ApprovedPlanRow>,
 ): Promise<{ rows: ClassifiedRow[]; excluded: ExcludedRow[] }> {
   if (trainingExportSizeViolation({ candidates: plan.length })) throw new Error("Approved candidate count exceeds the export limit.");
-  const readProjection = async (storageId: Id<"_storage">, expectedSha256: string): Promise<HarborReviewerProjection> => {
+  const readProjection = async (storageId: Id<"_storage">, expectedSha256: string, expectedTaskHash: string): Promise<HarborReviewerProjection> => {
     const blob = await ctx.storage.get(storageId);
     if (!blob) throw new Error("Approved reviewer projection is unavailable.");
     if (trainingExportSizeViolation({ projectionBytes: blob.size })) throw new Error("Approved reviewer projection exceeds the byte limit.");
     const bytes = await blob.arrayBuffer();
     if (await sha256Buffer(bytes) !== expectedSha256) throw new Error("Approved reviewer projection hash mismatch.");
     const raw: unknown = JSON.parse(new TextDecoder().decode(bytes));
-    return parseHarborReviewerProjection(raw);
+    const projection = parseHarborReviewerProjection(raw);
+    if (!projection.taskRevision) throw new Error("Approved reviewer projection lacks its task revision.");
+    if (await deriveTrainingTaskHash(projection.taskPrompt, projection.taskRevision) !== expectedTaskHash) throw new Error("Approved reviewer projection task hash mismatch.");
+    return projection;
   };
   const rows: ClassifiedRow[] = [];
   const excluded: ExcludedRow[] = [];
@@ -637,7 +641,7 @@ async function hydrateApprovedPlan(
       continue;
     }
     if (candidate.format === "sft") {
-      const projection = await readProjection(candidate.projectionStorageId, candidate.projectionSha256);
+      const projection = await readProjection(candidate.projectionStorageId, candidate.projectionSha256, candidate.taskHash);
       appendBounded({
         privacyClass: candidate.privacyClass,
         row: { kind: "sft", messages: [
@@ -648,8 +652,8 @@ async function hydrateApprovedPlan(
       continue;
     }
     const [left, right] = await Promise.all([
-      readProjection(candidate.leftProjectionStorageId, candidate.leftProjectionSha256),
-      readProjection(candidate.rightProjectionStorageId, candidate.rightProjectionSha256),
+      readProjection(candidate.leftProjectionStorageId, candidate.leftProjectionSha256, candidate.taskHash),
+      readProjection(candidate.rightProjectionStorageId, candidate.rightProjectionSha256, candidate.taskHash),
     ]);
     const leftSteps = left.events.filter((event) => event.kind !== "final_output" && event.kind !== "termination");
     const rightSteps = right.events.filter((event) => event.kind !== "final_output" && event.kind !== "termination");

--- a/convex/lib/trainingExport.ts
+++ b/convex/lib/trainingExport.ts
@@ -120,6 +120,7 @@ export interface ExcludedRow {
     | "hidden_reasoning"
     | "post_hoc_or_non_observable"
     | "task_mismatch"
+    | "invalid_task_hash"
     | "canary_or_private_leak";
   privacyClass: PrivacyClass;
 }

--- a/convex/migrations/backfillFullSpanTrainingTaskHash.ts
+++ b/convex/migrations/backfillFullSpanTrainingTaskHash.ts
@@ -1,0 +1,171 @@
+/** Transitional, bounded backfill for #356 full-span training task hashes. */
+import { paginationOptsValidator } from "convex/server";
+import { v } from "convex/values";
+import { action, internalAction, internalMutation, internalQuery, type ActionCtx } from "../_generated/server";
+import { internal } from "../_generated/api";
+import type { Id } from "../_generated/dataModel";
+import { deriveTrainingTaskHash, parseHarborReviewerProjection } from "../lib/harborEvidence";
+import { requireProjectRole } from "../lib/auth";
+import { TRAINING_EXPORT_LIMITS } from "../lib/trainingExport";
+
+const MAX_BATCH_SIZE = 100;
+const SHA256 = /^[0-9a-f]{64}$/;
+type Issue =
+  | "missing_projection"
+  | "projection_unavailable"
+  | "projection_oversized"
+  | "malformed_projection"
+  | "missing_task_revision"
+  | "invalid_existing_hash"
+  | "changed_during_backfill";
+
+type Report = {
+  readonly scanned: number;
+  readonly patched: number;
+  readonly wouldPatch: number;
+  readonly alreadyValid: number;
+  readonly issues: ReadonlyArray<{ readonly stableRunId: string; readonly reason: Issue }>;
+  readonly continueCursor: string;
+  readonly isDone: boolean;
+  readonly dryRun: boolean;
+};
+
+/** Authorize one project owner before privileged migration internals run. */
+export const authorizeProjectOwner = internalQuery({
+  args: { projectId: v.id("projects") },
+  handler: async (ctx, args): Promise<void> => {
+    await requireProjectRole(ctx, args.projectId, ["owner"]);
+  },
+});
+
+/** Read one cursor-bounded project page; projection bytes remain in storage. */
+export const listProjectBatch = internalQuery({
+  args: { projectId: v.id("projects"), paginationOpts: paginationOptsValidator },
+  handler: async (ctx, args) => await ctx.db
+    .query("fullSpanEvalRuns")
+    .withIndex("by_project", (q) => q.eq("projectId", args.projectId))
+    .paginate(args.paginationOpts),
+});
+
+/** Patch only the exact still-unhashed row/projection observed by the action. */
+export const patchIfUnchanged = internalMutation({
+  args: {
+    fullSpanRunId: v.id("fullSpanEvalRuns"),
+    expectedProjectionStorageId: v.id("_storage"),
+    trainingTaskHash: v.string(),
+  },
+  handler: async (ctx, args): Promise<"patched" | "already_valid" | "changed"> => {
+    if (!SHA256.test(args.trainingTaskHash)) throw new Error("Derived training task hash is invalid.");
+    const row = await ctx.db.get(args.fullSpanRunId);
+    if (!row || row.reviewerProjectionStorageId !== args.expectedProjectionStorageId) return "changed";
+    if (row.trainingTaskHash === args.trainingTaskHash) return "already_valid";
+    if (row.trainingTaskHash !== undefined) return "changed";
+    await ctx.db.patch(row._id, { trainingTaskHash: args.trainingTaskHash });
+    return "patched";
+  },
+});
+
+type BackfillArgs = {
+  readonly projectId: Id<"projects">;
+  readonly dryRun: boolean;
+  readonly cursor?: string;
+  readonly batchSize?: number;
+};
+
+async function runBatch(ctx: ActionCtx, args: BackfillArgs): Promise<Report> {
+  const batchSize = args.batchSize ?? 25;
+  if (!Number.isSafeInteger(batchSize) || batchSize < 1 || batchSize > MAX_BATCH_SIZE) {
+    throw new Error(`Backfill batchSize must be an integer from 1 to ${MAX_BATCH_SIZE}.`);
+  }
+  const page = await ctx.runQuery(internal.migrations.backfillFullSpanTrainingTaskHash.listProjectBatch, {
+    projectId: args.projectId,
+    paginationOpts: { cursor: args.cursor ?? null, numItems: batchSize },
+  });
+  let patched = 0;
+  let wouldPatch = 0;
+  let alreadyValid = 0;
+  const issues: Array<{ stableRunId: string; reason: Issue }> = [];
+
+  for (const row of page.page) {
+    const projectionStorageId = row.reviewerProjectionStorageId;
+    if (!projectionStorageId) {
+      issues.push({ stableRunId: row.stableRunId, reason: "missing_projection" });
+      continue;
+    }
+    const blob = await ctx.storage.get(projectionStorageId);
+    if (!blob) {
+      issues.push({ stableRunId: row.stableRunId, reason: "projection_unavailable" });
+      continue;
+    }
+    if (blob.size > TRAINING_EXPORT_LIMITS.maxProjectionBytes) {
+      issues.push({ stableRunId: row.stableRunId, reason: "projection_oversized" });
+      continue;
+    }
+    let projection: ReturnType<typeof parseHarborReviewerProjection>;
+    try {
+      const raw: unknown = JSON.parse(await blob.text());
+      projection = parseHarborReviewerProjection(raw);
+    } catch {
+      issues.push({ stableRunId: row.stableRunId, reason: "malformed_projection" });
+      continue;
+    }
+    if (!projection.taskRevision) {
+      issues.push({ stableRunId: row.stableRunId, reason: "missing_task_revision" });
+      continue;
+    }
+    const derived = await deriveTrainingTaskHash(projection.taskPrompt, projection.taskRevision);
+    if (row.trainingTaskHash !== undefined) {
+      if (row.trainingTaskHash === derived) alreadyValid++;
+      else issues.push({ stableRunId: row.stableRunId, reason: "invalid_existing_hash" });
+      continue;
+    }
+    if (args.dryRun) {
+      wouldPatch++;
+      continue;
+    }
+    const outcome = await ctx.runMutation(internal.migrations.backfillFullSpanTrainingTaskHash.patchIfUnchanged, {
+      fullSpanRunId: row._id,
+      expectedProjectionStorageId: projectionStorageId,
+      trainingTaskHash: derived,
+    });
+    if (outcome === "patched") patched++;
+    else if (outcome === "already_valid") alreadyValid++;
+    else issues.push({ stableRunId: row.stableRunId, reason: "changed_during_backfill" });
+  }
+
+  return {
+    scanned: page.page.length,
+    patched,
+    wouldPatch,
+    alreadyValid,
+    issues,
+    continueCursor: page.continueCursor,
+    isDone: page.isDone,
+    dryRun: args.dryRun,
+  };
+}
+
+const BACKFILL_ARGS = {
+  projectId: v.id("projects"),
+  dryRun: v.boolean(),
+  cursor: v.optional(v.string()),
+  batchSize: v.optional(v.number()),
+};
+
+/**
+ * Owner-only dry-run/apply entry point. Processes at most 100 rows and returns a
+ * cursor plus aggregate/content-safe issue report. It never reads raw evidence.
+ */
+export const backfillProjectBatch = action({
+  args: BACKFILL_ARGS,
+  handler: async (ctx, args): Promise<Report> => {
+    await ctx.runQuery(internal.migrations.backfillFullSpanTrainingTaskHash.authorizeProjectOwner, { projectId: args.projectId });
+    return await runBatch(ctx, args);
+  },
+});
+
+/** Privileged CLI entry point with the same bounded, dry-run-capable contract. */
+export const backfillProjectBatchInternal = internalAction({
+  args: BACKFILL_ARGS,
+  handler: runBatch,
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -836,7 +836,9 @@ const schema = defineSchema({
     stableRunId: v.string(),
     attempt: v.string(),
     fingerprint: v.string(),
-    trainingTaskHash: v.string(),
+    // Transitional rollout: legacy #354 rows omit this. Approval/export fail
+    // closed until the reviewer-safe projection hash has been backfilled.
+    trainingTaskHash: v.optional(v.string()),
     status: v.union(
       v.literal("pending"),
       v.literal("staged"),
@@ -1202,6 +1204,7 @@ const schema = defineSchema({
       v.literal("non_comparable_prefix"),
       v.literal("no_preference"),
       v.literal("task_mismatch"),
+      v.literal("invalid_task_hash"),
     )),
   }).index("by_approval_and_order", ["approvalId", "sortOrder"]),
 

--- a/convex/tests/fullSpanTrainingExport.test.ts
+++ b/convex/tests/fullSpanTrainingExport.test.ts
@@ -7,6 +7,7 @@ import type { Id } from "../_generated/dataModel";
 import schema from "../schema";
 import isolatedSandboxFixture from "./fixtures/daytona-reviewer-contract.json";
 import { TRAINING_EXPORT_LIMITS, verifyApprovedExportArtifact } from "../lib/trainingExport";
+import { deriveTrainingTaskHash } from "../lib/harborEvidence";
 
 const fixture = JSON.parse(readFileSync(new URL("./fixtures/mogil-harbor-evidence-v1.json", import.meta.url), "utf8")) as unknown;
 const headers = (token: string) => ({ authorization: `Bearer ${token}`, "content-type": "application/json" });
@@ -70,6 +71,97 @@ async function exportText(t: ReturnType<typeof convexTest>, exportId: Id<"traini
 }
 
 describe("#287 approved full-span training export", () => {
+  test("legacy rows without a task hash remain readable but approval fails closed before backfill", async () => {
+    const { t, owner, campaignId } = await setup();
+    const legacy = await t.run(async (ctx) => {
+      const span = await ctx.db.query("fullSpanEvalRuns").unique();
+      if (!span) throw new Error("span missing");
+      await ctx.db.patch(span._id, { trainingTaskHash: undefined });
+      return await ctx.db.get(span._id);
+    });
+    expect(legacy?.trainingTaskHash).toBeUndefined();
+    await expect(owner.action(api.trainingApprovals.approveVerdictCampaign, { campaignId })).rejects.toThrow(/no quality-eligible/i);
+  });
+
+  test("owner backfill is dry-runnable, exact, bounded, and idempotent", async () => {
+    const { t, owner, guest, ids } = await setup();
+    await t.run(async (ctx) => {
+      const span = await ctx.db.query("fullSpanEvalRuns").unique();
+      if (!span) throw new Error("span missing");
+      await ctx.db.patch(span._id, { trainingTaskHash: undefined });
+    });
+    const dryRun = await owner.action(api.migrations.backfillFullSpanTrainingTaskHash.backfillProjectBatch, {
+      projectId: ids.projectId, dryRun: true, batchSize: 1,
+    });
+    expect(dryRun).toMatchObject({ scanned: 1, patched: 0, wouldPatch: 1, alreadyValid: 0, issues: [], isDone: true, dryRun: true });
+    expect((await t.run(async (ctx) => await ctx.db.query("fullSpanEvalRuns").unique()))?.trainingTaskHash).toBeUndefined();
+
+    const applied = await owner.action(api.migrations.backfillFullSpanTrainingTaskHash.backfillProjectBatch, {
+      projectId: ids.projectId, dryRun: false, batchSize: 1,
+    });
+    expect(applied).toMatchObject({ scanned: 1, patched: 1, wouldPatch: 0, alreadyValid: 0, issues: [], isDone: true, dryRun: false });
+    const expected = await deriveTrainingTaskHash("Fix fictional widget arithmetic.", "1");
+    expect((await t.run(async (ctx) => await ctx.db.query("fullSpanEvalRuns").unique()))?.trainingTaskHash).toBe(expected);
+
+    const replay = await owner.action(api.migrations.backfillFullSpanTrainingTaskHash.backfillProjectBatch, {
+      projectId: ids.projectId, dryRun: false, batchSize: 1,
+    });
+    expect(replay).toMatchObject({ scanned: 1, patched: 0, wouldPatch: 0, alreadyValid: 1, issues: [], isDone: true });
+    await expect(t.action(internal.migrations.backfillFullSpanTrainingTaskHash.backfillProjectBatchInternal, {
+      projectId: ids.projectId, dryRun: true, batchSize: 1,
+    })).resolves.toMatchObject({ scanned: 1, alreadyValid: 1, issues: [], isDone: true });
+    await expect(owner.action(api.migrations.backfillFullSpanTrainingTaskHash.backfillProjectBatch, {
+      projectId: ids.projectId, dryRun: true, batchSize: 101,
+    })).rejects.toThrow(/1 to 100/i);
+    await expect(guest.action(api.migrations.backfillFullSpanTrainingTaskHash.backfillProjectBatch, {
+      projectId: ids.projectId, dryRun: true, batchSize: 1,
+    })).rejects.toThrow(/permission denied/i);
+  });
+
+  test.each([
+    ["missing projection", "missing_projection"],
+    ["missing blob", "projection_unavailable"],
+    ["malformed projection", "malformed_projection"],
+    ["legacy projection without revision", "missing_task_revision"],
+    ["invalid existing hash", "invalid_existing_hash"],
+  ] as const)("backfill reports %s without patching", async (scenario, reason) => {
+    const { t, owner, ids } = await setup();
+    await t.run(async (ctx) => {
+      const span = await ctx.db.query("fullSpanEvalRuns").unique();
+      if (!span) throw new Error("span missing");
+      if (scenario === "missing projection") {
+        await ctx.db.patch(span._id, { trainingTaskHash: undefined, reviewerProjectionStorageId: undefined });
+        return;
+      }
+      if (scenario === "missing blob") {
+        const storageId = span.reviewerProjectionStorageId;
+        if (!storageId) throw new Error("projection missing");
+        await ctx.storage.delete(storageId);
+        await ctx.db.patch(span._id, { trainingTaskHash: undefined });
+        return;
+      }
+      if (scenario === "malformed projection") {
+        const storageId = await ctx.storage.store(new Blob(["not-json"]));
+        await ctx.db.patch(span._id, { trainingTaskHash: undefined, reviewerProjectionStorageId: storageId });
+        return;
+      }
+      if (scenario === "invalid existing hash") {
+        await ctx.db.patch(span._id, { trainingTaskHash: "0".repeat(64) });
+        return;
+      }
+      const prior = span.reviewerProjectionStorageId ? await ctx.storage.get(span.reviewerProjectionStorageId) : null;
+      if (!prior) throw new Error("projection missing");
+      const projection = JSON.parse(await prior.text()) as Record<string, unknown>;
+      delete projection.taskRevision;
+      const storageId = await ctx.storage.store(new Blob([JSON.stringify(projection)]));
+      await ctx.db.patch(span._id, { trainingTaskHash: undefined, reviewerProjectionStorageId: storageId });
+    });
+    const report = await owner.action(api.migrations.backfillFullSpanTrainingTaskHash.backfillProjectBatch, {
+      projectId: ids.projectId, dryRun: false, batchSize: 1,
+    });
+    expect(report).toMatchObject({ scanned: 1, patched: 0, wouldPatch: 0, alreadyValid: 0, issues: [{ reason }] });
+  });
+
   test("quality eligibility and a positive verdict remain denied until owner approval; revocation denies later export", async () => {
     const { owner, guest, ids, campaignId } = await setup();
     await expect(guest.action(api.trainingApprovals.approveVerdictCampaign, { campaignId })).rejects.toThrow(/Permission denied/);
@@ -220,6 +312,19 @@ describe("#287 approved full-span training export", () => {
     await expect(owner.action(api.exports.generateExport, { projectId: ids.projectId, verdictCampaignId: campaignId, trainingApprovalId: approval.approvalId, source: "trajectory", format: "sft" })).rejects.toThrow(/hash mismatch/i);
   });
 
+  test.each([undefined, "0".repeat(64)])("generation rejects approval snapshots with a missing or unvalidated task hash", async (taskHash) => {
+    const { t, owner, ids, campaignId } = await setup();
+    const approval = await owner.action(api.trainingApprovals.approveVerdictCampaign, { campaignId });
+    await t.run(async (ctx) => {
+      const item = await ctx.db.query("trainingApprovalItems").withIndex("by_approval_and_order", (q) => q.eq("approvalId", approval.approvalId)).unique();
+      if (!item) throw new Error("approval item missing");
+      await ctx.db.patch(item._id, { taskHash });
+    });
+    await expect(owner.action(api.exports.generateExport, {
+      projectId: ids.projectId, verdictCampaignId: campaignId, trainingApprovalId: approval.approvalId, source: "trajectory", format: "sft",
+    })).rejects.toThrow(/snapshot is invalid|task hash mismatch/i);
+  });
+
   test("record mutation atomically rejects active approvals with the wrong campaign binding", async () => {
     const { t, owner, ids, campaignId } = await setup();
     const approval = await owner.action(api.trainingApprovals.approveVerdictCampaign, { campaignId });
@@ -295,8 +400,36 @@ describe("#287 approved full-span training export", () => {
       const state = await setup();
       await state.t.run(async (ctx) => {
         const span = await ctx.db.query("fullSpanEvalRuns").unique();
-        if (!span) throw new Error("span missing");
-        const projection = await ctx.storage.store(new Blob(["x".repeat(size)]));
+        if (!span?.reviewerProjectionStorageId) throw new Error("span projection missing");
+        let text: string;
+        if (!allowed) {
+          text = "x".repeat(size);
+        } else {
+          const prior = await ctx.storage.get(span.reviewerProjectionStorageId);
+          if (!prior) throw new Error("projection blob missing");
+          const projection = JSON.parse(await prior.text()) as Record<string, unknown>;
+          const events = projection.events as Array<Record<string, unknown>>;
+          const verifier = projection.verifierEvidence as Record<string, unknown>;
+          projection.finalOutput = "x";
+          if (!events[0]) throw new Error("projection event missing");
+          events[0].content = "x";
+          projection.patch = "x";
+          verifier.stdout = "x";
+          verifier.stderr = "x";
+          const fields: Array<[Record<string, unknown>, string, number]> = [
+            [projection, "finalOutput", 256_000], [events[0], "content", 256_000],
+            [projection, "patch", 65_536], [verifier, "stdout", 8_192], [verifier, "stderr", 8_192],
+          ];
+          for (const [target, key, max] of fields) {
+            const current = String(target[key]);
+            const deficit = size - new TextEncoder().encode(JSON.stringify(projection)).byteLength;
+            if (deficit <= 0) break;
+            target[key] = current + "x".repeat(Math.min(deficit, max - current.length));
+          }
+          text = JSON.stringify(projection);
+          expect(new TextEncoder().encode(text).byteLength).toBe(size);
+        }
+        const projection = await ctx.storage.store(new Blob([text]));
         await ctx.db.patch(span._id, { reviewerProjectionStorageId: projection });
       });
       const approval = state.owner.action(api.trainingApprovals.approveVerdictCampaign, { campaignId: state.campaignId });

--- a/convex/trainingApprovals.ts
+++ b/convex/trainingApprovals.ts
@@ -5,6 +5,7 @@ import { internal } from "./_generated/api";
 import type { Doc, Id } from "./_generated/dataModel";
 import { requireProjectRole } from "./lib/auth";
 import { TRAINING_EXPORT_LIMITS, trainingExportSizeViolation } from "./lib/trainingExport";
+import { deriveTrainingTaskHash, parseHarborReviewerProjection } from "./lib/harborEvidence";
 
 export const TRAINING_POLICY_VERSION = "full-span-training-v2";
 
@@ -36,7 +37,7 @@ type ApprovalResult = { readonly approvalId: Id<"trainingApprovals">; readonly e
 type PreparedResult = { readonly existing: ApprovalResult | null; readonly projectId: Id<"projects">; readonly reviewerCount: number; readonly candidates: PreparedCandidate[] };
 
 const PRIVACY = v.union(v.literal("public"), v.literal("internal"), v.literal("confidential"), v.literal("pii"), v.literal("phi"));
-const EXCLUSION = v.union(v.literal("not_full_span"), v.literal("fixture_only"), v.literal("insufficient_evidence"), v.literal("sensitive"), v.literal("no_approved_verdict"), v.literal("review_disagreement"), v.literal("non_comparable_prefix"), v.literal("no_preference"), v.literal("task_mismatch"));
+const EXCLUSION = v.union(v.literal("not_full_span"), v.literal("fixture_only"), v.literal("insufficient_evidence"), v.literal("sensitive"), v.literal("no_approved_verdict"), v.literal("review_disagreement"), v.literal("non_comparable_prefix"), v.literal("no_preference"), v.literal("task_mismatch"), v.literal("invalid_task_hash"));
 const SNAPSHOT = v.object({ storageId: v.id("_storage"), sha256: v.string(), taskHash: v.string(), privacyClass: PRIVACY });
 const CANDIDATE = v.object({
   agentTraceId: v.optional(v.id("agentTraces")), matchupId: v.optional(v.id("agentTraceMatchups")),
@@ -45,6 +46,8 @@ const CANDIDATE = v.object({
   leftProjection: v.optional(SNAPSHOT), rightProjection: v.optional(SNAPSHOT), privacyClass: PRIVACY,
   reviewerCount: v.number(), eligibility: v.union(v.literal("eligible"), v.literal("excluded")), exclusionReason: v.optional(EXCLUSION),
 });
+
+const SHA256 = /^[0-9a-f]{64}$/;
 
 function sensitive(value: PrivacyClass): boolean { return value === "confidential" || value === "pii" || value === "phi"; }
 function combinedPrivacy(left: PrivacyClass, right: PrivacyClass): PrivacyClass {
@@ -61,6 +64,7 @@ async function projectionRef(ctx: QueryCtx, trace: Doc<"agentTraces"> | null): P
   if (!span || span.status !== "ready") return { eligible: false, reason: "not_full_span", privacyClass };
   if (span.runQualification === "fixture_only") return { eligible: false, reason: "fixture_only", privacyClass };
   if (span.runQualification !== "quality_eligible" || !span.canJudgeTaskSuccess || span.evidenceCompleteness !== "complete" || !span.reviewerProjectionStorageId) return { eligible: false, reason: "insufficient_evidence", privacyClass };
+  if (!span.trainingTaskHash || !SHA256.test(span.trainingTaskHash)) return { eligible: false, reason: "invalid_task_hash", privacyClass };
   return { eligible: true, ref: { storageId: span.reviewerProjectionStorageId, taskHash: span.trainingTaskHash, privacyClass } };
 }
 
@@ -73,7 +77,18 @@ async function snapshotRef(storage: { get: (id: Id<"_storage">) => Promise<Blob 
   const blob = await storage.get(ref.storageId);
   if (!blob) throw new Error("Reviewer projection is unavailable for approval.");
   if (trainingExportSizeViolation({ projectionBytes: blob.size })) throw new Error("Reviewer projection exceeds the training approval byte limit.");
-  return { ...ref, sha256: await sha256Bytes(await blob.arrayBuffer()) };
+  const bytes = await blob.arrayBuffer();
+  let projection: ReturnType<typeof parseHarborReviewerProjection>;
+  try {
+    const raw: unknown = JSON.parse(new TextDecoder().decode(bytes));
+    projection = parseHarborReviewerProjection(raw);
+  } catch {
+    throw new Error("Reviewer projection is malformed for training approval.");
+  }
+  if (!projection.taskRevision) throw new Error("Reviewer projection lacks the task revision required for training approval.");
+  const derivedTaskHash = await deriveTrainingTaskHash(projection.taskPrompt, projection.taskRevision);
+  if (derivedTaskHash !== ref.taskHash) throw new Error("Reviewer projection task hash mismatch.");
+  return { ...ref, sha256: await sha256Bytes(bytes) };
 }
 
 export const prepareVerdictApproval = internalQuery({

--- a/docs/full-span-training-export.md
+++ b/docs/full-span-training-export.md
@@ -14,6 +14,7 @@ A `quality_eligible` objective result and a positive human verdict/preference ar
 
 Approval is default-deny:
 
+- `fullSpanEvalRuns.trainingTaskHash` is transitional/optional while legacy rows are migrated; a missing, malformed, or projection-mismatched hash makes the row ineligible for approval and unusable for export;
 - approval snapshots the exact reviewer-projection storage ID and SHA-256 of its exact bytes; DPO snapshots both sides, winner, divergence index, persisted shared-prefix hash, and reviewer-safe task prompt/revision hash;
 - generation reads only those immutable snapshot references and rejects missing, oversized, or hash-mismatched blobs—it never rediscovers the current span or matchup;
 - only strict full-span evidence with `runQualification=quality_eligible`, complete integrity-bound reviewer evidence, and a positive human judgment is eligible;
@@ -83,6 +84,80 @@ Convex storage is blob-oriented rather than a true streaming writer, so export f
 | Exports retained per active approval | 20 |
 
 Exact-limit values are accepted; one byte/item above is rejected before artifact handoff. Candidate count is checked during both approval and generation.
+
+## Staged production migration for `trainingTaskHash`
+
+Do not combine these stages into one deploy. Do not make the schema field required until the final verification below is clean.
+
+### Stage 1 — deploy the compatibility release
+
+1. Confirm the release has `trainingTaskHash: v.optional(v.string())` in `fullSpanEvalRuns`.
+2. Run the repository gates from a clean checkout.
+3. Deploy only the compatibility release:
+
+   ```bash
+   npx convex deploy
+   ```
+
+   This release accepts pre-#356 rows. New ingests store `taskRevision` inside the immutable reviewer-safe projection and write the canonical lowercase SHA-256 task hash. Training approval and export remain fail-closed for missing, malformed, or mismatched hashes.
+
+### Stage 2 — dry-run every production project in bounded pages
+
+Obtain each project ID from the authenticated owner/admin surface. For each project, run the privileged internal action in pages of at most 100 (25 below). The action reads only `reviewerProjectionStorageId`; it never reads `rawEvidenceStorageId`, trace bodies, or unrestricted producer artifacts.
+
+```bash
+export PROJECT_ID='<production Convex projects document ID>'
+export CURSOR=''
+while true; do
+  ARGS=$(jq -nc \
+    --arg projectId "$PROJECT_ID" \
+    --arg cursor "$CURSOR" \
+    '{projectId:$projectId,dryRun:true,batchSize:25} + (if $cursor == "" then {} else {cursor:$cursor} end)')
+  RESULT=$(npx convex run --prod \
+    migrations/backfillFullSpanTrainingTaskHash:backfillProjectBatchInternal \
+    "$ARGS") || exit 1
+  printf '%s\n' "$RESULT" | jq .
+  test "$(printf '%s' "$RESULT" | jq '.issues | length')" -eq 0 || exit 1
+  test "$(printf '%s' "$RESULT" | jq -r '.isDone')" = true && break
+  CURSOR=$(printf '%s' "$RESULT" | jq -r '.continueCursor')
+done
+```
+
+Record the summed `scanned`, `wouldPatch`, `alreadyValid`, and issue counts per project. `issues` must be empty before apply. Meanings are intentionally fail-closed:
+
+- `missing_projection` / `projection_unavailable` / `malformed_projection` / `projection_oversized`: the immutable reviewer projection cannot safely establish task identity;
+- `missing_task_revision`: the legacy projection predates reviewer-safe revision storage;
+- `invalid_existing_hash`: a present hash does not equal the canonical hash of that exact projection;
+- `changed_during_backfill`: the immutable pointer/hash changed between read and patch.
+
+**Stop on any issue.** Never recover a revision from `rawEvidenceStorageId`, unrestricted trace steps, `attempt`, filenames, or guessed defaults. In particular, the original #354 projection shape did not persist `taskRevision`; those rows are not safely derivable and must remain denied until a separately reviewed, authoritative reviewer-safe reprojection path exists. Do not harden the schema while any such row remains.
+
+### Stage 3 — apply, then verify idempotency
+
+Repeat the same loop with `dryRun:false`. Keep the same project list and page size. `patched + alreadyValid` must reconcile with the issue-free dry-run's `scanned`, and every page must have zero issues.
+
+Then run the Stage 2 dry-run loop again from an empty cursor. Across every project it must report:
+
+```text
+wouldPatch = 0
+patched = 0
+issues = []
+alreadyValid = scanned
+```
+
+Also verify that approval of a known closed legacy result was denied before its row was patched and succeeds only after this clean backfill; generate and verify one non-sensitive synthetic export through the normal owner flow. Do not use customer/private rows for this check.
+
+### Stage 4 — later final hardening release
+
+Only after Stage 3 is recorded clean for every production project:
+
+1. In a separate reviewed change, replace `trainingTaskHash: v.optional(v.string())` with `trainingTaskHash: v.string()`.
+2. Keep all approval/export recomputation checks; schema requiredness does not replace them.
+3. Run the full Convex/eval/component/build gates.
+4. Deploy that separate hardening release with `npx convex deploy`.
+5. Re-run one dry-run page per project. It must still report only `alreadyValid` rows and zero issues.
+
+If any deploy, page, reconciliation, or synthetic approval/export verification fails, stop at the current compatible schema and investigate. Do not wipe, guess hashes, bypass approval, or use `--push` on a migration command.
 
 ## Operator steps
 

--- a/src/lib/evals/harborEvidence.ts
+++ b/src/lib/evals/harborEvidence.ts
@@ -46,6 +46,8 @@ export type HarborReviewerEvent = {
 };
 export type HarborReviewerProjection = {
   readonly taskPrompt: string;
+  /** Reviewer-safe producer revision. Legacy projections may not contain it. */
+  readonly taskRevision?: string;
   readonly timing: { readonly startedAt: string; readonly completedAt: string; readonly durationMs: number };
   readonly events: ReadonlyArray<HarborReviewerEvent>;
   readonly finalOutput: string;
@@ -235,11 +237,12 @@ function toolAlias(name: string): string {
 export function parseHarborReviewerProjection(raw: unknown): HarborReviewerProjection {
   const row = rec(raw, "reviewer projection");
   exact(row, [
-    "taskPrompt", "timing", "events", "finalOutput", "termination", "outcomes",
+    "taskPrompt", "taskRevision", "timing", "events", "finalOutput", "termination", "outcomes",
     "runQualification", "evidenceCompleteness", "evidenceWarning", "canJudgeTaskSuccess",
     "changedFiles", "patch", "patchTruncated", "verifierEvidence", "integrity",
   ], "reviewer projection");
   text(row.taskPrompt, "reviewer projection.taskPrompt");
+  optionalText(row.taskRevision, "reviewer projection.taskRevision", 200);
   text(row.finalOutput, "reviewer projection.finalOutput");
   const timing = rec(row.timing, "reviewer projection.timing");
   exact(timing, ["startedAt", "completedAt", "durationMs"], "reviewer projection.timing");
@@ -317,6 +320,11 @@ async function sha256Text(value: string): Promise<string> {
   const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(value));
   return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
 }
+
+/** Derive the canonical training task hash from reviewer-safe task identity. */
+export async function deriveTrainingTaskHash(taskPrompt: string, taskRevision: string): Promise<string> {
+  return await sha256Text(stableStringify({ prompt: taskPrompt, revision: taskRevision }));
+}
 function collectPrivateStrings(value: unknown): string[] {
   if (typeof value === "string") return value.length >= 2 ? [value] : [];
   if (Array.isArray(value)) return value.flatMap(collectPrivateStrings);
@@ -388,7 +396,7 @@ export async function parseHarborEvidenceV1(raw: unknown): Promise<ParsedHarborE
   const task = rec(reviewer.task, "reviewer.task");
   exact(task, ["id", "revision", "privacy_class", "prompt"], "reviewer.task");
   text(task.id, "reviewer.task.id", 200);
-  const taskRevision = text(task.revision, "reviewer.task.revision", 200);
+  const taskRevision = sanitizeString(text(task.revision, "reviewer.task.revision", 200));
   const privacy = text(task.privacy_class, "reviewer.task.privacy_class", 30);
   if (!PRIVACY.has(privacy)) throw new Error("reviewer.task.privacy_class is unsupported");
   const taskPrompt = sanitizeString(text(task.prompt, "reviewer.task.prompt"));
@@ -587,6 +595,7 @@ export async function parseHarborEvidenceV1(raw: unknown): Promise<ParsedHarborE
 
   const projection: HarborReviewerProjection = {
     taskPrompt,
+    taskRevision,
     timing: { startedAt, completedAt: endedAt, durationMs: Date.parse(endedAt) - Date.parse(startedAt) },
     events: projectionEvents,
     finalOutput,
@@ -643,7 +652,7 @@ export async function parseHarborEvidenceV1(raw: unknown): Promise<ParsedHarborE
     run: { stableId, attempt, status: runStatus as ParsedHarborEvidence["run"]["status"] },
     trace,
     projection: safeProjection,
-    trainingTaskHash: await sha256Text(stableStringify({ prompt: safeProjection.taskPrompt, revision: taskRevision })),
+    trainingTaskHash: await deriveTrainingTaskHash(safeProjection.taskPrompt, taskRevision),
     objective: {
       process: { status: topOutcomes.process },
       verifier: { status: topOutcomes.verifier },


### PR DESCRIPTION
## Summary

Production deployment of #356 failed because legacy `fullSpanEvalRuns` rows predate the required `trainingTaskHash`. This stages a backward-compatible, fail-closed migration.

- make the field transitional/optional so existing production rows validate
- keep approval/export denied for missing, malformed, or projection-mismatched hashes
- recompute task identity from exact reviewer-safe prompt + revision at approval and export time
- add a bounded, cursor-based owner/internal backfill with dry-run, idempotency, race checks, and content-safe reporting
- never read raw evidence, unrestricted trace steps, or guess legacy revisions
- document staged deploy, dry-run, apply, verification, and later hardening

## Important legacy boundary

Original #354 reviewer projections did not persist `taskRevision`. Those rows cannot be safely backfilled without guessing or reading outside the approved projection boundary. They remain reviewable but training-ineligible. New Mogil evidence includes reviewer-safe revision and is eligible for exact hashing.

## Verification

- eval tests: 219 passed
- Convex tests: 345 passed
- browser component tests: 19 passed
- production build and TypeScript: passed
- `git diff --check`: passed

No production data, deployment, wipe, approval, export, or training action was performed by this branch.
