### PR TITLE
Fix training-path integrity blockers (#310, #311, #312)

### DIFF
--- a/convex/agentTraceReview.ts
+++ b/convex/agentTraceReview.ts
@@ -12,6 +12,7 @@ import { v } from "convex/values";
 import { mutation, query } from "./_generated/server";
 import type { Id } from "./_generated/dataModel";
 import { requireProjectRole } from "./lib/auth";
+import { generateToken } from "./lib/crypto";
 
 const LABEL = v.union(
   v.literal("suggestion"),
@@ -166,7 +167,14 @@ export const myVerdict = query({
 
 // --- step-level pairwise preference ------------------------------------------
 
-/** Owner/editor sets up a pairwise between two traces at a divergence point. */
+/**
+ * Owner/editor sets up a pairwise between two traces at a divergence point.
+ * #312: a matchup is only DPO-valid if both traces genuinely share the prefix
+ * before the divergence step. Mutations can't read step bodies (storage is
+ * action-only), so this checks the step SKELETON (kind/role/toolName per
+ * index); the export action does the content-level comparison and excludes
+ * mismatches with a manifest reason.
+ */
 export const createMatchup = mutation({
   args: {
     leftTraceId: v.id("agentTraces"),
@@ -183,19 +191,50 @@ export const createMatchup = mutation({
       throw new Error("Both traces must be in the same project.");
     }
     await requireProjectRole(ctx, left.projectId, ["owner", "editor"]);
+    const div = args.divergenceStepIndex;
+    if (!Number.isInteger(div) || div < 0 || div >= left.stepCount || div >= right.stepCount) {
+      throw new Error(
+        "The divergence step must exist in both traces — pick an index inside both runs.",
+      );
+    }
+    const prefixOf = (traceId: Id<"agentTraces">) =>
+      ctx.db
+        .query("agentTraceSteps")
+        .withIndex("by_trace_and_index", (q) =>
+          q.eq("agentTraceId", traceId).lt("stepIndex", div),
+        )
+        .collect();
+    const [lSteps, rSteps] = [await prefixOf(args.leftTraceId), await prefixOf(args.rightTraceId)];
+    if (lSteps.length !== rSteps.length) {
+      throw new Error("The two traces don’t share a prefix before that step — pick an earlier divergence point.");
+    }
+    for (let i = 0; i < lSteps.length; i++) {
+      const a = lSteps[i]!;
+      const b = rSteps[i]!;
+      if (a.kind !== b.kind || a.role !== b.role || a.toolName !== b.toolName) {
+        throw new Error(
+          `The traces already differ at step ${a.stepIndex} — pick a divergence point where both runs still match.`,
+        );
+      }
+    }
     return await ctx.db.insert("agentTraceMatchups", {
       projectId: left.projectId,
       leftTraceId: args.leftTraceId,
       rightTraceId: args.rightTraceId,
-      divergenceStepIndex: args.divergenceStepIndex,
+      divergenceStepIndex: div,
       leftBlindLabel: args.leftBlindLabel,
       rightBlindLabel: args.rightBlindLabel,
       reasonTags: [],
+      reviewToken: generateToken(),
     });
   },
 });
 
-/** Reviewer records the better next action. */
+/**
+ * Reviewer records the better next action. #311: one decision row per
+ * (matchup, reviewer) — upserted, never written to the matchup row, so
+ * concurrent reviewers can't overwrite each other.
+ */
 export const decideMatchup = mutation({
   args: {
     matchupId: v.id("agentTraceMatchups"),
@@ -206,10 +245,26 @@ export const decideMatchup = mutation({
     const matchup = await ctx.db.get(args.matchupId);
     if (!matchup) throw new Error("Matchup not found.");
     const { userId } = await requireProjectRole(ctx, matchup.projectId, [...REVIEW_ROLES]);
-    await ctx.db.patch(args.matchupId, {
+    const existing = await ctx.db
+      .query("agentTraceMatchupDecisions")
+      .withIndex("by_matchup_and_user", (q) =>
+        q.eq("matchupId", args.matchupId).eq("userId", userId),
+      )
+      .unique();
+    if (existing) {
+      await ctx.db.patch(existing._id, {
+        winner: args.winner,
+        reasonTags: args.reasonTags,
+        decidedAt: Date.now(),
+      });
+      return;
+    }
+    await ctx.db.insert("agentTraceMatchupDecisions", {
+      matchupId: args.matchupId,
+      projectId: matchup.projectId,
+      userId,
       winner: args.winner,
       reasonTags: args.reasonTags,
-      userId,
       decidedAt: Date.now(),
     });
   },
@@ -225,8 +280,17 @@ export const getMatchup = query({
   handler: async (ctx, args) => {
     const matchup = await ctx.db.get(args.matchupId);
     if (!matchup) return null;
-    await requireProjectRole(ctx, matchup.projectId, [...REVIEW_ROLES]);
+    const { userId } = await requireProjectRole(ctx, matchup.projectId, [...REVIEW_ROLES]);
     const project = await ctx.db.get(matchup.projectId);
+    // #311: the caller sees ONLY their own decision — never other reviewers'
+    // picks. Legacy single-decision fields count only if they were the caller's.
+    const mine = await ctx.db
+      .query("agentTraceMatchupDecisions")
+      .withIndex("by_matchup_and_user", (q) =>
+        q.eq("matchupId", args.matchupId).eq("userId", userId),
+      )
+      .unique();
+    const legacyMine = matchup.userId === userId ? matchup : null;
     return {
       _id: matchup._id,
       projectName: project?.name ?? "Project",
@@ -235,8 +299,31 @@ export const getMatchup = query({
       divergenceStepIndex: matchup.divergenceStepIndex,
       leftBlindLabel: matchup.leftBlindLabel,
       rightBlindLabel: matchup.rightBlindLabel,
-      winner: matchup.winner ?? null,
-      reasonTags: matchup.reasonTags,
+      winner: mine?.winner ?? legacyMine?.winner ?? null,
+      reasonTags: mine?.reasonTags ?? legacyMine?.reasonTags ?? [],
     };
+  },
+});
+
+/**
+ * #310: resolve an opaque matchup review handle (reviewToken; raw id accepted
+ * only for pre-token rows). Mirrors agentTraces.resolveReviewHandle.
+ * ponytail: delete the normalizeId fallback once backfillReviewTokens has run.
+ */
+export const resolveMatchupHandle = query({
+  args: { handle: v.string() },
+  handler: async (ctx, args): Promise<{ matchupId: Id<"agentTraceMatchups"> } | null> => {
+    const byToken = await ctx.db
+      .query("agentTraceMatchups")
+      .withIndex("by_review_token", (q) => q.eq("reviewToken", args.handle))
+      .unique();
+    let matchup = byToken;
+    if (!matchup) {
+      const id = ctx.db.normalizeId("agentTraceMatchups", args.handle);
+      matchup = id ? await ctx.db.get(id) : null;
+    }
+    if (!matchup) return null;
+    await requireProjectRole(ctx, matchup.projectId, [...REVIEW_ROLES]);
+    return { matchupId: matchup._id };
   },
 });

--- a/convex/agentTraces.ts
+++ b/convex/agentTraces.ts
@@ -26,6 +26,7 @@ import type { ActionCtx } from "./_generated/server";
 import { internal } from "./_generated/api";
 import type { Id } from "./_generated/dataModel";
 import { requireAuth, requireProjectRole, isBlindReviewer } from "./lib/auth";
+import { generateToken } from "./lib/crypto";
 import type { AgentRunTrace } from "./lib/agentTrace";
 import { redactValue } from "./lib/agentTrace";
 import { splitStep } from "./lib/agentTraceStorage";
@@ -138,6 +139,7 @@ export const insertTraceParent = internalMutation({
       durationMs: args.durationMs,
       totalTokens: args.totalTokens,
       importedById: userId,
+      reviewToken: generateToken(),
     });
     return { agentTraceId, deduped: false };
   },
@@ -185,6 +187,7 @@ export const insertTraceParentForIngest = internalMutation({
       source: "agent_harness",
       status: "pending",
       importedById,
+      reviewToken: generateToken(),
     });
     return { agentTraceId, deduped: false };
   },
@@ -486,7 +489,9 @@ export const listReviewableTraces = query({
       .withIndex("by_user", (q) => q.eq("userId", userId))
       .collect();
     const out: Array<{
-      _id: Id<"agentTraces">;
+      // #310: opaque review handle — the reviewToken, falling back to the raw
+      // id only for pre-fix rows that backfillReviewTokens hasn't stamped yet.
+      handle: string;
       projectName: string;
       status: string;
       stepCount: number;
@@ -506,7 +511,7 @@ export const listReviewableTraces = query({
       for (const tr of traces) {
         if (tr.status !== "ready") continue;
         out.push({
-          _id: tr._id,
+          handle: tr.reviewToken ?? tr._id,
           projectName: project?.name ?? "Project",
           status: tr.status,
           stepCount: tr.stepCount,
@@ -518,6 +523,58 @@ export const listReviewableTraces = query({
       }
     }
     return out.sort((a, b) => b.createdAt - a.createdAt).slice(0, 200);
+  },
+});
+
+/**
+ * #310: resolve an opaque review handle to the trace id the review queries
+ * take. The handle is the reviewToken; a raw Convex id is accepted only as a
+ * fallback for rows created before tokens existed.
+ * ponytail: delete the normalizeId fallback once backfillReviewTokens has run
+ * in prod — after that every row has a token.
+ */
+export const resolveReviewHandle = query({
+  args: { handle: v.string() },
+  handler: async (ctx, args): Promise<{ agentTraceId: Id<"agentTraces"> } | null> => {
+    const byToken = await ctx.db
+      .query("agentTraces")
+      .withIndex("by_review_token", (q) => q.eq("reviewToken", args.handle))
+      .unique();
+    let trace = byToken;
+    if (!trace) {
+      const id = ctx.db.normalizeId("agentTraces", args.handle);
+      trace = id ? await ctx.db.get(id) : null;
+    }
+    if (!trace) return null;
+    await requireProjectRole(ctx, trace.projectId, ["owner", "editor", "evaluator"]);
+    return { agentTraceId: trace._id };
+  },
+});
+
+/**
+ * #310 one-shot backfill: stamp reviewToken on traces and matchups created
+ * before the token existed. Run once after deploy:
+ *   npx convex run agentTraces:backfillReviewTokens
+ * ponytail: full-table collect — fine at pre-launch scale, paginate if it
+ * ever times out.
+ */
+export const backfillReviewTokens = internalMutation({
+  args: {},
+  handler: async (ctx): Promise<{ stamped: number }> => {
+    let stamped = 0;
+    for (const tr of await ctx.db.query("agentTraces").collect()) {
+      if (!tr.reviewToken) {
+        await ctx.db.patch(tr._id, { reviewToken: generateToken() });
+        stamped++;
+      }
+    }
+    for (const m of await ctx.db.query("agentTraceMatchups").collect()) {
+      if (!m.reviewToken) {
+        await ctx.db.patch(m._id, { reviewToken: generateToken() });
+        stamped++;
+      }
+    }
+    return { stamped };
   },
 });
 

--- a/convex/exports.ts
+++ b/convex/exports.ts
@@ -25,6 +25,7 @@ import { requireProjectRole } from "./lib/auth";
 import { readMessages } from "./lib/messages";
 import {
   buildExportManifest,
+  contentHash,
   gateRows,
   toJsonl,
   renderStep,
@@ -174,6 +175,9 @@ interface TrajectoryPlanRow {
   privacyClass: PrivacyClass;
   metadata: Record<string, unknown>;
   prefix?: StepRef[];
+  // #312: the LOSER's prefix refs, so the action can verify both sides were
+  // built on identical rendered prefixes before emitting the pair.
+  rejectedPrefix?: StepRef[];
   chosen?: StepRef;
   rejected?: StepRef;
   messages?: StepRef[];
@@ -202,9 +206,26 @@ export const gatherTrajectoryPlan = internalQuery({
         .withIndex("by_project", (q) => q.eq("projectId", args.projectId))
         .collect();
       for (const m of matchups) {
-        if (m.winner !== "left" && m.winner !== "right") continue;
-        const winnerId = m.winner === "left" ? m.leftTraceId : m.rightTraceId;
-        const loserId = m.winner === "left" ? m.rightTraceId : m.leftTraceId;
+        // #311: aggregate per-reviewer decision rows — strict majority of
+        // left/right picks wins; a split has no signal. The legacy single-
+        // decision fields on the matchup row count as one vote only for
+        // matchups decided before decisions existed.
+        const decisions = await ctx.db
+          .query("agentTraceMatchupDecisions")
+          .withIndex("by_matchup", (q) => q.eq("matchupId", m._id))
+          .collect();
+        const votes =
+          decisions.length > 0
+            ? decisions.map((d) => ({ winner: d.winner, userId: d.userId, reasonTags: d.reasonTags }))
+            : m.winner && m.userId
+              ? [{ winner: m.winner, userId: m.userId, reasonTags: m.reasonTags }]
+              : [];
+        const leftVotes = votes.filter((d) => d.winner === "left").length;
+        const rightVotes = votes.filter((d) => d.winner === "right").length;
+        if (leftVotes === rightVotes) continue;
+        const side = leftVotes > rightVotes ? "left" : "right";
+        const winnerId = side === "left" ? m.leftTraceId : m.rightTraceId;
+        const loserId = side === "left" ? m.rightTraceId : m.leftTraceId;
         const [wt, lt] = [await ctx.db.get(winnerId), await ctx.db.get(loserId)];
         if (!wt || !lt) continue;
         const wSteps = await stepsOf(winnerId);
@@ -212,16 +233,22 @@ export const gatherTrajectoryPlan = internalQuery({
         const chosen = wSteps.find((s) => s.stepIndex === m.divergenceStepIndex);
         const rejected = lSteps.find((s) => s.stepIndex === m.divergenceStepIndex);
         if (!chosen || !rejected) continue;
+        const prefixRefs = (steps: typeof wSteps) =>
+          steps
+            .filter((s) => s.stepIndex < m.divergenceStepIndex)
+            .map((s) => ({ meta: metaOf(s), storageId: s.fullBodyStorageId }));
         plan.push({
           privacyClass: moreSensitive(wt.privacyClass, lt.privacyClass),
-          metadata: { reason_tags: m.reasonTags },
-          prefix: wSteps
-            .filter((s) => s.stepIndex < m.divergenceStepIndex)
-            .map((s) => ({ meta: metaOf(s), storageId: s.fullBodyStorageId })),
+          metadata: {
+            reason_tags: [...new Set(votes.flatMap((d) => d.reasonTags))],
+            decision_counts: { left: leftVotes, right: rightVotes },
+          },
+          prefix: prefixRefs(wSteps),
+          rejectedPrefix: prefixRefs(lSteps),
           chosen: { meta: metaOf(chosen), storageId: chosen.fullBodyStorageId },
           rejected: { meta: metaOf(rejected), storageId: rejected.fullBodyStorageId },
         });
-        if (m.userId) reviewerIds.add(m.userId);
+        for (const d of votes) reviewerIds.add(d.userId);
       }
     } else if (args.format === "sft") {
       const traces = await ctx.db
@@ -400,14 +427,28 @@ async function hydrateTrajectory(
   const out: ClassifiedRow[] = [];
   for (const r of plan) {
     if (format === "dpo" && r.chosen && r.rejected) {
-      const prefix = await Promise.all(
-        (r.prefix ?? []).map(async (s) => ({ meta: s.meta, body: await read(s.storageId) })),
-      );
+      const hydrateRefs = (refs: StepRef[]) =>
+        Promise.all(refs.map(async (s) => ({ meta: s.meta, body: await read(s.storageId) })));
+      const prefix = await hydrateRefs(r.prefix ?? []);
       const chosen = renderStep(r.chosen.meta, await read(r.chosen.storageId));
       const rejected = renderStep(r.rejected.meta, await read(r.rejected.storageId));
+      // #312: prove comparability at content level — render BOTH prefixes and
+      // compare. A match is recorded as prefix_hash on the row (the persisted
+      // proof); a mismatch flags the row so gateRows excludes it with reason.
+      const prompt = renderTranscript(prefix);
+      const rejectedPrompt = renderTranscript(await hydrateRefs(r.rejectedPrefix ?? []));
+      const comparable = prompt === rejectedPrompt;
       out.push({
         privacyClass: r.privacyClass,
-        row: { kind: "dpo", prompt: renderTranscript(prefix), chosen, rejected, metadata: r.metadata },
+        row: {
+          kind: "dpo",
+          prompt,
+          chosen,
+          rejected,
+          metadata: comparable
+            ? { ...r.metadata, prefix_hash: contentHash(prompt) }
+            : { ...r.metadata, prefix_mismatch: true },
+        },
       });
     } else if (format === "sft" && r.messages) {
       const msgs = await Promise.all(

--- a/convex/lib/trainingExport.ts
+++ b/convex/lib/trainingExport.ts
@@ -70,7 +70,7 @@ export interface ClassifiedRow {
 }
 
 export interface ExcludedRow {
-  reason: "prod_sensitive" | "pii_leak" | "empty" | "degenerate";
+  reason: "prod_sensitive" | "pii_leak" | "empty" | "degenerate" | "prefix_mismatch";
   privacyClass: PrivacyClass;
 }
 
@@ -130,6 +130,13 @@ export function gateRows(
       excluded.push({ reason: "prod_sensitive", privacyClass });
       continue;
     }
+    // #312: DPO is a preference over the next action given an IDENTICAL
+    // prefix. The export action compares both traces' rendered prefixes and
+    // flags mismatches; a mismatched pair is not valid DPO signal.
+    if (row.kind === "dpo" && row.metadata["prefix_mismatch"] === true) {
+      excluded.push({ reason: "prefix_mismatch", privacyClass });
+      continue;
+    }
     // A DPO pair with identical chosen/rejected carries no preference signal —
     // it pollutes the dataset. Drop it (e.g. the matchup's divergence index
     // landed on a shared-prefix step). Surfaced by the M31 dogfood pass.
@@ -182,6 +189,20 @@ export function renderStep(meta: StepMeta, body: unknown): string {
 /** Ordered (meta, body) pairs → a transcript string (DPO prefix / SFT turns). */
 export function renderTranscript(steps: Array<{ meta: StepMeta; body: unknown }>): string {
   return steps.map((s) => renderStep(s.meta, s.body)).join("\n");
+}
+
+/**
+ * #312: cheap stable content hash (FNV-1a, hex) recorded as `prefix_hash` on
+ * every exported DPO row — the persisted proof that chosen and rejected were
+ * built on the same rendered prefix. Not cryptographic; equality proof only.
+ */
+export function contentHash(text: string): string {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < text.length; i++) {
+    h ^= text.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return (h >>> 0).toString(16).padStart(8, "0");
 }
 
 /** The more-sensitive of two privacy classes (for a matchup spanning two traces). */
@@ -253,8 +274,12 @@ export function buildExportManifest(input: {
   const notes: string[] = [];
   if (format === "dpo") {
     notes.push(
-      "DPO rows are emitted only for comparable chosen/rejected pairs; a pair whose chosen and rejected text are identical carries no preference signal and is excluded (degenerate) rather than written.",
+      "DPO rows are emitted only for verified-comparable pairs: chosen and rejected must be built on an identical rendered prefix (recorded as prefix_hash in row metadata); pairs whose prefixes differ are excluded (prefix_mismatch), and a pair whose chosen and rejected text are identical is excluded (degenerate).",
     );
+    if ((byReason.prefix_mismatch ?? 0) > 0)
+      notes.push(
+        `${byReason.prefix_mismatch} pair(s) excluded because the two trajectories' prefixes did not match at export time — their preference signal is not valid DPO.`,
+      );
     if (included.length === 0)
       notes.push(
         "No comparable preference pairs were found, so no DPO rows were written. Decide more A/B matchups (trajectories) or add best+weak ratings on the same run (prompt outputs).",

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -772,10 +772,15 @@ const schema = defineSchema({
     finalAnswerStorageId: v.optional(v.id("_storage")),
     finalAnswerBlindStorageId: v.optional(v.id("_storage")),
     importedById: v.id("users"),
+    // #310: opaque handle for the blind /eval/traces/:handle route so the real
+    // Convex id never appears in reviewer URLs. Stamped at insert; optional for
+    // rows created before the fix (backfillReviewTokens migrates them).
+    reviewToken: v.optional(v.string()),
   })
     .index("by_project", ["projectId"])
     .index("by_trace_id", ["traceId"])
-    .index("by_project_and_status", ["projectId", "status"]),
+    .index("by_project_and_status", ["projectId", "status"])
+    .index("by_review_token", ["reviewToken"]),
 
   // #264 (M31 Trajectory Spine): one row per trace step, ordered by
   // (agentTraceId, stepIndex). Own ~1MiB doc budget per row. Light,
@@ -895,6 +900,10 @@ const schema = defineSchema({
     divergenceStepIndex: v.number(),
     leftBlindLabel: v.string(),
     rightBlindLabel: v.string(),
+    // #311 LEGACY single-decision fields. New decisions live one-row-per-
+    // reviewer in agentTraceMatchupDecisions; these remain only so matchups
+    // decided before the fix keep their signal (export reads them as a
+    // fallback). Never written by decideMatchup anymore.
     userId: v.optional(v.id("users")),
     winner: v.optional(
       v.union(
@@ -917,9 +926,43 @@ const schema = defineSchema({
       ),
     ),
     decidedAt: v.optional(v.number()),
+    // #310: opaque handle for /eval/matchups/:handle (see agentTraces.reviewToken).
+    reviewToken: v.optional(v.string()),
   })
     .index("by_project", ["projectId"])
-    .index("by_left", ["leftTraceId"]),
+    .index("by_left", ["leftTraceId"])
+    .index("by_review_token", ["reviewToken"]),
+
+  // #311: one decision row per (matchup, reviewer) so concurrent reviewers
+  // never overwrite each other. Export aggregates these (strict majority);
+  // getMatchup returns only the caller's own row — reviewers never see each
+  // other's picks (blind posture).
+  agentTraceMatchupDecisions: defineTable({
+    matchupId: v.id("agentTraceMatchups"),
+    projectId: v.id("projects"),
+    userId: v.id("users"),
+    winner: v.union(
+      v.literal("left"),
+      v.literal("right"),
+      v.literal("tie"),
+      v.literal("skip"),
+    ),
+    reasonTags: v.array(
+      v.union(
+        v.literal("tone"),
+        v.literal("accuracy"),
+        v.literal("clarity"),
+        v.literal("length"),
+        v.literal("format"),
+        v.literal("relevance"),
+        v.literal("safety"),
+        v.literal("other"),
+      ),
+    ),
+    decidedAt: v.number(),
+  })
+    .index("by_matchup", ["matchupId"])
+    .index("by_matchup_and_user", ["matchupId", "userId"]),
 
   // #53 (export bridge): a generated training-data export. The JSONL is in
   // storage; this row tracks provenance + counts and gates the download to a

--- a/convex/tests/agentTraceReview.test.ts
+++ b/convex/tests/agentTraceReview.test.ts
@@ -1,7 +1,7 @@
 /// <reference types="vite/client" />
 import { convexTest } from "convex-test";
 import { describe, expect, test } from "vitest";
-import { api } from "../_generated/api";
+import { api, internal } from "../_generated/api";
 import type { Id } from "../_generated/dataModel";
 import schema from "../schema";
 import {
@@ -148,5 +148,107 @@ describe("#267 step-level trace review", () => {
     // No provenance in the matchup payload.
     expect(JSON.stringify(m)).not.toContain("jeeves_clog");
     expect(JSON.stringify(m)).not.toContain("claude-sonnet-4-0");
+  });
+
+  test("#311: two reviewers' decisions coexist; each sees only their own pick", async () => {
+    const t = convexTest(schema);
+    const { ids, asOwner, asBlind } = await seed(t);
+    const left = await persist(asOwner, ids.projectId, baseRun);
+    const right = await persist(asOwner, ids.projectId, { ...baseRun, run_id: "JEEVES-RUN-REVIEW-C" });
+    const matchupId = await asOwner.mutation(api.agentTraceReview.createMatchup, {
+      leftTraceId: left, rightTraceId: right, divergenceStepIndex: 3,
+      leftBlindLabel: "A", rightBlindLabel: "B",
+    });
+
+    await asBlind.mutation(api.agentTraceReview.decideMatchup, { matchupId, winner: "left", reasonTags: ["accuracy"] });
+    await asOwner.mutation(api.agentTraceReview.decideMatchup, { matchupId, winner: "right", reasonTags: ["tone"] });
+    // Re-decide upserts, never duplicates.
+    await asBlind.mutation(api.agentTraceReview.decideMatchup, { matchupId, winner: "tie", reasonTags: [] });
+
+    const rows = await t.run(async (ctx) =>
+      ctx.db.query("agentTraceMatchupDecisions").withIndex("by_matchup", (q) => q.eq("matchupId", matchupId)).collect(),
+    );
+    expect(rows).toHaveLength(2);
+
+    const mineBlind = await asBlind.query(api.agentTraceReview.getMatchup, { matchupId });
+    const mineOwner = await asOwner.query(api.agentTraceReview.getMatchup, { matchupId });
+    expect(mineBlind?.winner).toBe("tie");
+    expect(mineOwner?.winner).toBe("right");
+    // The matchup row itself is never patched (last-write-wins is gone).
+    const raw = await t.run(async (ctx) => ctx.db.get(matchupId));
+    expect(raw?.winner).toBeUndefined();
+  });
+
+  test("#312: createMatchup rejects divergence points the traces don't share", async () => {
+    const t = convexTest(schema);
+    const { ids, asOwner } = await seed(t);
+    const left = await persist(asOwner, ids.projectId, baseRun);
+    // Diverges at step 1 (different tool), so any later divergence index is invalid.
+    const right = await persist(asOwner, ids.projectId, {
+      ...baseRun,
+      run_id: "JEEVES-RUN-REVIEW-D",
+      steps: [
+        { type: "message", role: "assistant", content: "Looking it up." },
+        { type: "tool_call", id: "t1", name: "close_ticket", args: {} },
+        { type: "tool_result", id: "t1", name: "close_ticket", result: {} },
+        { type: "tool_call", id: "t2", name: "create_escalation", args: { reason: "hardship" } },
+      ],
+    });
+    await expect(
+      asOwner.mutation(api.agentTraceReview.createMatchup, {
+        leftTraceId: left, rightTraceId: right, divergenceStepIndex: 3,
+        leftBlindLabel: "A", rightBlindLabel: "B",
+      }),
+    ).rejects.toThrow(/already differ/);
+    // Out-of-range divergence is rejected too.
+    await expect(
+      asOwner.mutation(api.agentTraceReview.createMatchup, {
+        leftTraceId: left, rightTraceId: right, divergenceStepIndex: 99,
+        leftBlindLabel: "A", rightBlindLabel: "B",
+      }),
+    ).rejects.toThrow(/must exist in both/);
+  });
+
+  test("#310: review handles are opaque tokens, resolvable by reviewers", async () => {
+    const t = convexTest(schema);
+    const { ids, asOwner, asBlind } = await seed(t);
+    const traceId = await persist(asOwner, ids.projectId, baseRun);
+
+    const list = await asBlind.query(api.agentTraces.listReviewableTraces, {});
+    const handle = list[0]?.handle;
+    expect(handle).toBeDefined();
+    expect(handle).not.toBe(traceId); // never the raw Convex id
+    expect(handle).toMatch(/^[0-9a-f]{32}$/);
+
+    const resolved = await asBlind.query(api.agentTraces.resolveReviewHandle, { handle: handle! });
+    expect(resolved?.agentTraceId).toBe(traceId);
+
+    const right = await persist(asOwner, ids.projectId, { ...baseRun, run_id: "JEEVES-RUN-REVIEW-E" });
+    const matchupId = await asOwner.mutation(api.agentTraceReview.createMatchup, {
+      leftTraceId: traceId, rightTraceId: right, divergenceStepIndex: 3,
+      leftBlindLabel: "A", rightBlindLabel: "B",
+    });
+    const token = await t.run(async (ctx) => (await ctx.db.get(matchupId))?.reviewToken);
+    expect(token).toMatch(/^[0-9a-f]{32}$/);
+    const m = await asBlind.query(api.agentTraceReview.resolveMatchupHandle, { handle: token! });
+    expect(m?.matchupId).toBe(matchupId);
+  });
+
+  test("#310: pre-token rows still resolve by raw id until backfill runs", async () => {
+    const t = convexTest(schema);
+    const { ids, asOwner, asBlind } = await seed(t);
+    const traceId = await persist(asOwner, ids.projectId, baseRun);
+    // Simulate a legacy row created before tokens existed.
+    await t.run(async (ctx) => ctx.db.patch(traceId, { reviewToken: undefined }));
+
+    const resolved = await asBlind.query(api.agentTraces.resolveReviewHandle, { handle: traceId });
+    expect(resolved?.agentTraceId).toBe(traceId);
+
+    // Backfill stamps it; afterwards the token resolves too.
+    await t.mutation(internal.agentTraces.backfillReviewTokens, {});
+    const token = await t.run(async (ctx) => (await ctx.db.get(traceId))?.reviewToken);
+    expect(token).toMatch(/^[0-9a-f]{32}$/);
+    const byToken = await asBlind.query(api.agentTraces.resolveReviewHandle, { handle: token! });
+    expect(byToken?.agentTraceId).toBe(traceId);
   });
 });

--- a/convex/tests/exports.test.ts
+++ b/convex/tests/exports.test.ts
@@ -85,6 +85,96 @@ describe("#53 training export", () => {
     expect(line.prompt).not.toContain("create_escalation"); // prefix stops before divergence
   });
 
+  test("#311: decisions aggregate by strict majority; splits export nothing", async () => {
+    const t = convexTest(schema);
+    const { ids, asOwner, asEval } = await seed(t);
+    const thirdId = await t.run(async (ctx) => {
+      const u = await ctx.db.insert("users", { name: "Rev2", email: "rev2@test.com" });
+      await ctx.db.insert("projectCollaborators", { projectId: ids.projectId, userId: u, role: "evaluator", invitedById: ids.ownerUserId, invitedAt: Date.now() });
+      return u;
+    });
+    const asThird = t.withIdentity({ subject: `${thirdId}|s`, tokenIdentifier: `test|${thirdId}` });
+
+    const left = await persist(asOwner, ids.projectId, runWith("A", "create_escalation"));
+    const right = await persist(asOwner, ids.projectId, runWith("B", "close_ticket"));
+    const matchupId = await asOwner.mutation(api.agentTraceReview.createMatchup, {
+      leftTraceId: left, rightTraceId: right, divergenceStepIndex: 2,
+      leftBlindLabel: "A", rightBlindLabel: "B",
+    });
+
+    // 1-1 split → no signal, nothing exported.
+    await asOwner.mutation(api.agentTraceReview.decideMatchup, { matchupId, winner: "left", reasonTags: ["accuracy"] });
+    await asEval.mutation(api.agentTraceReview.decideMatchup, { matchupId, winner: "right", reasonTags: ["tone"] });
+    const split = await asOwner.action(api.exports.generateExport, {
+      projectId: ids.projectId, source: "trajectory", format: "dpo",
+    });
+    expect(split.rowCount).toBe(0);
+
+    // 2-1 majority → one pair, with the vote tally and the prefix proof on the row.
+    await asThird.mutation(api.agentTraceReview.decideMatchup, { matchupId, winner: "left", reasonTags: ["safety"] });
+    const res = await asOwner.action(api.exports.generateExport, {
+      projectId: ids.projectId, source: "trajectory", format: "dpo",
+    });
+    expect(res.rowCount).toBe(1);
+    expect(res.manifest.reviewers).toBe(3);
+    const line = JSON.parse(await readExport(t, res.exportId));
+    expect(line.chosen).toContain("create_escalation");
+    expect(line.metadata.decision_counts).toEqual({ left: 2, right: 1 });
+    expect(line.metadata.prefix_hash).toMatch(/^[0-9a-f]{8}$/);
+    expect(line.metadata.reason_tags).toEqual(expect.arrayContaining(["accuracy", "tone", "safety"]));
+  });
+
+  test("#311: legacy single-decision matchups still export as one vote", async () => {
+    const t = convexTest(schema);
+    const { ids, asOwner } = await seed(t);
+    const left = await persist(asOwner, ids.projectId, runWith("A", "create_escalation"));
+    const right = await persist(asOwner, ids.projectId, runWith("B", "close_ticket"));
+    const matchupId = await asOwner.mutation(api.agentTraceReview.createMatchup, {
+      leftTraceId: left, rightTraceId: right, divergenceStepIndex: 2,
+      leftBlindLabel: "A", rightBlindLabel: "B",
+    });
+    // Simulate a pre-#311 row: winner written directly on the matchup, no decision rows.
+    await t.run(async (ctx) =>
+      ctx.db.patch(matchupId, { winner: "right", userId: ids.ownerUserId, decidedAt: Date.now() }),
+    );
+    const res = await asOwner.action(api.exports.generateExport, {
+      projectId: ids.projectId, source: "trajectory", format: "dpo",
+    });
+    expect(res.rowCount).toBe(1);
+    const line = JSON.parse(await readExport(t, res.exportId));
+    expect(line.chosen).toContain("close_ticket");
+  });
+
+  test("#312: pairs whose prefix content differs are excluded with a manifest reason", async () => {
+    const t = convexTest(schema);
+    const { ids, asOwner } = await seed(t);
+    // Same step SKELETON (kind/role/toolName) so createMatchup's guard passes,
+    // but different tool ARGS at step 1 — the content-level check must catch it.
+    const withArgs = (run_id: string, acct: string): JeevesClogRunExport => ({
+      ...runWith(run_id, "create_escalation"),
+      steps: [
+        { type: "message", role: "assistant", content: "Looking it up." },
+        { type: "tool_call", id: "t1", name: "lookup_account", args: { id: acct } },
+        { type: "tool_call", id: "t2", name: run_id === "A" ? "create_escalation" : "close_ticket", args: { note: "x" } },
+      ],
+    });
+    const left = await persist(asOwner, ids.projectId, withArgs("A", "ACCT-1"));
+    const right = await persist(asOwner, ids.projectId, withArgs("B", "ACCT-2"));
+    const matchupId = await asOwner.mutation(api.agentTraceReview.createMatchup, {
+      leftTraceId: left, rightTraceId: right, divergenceStepIndex: 2,
+      leftBlindLabel: "A", rightBlindLabel: "B",
+    });
+    await asOwner.mutation(api.agentTraceReview.decideMatchup, { matchupId, winner: "left", reasonTags: [] });
+
+    const res = await asOwner.action(api.exports.generateExport, {
+      projectId: ids.projectId, source: "trajectory", format: "dpo",
+    });
+    expect(res.rowCount).toBe(0);
+    expect(res.excludedCount).toBe(1);
+    expect(res.manifest.excluded_by_reason.prefix_mismatch).toBe(1);
+    expect(res.manifest.notes.join(" ")).toMatch(/prefix(es)? did not match/);
+  });
+
   test("output-preference DPO: best vs weak with the resolved prompt", async () => {
     const t = convexTest(schema);
     const { ids, asOwner } = await seed(t);

--- a/convex/tests/trainingExport.test.ts
+++ b/convex/tests/trainingExport.test.ts
@@ -51,6 +51,22 @@ describe("#53 training-export data-boundary gate", () => {
     expect(excluded[0]?.reason).toBe("degenerate");
   });
 
+  test("#312: DPO pairs flagged prefix_mismatch are excluded — not comparable", () => {
+    const flagged: ExportRow = {
+      kind: "dpo",
+      prompt: "prefix as the winner saw it",
+      chosen: "better",
+      rejected: "worse",
+      metadata: { prefix_mismatch: true },
+    };
+    const { included, excluded } = gateRows([
+      { row: flagged, privacyClass: "public" },
+      { row: dpo(), privacyClass: "public" },
+    ]);
+    expect(included).toHaveLength(1);
+    expect(excluded[0]?.reason).toBe("prefix_mismatch");
+  });
+
   test("empty rows are excluded with a reason, never silently dropped", () => {
     const rows: ClassifiedRow[] = [
       { row: dpo({ chosen: "   " }), privacyClass: "public" },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -146,8 +146,9 @@ export function App() {
           <Route path="/eval" element={<EvalLayout />}>
             <Route index element={<InvitesInbox />} />
             <Route path="traces" element={<TraceReviewList />} />
-            <Route path="traces/:agentTraceId" element={<TraceReview />} />
-            <Route path="matchups/:matchupId" element={<TraceMatchupReview />} />
+            {/* #310: blind routes take opaque review tokens, never real ids. */}
+            <Route path="traces/:handle" element={<TraceReview />} />
+            <Route path="matchups/:handle" element={<TraceMatchupReview />} />
           </Route>
           <Route path="/denied" element={<Denied />} />
           <Route path="*" element={<NotFound />} />

--- a/src/routes/traces/TraceMatchupReview.tsx
+++ b/src/routes/traces/TraceMatchupReview.tsx
@@ -1,21 +1,31 @@
 /**
  * #271 (M31): blind reviewer's step-level pairwise-preference page. Rendered
- * under EvalLayout at /eval/matchups/:matchupId — no org/project context. The
- * matchup surface is the shared TraceMatchupBody; this wrapper only reads the
- * :matchupId param and sets the blind-eval document title (Rule 3).
+ * under EvalLayout at /eval/matchups/:handle — no org/project context. #310:
+ * the URL carries an opaque review token, resolved server-side to the matchup
+ * id; the matchup surface is the shared TraceMatchupBody. This wrapper also
+ * sets the blind-eval document title (Rule 3).
  */
 import { useEffect } from "react";
 import { useQuery } from "convex/react";
-import { useParams } from "react-router-dom";
+import { Link, useParams } from "react-router-dom";
 import { api } from "../../../convex/_generated/api";
-import type { Id } from "../../../convex/_generated/dataModel";
+import { buttonVariants } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { ArrowLeft } from "lucide-react";
 import { TraceMatchupBody } from "./TraceMatchupBody";
 
 export function TraceMatchupReview() {
-  const { matchupId } = useParams<{ matchupId: string }>();
-  const id = matchupId as Id<"agentTraceMatchups">;
+  const { handle } = useParams<{ handle: string }>();
+  const resolved = useQuery(
+    api.agentTraceReview.resolveMatchupHandle,
+    handle ? { handle } : "skip",
+  );
+  const matchupId = resolved?.matchupId;
 
-  const matchup = useQuery(api.agentTraceReview.getMatchup, { matchupId: id });
+  const matchup = useQuery(
+    api.agentTraceReview.getMatchup,
+    matchupId ? { matchupId } : "skip",
+  );
 
   // Rule 3: evaluators see "Evaluation — {project name}" and nothing else.
   useEffect(() => {
@@ -29,9 +39,39 @@ export function TraceMatchupReview() {
     };
   }, [matchup]);
 
+  if (resolved === undefined) {
+    return (
+      <div className="mx-auto max-w-5xl space-y-4 p-6">
+        <Skeleton className="h-8 w-64" />
+        <div className="grid gap-4 md:grid-cols-2">
+          <Skeleton className="h-96 w-full" />
+          <Skeleton className="h-96 w-full" />
+        </div>
+      </div>
+    );
+  }
+
+  if (resolved === null || !matchupId) {
+    return (
+      <div className="mx-auto max-w-3xl space-y-3 p-6">
+        <p className="text-sm">
+          This matchup isn’t available. It may have been removed, or you may not
+          have access to it.
+        </p>
+        <Link
+          to="/eval/traces"
+          className={buttonVariants({ size: "sm", variant: "outline" })}
+        >
+          <ArrowLeft aria-hidden="true" className="mr-1.5 h-3.5 w-3.5" />
+          Back to trajectories to review
+        </Link>
+      </div>
+    );
+  }
+
   return (
     <TraceMatchupBody
-      matchupId={id}
+      matchupId={matchupId}
       backTo="/eval/traces"
       backLabel="Trajectories to review"
     />

--- a/src/routes/traces/TraceReview.tsx
+++ b/src/routes/traces/TraceReview.tsx
@@ -1,21 +1,31 @@
 /**
  * #271 (M31): blind reviewer's single-trajectory review page. Rendered under
- * EvalLayout at /eval/traces/:agentTraceId — no org/project context. The review
- * surface itself is the shared TraceReviewBody; this wrapper only reads the
- * :agentTraceId param and sets the blind-eval document title (Rule 3).
+ * EvalLayout at /eval/traces/:handle — no org/project context. #310: the URL
+ * carries an opaque review token, resolved server-side to the trace id; the
+ * review surface itself is the shared TraceReviewBody. This wrapper also sets
+ * the blind-eval document title (Rule 3).
  */
 import { useEffect } from "react";
 import { useQuery } from "convex/react";
-import { useParams } from "react-router-dom";
+import { Link, useParams } from "react-router-dom";
 import { api } from "../../../convex/_generated/api";
-import type { Id } from "../../../convex/_generated/dataModel";
+import { buttonVariants } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { ArrowLeft } from "lucide-react";
 import { TraceReviewBody } from "./TraceReviewBody";
 
 export function TraceReview() {
-  const { agentTraceId } = useParams<{ agentTraceId: string }>();
-  const traceId = agentTraceId as Id<"agentTraces">;
+  const { handle } = useParams<{ handle: string }>();
+  const resolved = useQuery(
+    api.agentTraces.resolveReviewHandle,
+    handle ? { handle } : "skip",
+  );
+  const traceId = resolved?.agentTraceId;
 
-  const trace = useQuery(api.agentTraces.getTrace, { agentTraceId: traceId });
+  const trace = useQuery(
+    api.agentTraces.getTrace,
+    traceId ? { agentTraceId: traceId } : "skip",
+  );
 
   // Rule 3: evaluators see "Evaluation — {project name}" and nothing else.
   useEffect(() => {
@@ -28,6 +38,33 @@ export function TraceReview() {
       document.title = previous;
     };
   }, [trace]);
+
+  if (resolved === undefined) {
+    return (
+      <div className="mx-auto max-w-3xl space-y-4 p-6">
+        <Skeleton className="h-8 w-64" />
+        <Skeleton className="h-96 w-full" />
+      </div>
+    );
+  }
+
+  if (resolved === null || !traceId) {
+    return (
+      <div className="mx-auto max-w-3xl space-y-3 p-6">
+        <p className="text-sm">
+          This trajectory isn’t available. It may have been removed, or you may
+          not have access to it.
+        </p>
+        <Link
+          to="/eval/traces"
+          className={buttonVariants({ size: "sm", variant: "outline" })}
+        >
+          <ArrowLeft aria-hidden="true" className="mr-1.5 h-3.5 w-3.5" />
+          Back to trajectories to review
+        </Link>
+      </div>
+    );
+  }
 
   return (
     <TraceReviewBody

--- a/src/routes/traces/TraceReviewList.tsx
+++ b/src/routes/traces/TraceReviewList.tsx
@@ -62,9 +62,9 @@ export function TraceReviewList() {
                 Boolean,
               );
               return (
-                <li key={t._id}>
+                <li key={t.handle}>
                   <Link
-                    to={`/eval/traces/${t._id}`}
+                    to={`/eval/traces/${t.handle}`}
                     className="flex items-center justify-between gap-4 rounded-lg border bg-card px-4 py-3 transition-colors hover:bg-muted/50"
                   >
                     <div className="min-w-0">

--- a/src/routes/traces/__smoke__/convexReactMock.tsx
+++ b/src/routes/traces/__smoke__/convexReactMock.tsx
@@ -56,14 +56,14 @@ export function useMutation() {
 // Fixture rows for the blind reviewer's discovery list (listReviewableTraces).
 export const FIXTURE_REVIEWABLE = [
   {
-    _id: "trace_review_1",
+    handle: "trace_review_1",
     projectName: "Support Router",
     status: "ready",
     stepCount: 12,
     createdAt: 2,
   },
   {
-    _id: "trace_review_2",
+    handle: "trace_review_2",
     projectName: "Refund Agent",
     status: "ready",
     stepCount: 3,


### PR DESCRIPTION
Closes #310, closes #311, closes #312 — the three unfixed must-fix blockers from the 2026-07-09 customer-production-readiness review that sit directly on the blind-review → DPO/SFT training-data path.

## #310 — opaque tokens on blind review routes
- `agentTraces` + `agentTraceMatchups` gain a `reviewToken` (128-bit hex, stamped at insert) with a `by_review_token` index.
- `/eval/traces/:handle` and `/eval/matchups/:handle` resolve the token server-side (`resolveReviewHandle` / `resolveMatchupHandle`); `listReviewableTraces` returns handles, never raw ids.
- **Deploy step:** run `npx convex run agentTraces:backfillReviewTokens` once after deploy. A raw-id fallback keeps pre-token rows working until then (marked for deletion after backfill).
- Known ceiling: trace ids still appear in query *payloads* (e.g. `getMatchup` returns trace handles for step paging) — this PR removes them from URLs/DOM/history, which is the leak surface the readiness review flagged.

## #311 — per-reviewer matchup decisions
- New `agentTraceMatchupDecisions` table, one row per (matchup, reviewer), upserted; `decideMatchup` no longer patches the matchup row.
- `getMatchup` returns only the caller's own pick — reviewers never see each other's decisions.
- Export aggregates by strict majority of left/right votes; a split exports nothing; legacy single-decision rows count as one vote.

## #312 — DPO comparable-prefix enforcement
- `createMatchup` validates the shared step skeleton (kind/role/toolName) up to the divergence point and bounds-checks the index.
- The export action renders **both** traces' prefixes: a match records `prefix_hash` on the row as persisted proof; a mismatch is excluded with a `prefix_mismatch` reason and a manifest note. The manifest's comparability claim is now enforced, not asserted.

## Verification
- `npm run test:convex` — 267/267 (8 new tests covering all three fixes, including the legacy-data fallbacks)
- `npm run test:evals` — 175/175
- `npm run build` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)